### PR TITLE
Make typeql-grammar for Rust use the latest assemble_crate

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,5 +21,5 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "aaafe6509de3a1f25c6489044957e4d63f97e5c3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "0072659c6e51f7f913ce28f919c99965764e3b4e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )

--- a/grammar/BUILD
+++ b/grammar/BUILD
@@ -71,9 +71,6 @@ assemble_crate(
     target = ":typeql-grammar",
     description = "TypeQL Grammar for Rust",
     license = "AGPLv3",
-    deps = {
-        "antlr-rust": "0.2.0",
-    },
     readme_file = "//:README.md",
     homepage = "https://github.com/vaticle/typeql",
     repository = "https://github.com/vaticle/typeql",


### PR DESCRIPTION
## What is the goal of this PR?

Utilize the latest version of `assemble_crate` rule which automatically retrieves crate's dependencies from `rust_library`'s `deps` attribute

## What are the changes implemented in this PR?

Upgrade `@vaticle_dependencies` to include fixes in vaticle/bazel-distribution#325 and vaticle/dependencies#331