### PR TITLE
Assemble and deploy TypeQL Rust package

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,6 +47,17 @@ python_deps()
 load("@vaticle_dependencies//builder/antlr:deps.bzl", antlr_deps = "deps", "antlr_version")
 antlr_deps()
 
+# Load //builder/rust
+load("@vaticle_dependencies//builder/rust:deps.bzl", rust_deps = "deps")
+rust_deps()
+
+load("@rules_rust//rust:repositories.bzl", "rust_repositories")
+rust_repositories(version = "nightly", iso_date = "2021-07-01", edition="2018")
+
+load("@vaticle_dependencies//library/crates:crates.bzl", "raze_fetch_remote_crates")
+raze_fetch_remote_crates()
+
+
 load("@rules_antlr//antlr:lang.bzl", "JAVA")
 load("@rules_antlr//antlr:repositories.bzl", "rules_antlr_dependencies")
 rules_antlr_dependencies(antlr_version, JAVA)

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -1,5 +1,9 @@
 @maven//:com_eclipsesource_minimal_json_minimal_json
 @maven//:com_eclipsesource_minimal_json_minimal_json_0_9_5
+@maven//:com_electronwill_night_config_core
+@maven//:com_electronwill_night_config_core_3_6_5
+@maven//:com_electronwill_night_config_toml
+@maven//:com_electronwill_night_config_toml_3_6_5
 @maven//:com_google_code_findbugs_jsr305
 @maven//:com_google_code_findbugs_jsr305_3_0_2
 @maven//:com_google_errorprone_error_prone_annotations
@@ -30,6 +34,8 @@
 @maven//:io_opencensus_opencensus_contrib_http_util_0_24_0
 @maven//:org_antlr_antlr4_runtime
 @maven//:org_antlr_antlr4_runtime_4_7_1
+@maven//:org_apache_commons_commons_compress
+@maven//:org_apache_commons_commons_compress_1_21
 @maven//:org_apache_httpcomponents_httpclient
 @maven//:org_apache_httpcomponents_httpclient_4_5_11
 @maven//:org_apache_httpcomponents_httpcore

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,5 +21,5 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "41c2fb8bcc02dbc86385afa61c392bc67e5d0034", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "aaafe6509de3a1f25c6489044957e4d63f97e5c3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )

--- a/grammar/BUILD
+++ b/grammar/BUILD
@@ -21,8 +21,10 @@ load("@rules_antlr//antlr:antlr4.bzl", "antlr")
 load("@vaticle_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@vaticle_dependencies//builder/antlr:rules.bzl", "python_grammar_adapter")
+load("@vaticle_dependencies//builder/antlr:rules.bzl", "python_grammar_adapter", "rust_grammar_adapter")
 load("@vaticle_bazel_distribution//pip:rules.bzl", "assemble_pip", "deploy_pip")
+load("@vaticle_bazel_distribution//crates:rules.bzl", "assemble_crate", "deploy_crate")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 
 antlr(
     name = "java-src",
@@ -39,6 +41,51 @@ java_library(
         "@maven//:org_antlr_antlr4_runtime", # sync version with @antlr4_runtime//jar
     ],
     tags = ["maven_coordinates=com.vaticle.typeql:typeql-grammar:{pom_version}", "checkstyle_ignore"],
+)
+
+rust_grammar_adapter(
+    name = "rust-grammar",
+    input = "TypeQL.g4",
+    output = "TypeQLRust.g4",
+)
+
+antlr(
+    name = "rust-src",
+    srcs = [":rust-grammar"],
+    language = "Rust",
+    visitor = True,
+    package = "typeqlgrammar",
+)
+
+
+rust_library(
+    name = "typeql-grammar",
+    srcs = [":rust-src"],
+    deps = [
+        "@vaticle_dependencies//library/crates:antlr_rust",
+    ]
+)
+
+assemble_crate(
+    name = "assemble-crate",
+    target = ":typeql-grammar",
+    description = "TypeQL Grammar for Rust",
+    license = "AGPLv3",
+    deps = {
+        "antlr-rust": "0.2.0",
+    },
+    readme_file = "//:README.md",
+    homepage = "https://github.com/vaticle/typeql",
+    repository = "https://github.com/vaticle/typeql",
+    keywords = ["grakn", "database", "graph", "knowledgebase", "knowledgeengineering"],
+    authors = ["Vaticle <community@vaticle.com>"]
+)
+
+deploy_crate(
+    name = "deploy-crate",
+    target = ":assemble-crate",
+    snapshot = deployment["crate.snapshot"],
+    release = deployment["crate.release"],
 )
 
 python_grammar_adapter(


### PR DESCRIPTION
## What is the goal of this PR?

Assemble and deploy typeql-grammar package to allow Rust migration

## What are the changes implemented in this PR?

* Add a target that adapts grammar to Rust language using a tool implemented in vaticle/dependencies#318
* Pass an adapted grammar to ANTLR code generator
* Add `//grammar:assemble-crate` and `//grammar:deploy-crate` targets that consume code generated by ANTLR and produce/deploy a Rust package
