### PR TITLE
Allow sorting on multiple variables

### DIFF
--- a/grammar/TypeQL.g4
+++ b/grammar/TypeQL.g4
@@ -59,10 +59,10 @@ query_match_group_agg :   query_match   match_group       match_aggregate  ;
 
 modifiers             : ( filter ';' )? ( sort ';' )? ( offset ';' )? ( limit ';' )?;
 
-filter                :   GET         VAR_  ( ',' VAR_ )*   ;
-sort                  :   SORT        VAR_        ORDER_?   ;
-offset                :   OFFSET      LONG_                 ;
-limit                 :   LIMIT       LONG_                 ;
+filter                :   GET         VAR_  ( ',' VAR_ )*           ;
+sort                  :   SORT        VAR_  ( ',' VAR_ )*   ORDER_? ;
+offset                :   OFFSET      LONG_                         ;
+limit                 :   LIMIT       LONG_                         ;
 
 
 // GET AGGREGATE QUERY =========================================================


### PR DESCRIPTION
## What is the goal of this PR?

To enable https://github.com/vaticle/typedb/issues/6434, we add in the grammar that sorting on multiple (ordered) variables is allowed.

## What are the changes implemented in this PR?

* allow sorting on multiple variables
