### PR TITLE
Correcting AGPL date in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ TypeDB & TypeQL has been built using various open-source Graph and Distributed C
 
 ## Licensing
 
-This product includes software developed by [Vaticle](https://vaticle.com/).  It's released under the GNU Affero GENERAL PUBLIC LICENSE, Version 3, 29 June 2007. For license information, please see [LICENSE](https://github.com/vaticle/typedb/blob/master/LICENSE). Vaticle also provides a commercial license for TypeDB Cluster - get in touch with our team at enterprise@vaticle.com.
+This product includes software developed by [Vaticle](https://vaticle.com/).  It's released under the GNU Affero GENERAL PUBLIC LICENSE, Version 3, 19 November 2007. For license information, please see [LICENSE](https://github.com/vaticle/typedb/blob/master/LICENSE). Vaticle also provides a commercial license for TypeDB Cluster - get in touch with our team at enterprise@vaticle.com.
 
 Copyright (C) 2020 Vaticle


### PR DESCRIPTION
The README file mentions an incorrect date for the AGPL. This should say November 2007 instead of June 2007.

