### PR TITLE
Attribute variables are mandatory

### DIFF
--- a/grammar/TypeQL.g4
+++ b/grammar/TypeQL.g4
@@ -138,8 +138,8 @@ variable_thing        :   VAR_            ISA_ type   ( ',' attributes )?
 variable_relation     :   VAR_? relation  ISA_ type   ( ',' attributes )?
                       |   VAR_? relation  attributes?
                       ;
-variable_attribute    :   VAR_? predicate ISA_ type   ( ',' attributes )?
-                      |   VAR_? predicate attributes?
+variable_attribute    :   VAR_ predicate ISA_ type   ( ',' attributes )?
+                      |   VAR_ predicate attributes?
                       ;
 
 // RELATION CONSTRUCT ==========================================================


### PR DESCRIPTION
## What is the goal of this PR?

We identify a bug that allows writing `match "john";` as a valid query and resolve it by mandating variables for attribute constraints.

## What are the changes implemented in this PR?
* make attribute variables mandatory
