### PR TITLE
Assemble and deploy TypeQL Python package

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -54,6 +54,16 @@ build:
         export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grammar:deploy-maven -- snapshot
+    deploy-pip-snapshot:
+      filter:
+        owner: vaticle
+        branch: master
+      image: vaticle-ubuntu-20.04
+      dependencies: [ build, build-dependency ]
+      command: |
+        export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
+        export DEPLOY_PIP_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run --define version=$(git rev-parse HEAD) //grammar:deploy-pip -- snapshot
 
 release:
   filter:
@@ -81,3 +91,10 @@ release:
         export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run --define version=$(cat VERSION) //grammar:deploy-maven -- release
+    deploy-pip-release:
+      image: vaticle-ubuntu-20.04
+      dependencies: [ deploy-github ]
+      command: |
+        export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
+        export DEPLOY_PIP_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run --define version=$(cat VERSION) //grammar:deploy-pip -- release

--- a/BUILD
+++ b/BUILD
@@ -21,7 +21,7 @@ load("@vaticle_bazel_distribution//github:rules.bzl", "deploy_github")
 load("//:deployment.bzl", "deployment")
 
 exports_files(
-    ["VERSION", "RELEASE_TEMPLATE.md"],
+    ["VERSION", "RELEASE_TEMPLATE.md", "requirements.txt", "README.md"],
     visibility = ["//visibility:public"]
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -81,6 +81,10 @@ rules_pkg()
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
+# Load //pip
+load("@vaticle_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
+pip_deps()
+
 # Load //github
 load("@vaticle_bazel_distribution//github:deps.bzl", github_deps = "deps")
 github_deps()

--- a/grammar/BUILD
+++ b/grammar/BUILD
@@ -21,6 +21,8 @@ load("@rules_antlr//antlr:antlr4.bzl", "antlr")
 load("@vaticle_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("@vaticle_dependencies//builder/antlr:rules.bzl", "python_grammar_adapter")
+load("@vaticle_bazel_distribution//pip:rules.bzl", "assemble_pip", "deploy_pip")
 
 antlr(
     name = "java-src",
@@ -37,6 +39,62 @@ java_library(
         "@maven//:org_antlr_antlr4_runtime", # sync version with @antlr4_runtime//jar
     ],
     tags = ["maven_coordinates=com.vaticle.typeql:typeql-grammar:{pom_version}", "checkstyle_ignore"],
+)
+
+python_grammar_adapter(
+    name = "python-grammar",
+    input = "TypeQL.g4",
+    output = "TypeQLPython.g4",
+)
+
+antlr(
+    name = "python-src",
+    srcs = [":python-grammar"],
+    language = "Python3",
+    visitor = True,
+    package = "com.vaticle.typeql.grammar",
+)
+
+py_library(
+    name = "python",
+    srcs = [":python-src"],
+    imports = ["../../bazel-out/k8-fastbuild/bin/grammar/python-src.py/"],
+)
+
+assemble_pip(
+    name = "assemble-pip",
+    target = ":python",
+    package_name = "typeql-grammar",
+    classifiers = [
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "Environment :: Console",
+        "Topic :: Database :: Front-Ends"
+    ],
+    url = "https://github.com/vaticle/typeql",
+    author = "Vaticle",
+    author_email = "community@vaticle.com",
+    license = "AGPLv3",
+    requirements_file = "//:requirements.txt",
+    keywords = ["grakn", "database", "graph", "knowledgebase", "knowledge-engineering"],
+    description = "TypeQL Grammar for Python",
+    long_description_file = "//:README.md",
+)
+
+deploy_pip(
+    name = "deploy-pip",
+    target = ":assemble-pip",
+    snapshot = deployment["pypi.snapshot"],
+    release = deployment["pypi.release"],
 )
 
 checkstyle_test(

--- a/grammar/TypeQL.g4
+++ b/grammar/TypeQL.g4
@@ -57,7 +57,7 @@ query_match_group_agg :   query_match   match_group       match_aggregate  ;
 
 // MATCH QUERY MODIFIERS =======================================================
 
-modifiers             : ( filter';' )? ( sort';' )? ( offset';' )? ( limit';' )?;
+modifiers             : ( filter ';' )? ( sort ';' )? ( offset ';' )? ( limit ';' )?;
 
 filter                :   GET         VAR_  ( ',' VAR_ )*   ;
 sort                  :   SORT        VAR_        ORDER_?   ;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+antlr4-python3-runtime==4.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,18 @@
+#
+# Copyright (C) 2021 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 antlr4-python3-runtime==4.7.2


### PR DESCRIPTION
## What is the goal of this PR?

Assemble and deploy `typeql-grammar` package to help TypeQL adoption

## What are the changes implemented in this PR?

* Add a target that adapts grammar to Python language using a tool implemented in vaticle/dependencies#283
* Pass an adapted grammar to ANTLR code generator
* Add `//grammar:assemble-pip` and `//grammar:deploy-pip` targets that consume code generated by ANTLR and produce a Python package