### PR TITLE
Remove obsolete tests

### DIFF
--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -152,16 +152,6 @@ public class ParserTest {
     }
 
     @Test
-    public void testRoleTypeScopedSpecifically() {
-        String query = "match\n" +
-                "$m relates spouse;";
-        TypeQLMatch parsed = TypeQL.parseQuery(query).asMatch();
-        TypeQLMatch expected = match(var("m").relates("spouse"));
-
-        assertQueryEquals(expected, parsed, query);
-    }
-
-    @Test
     public void testRoleTypeNotScoped() {
         String query = "match\n" +
                 "marriage relates $s;";

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -272,14 +272,14 @@ public class ParserTest {
                 "not { $a is $b; };";
         TypeQLMatch parsed = TypeQL.parseQuery(query);
 
-        TypeQLMatch exepcted = match(
+        TypeQLMatch expected = match(
                 var("x").sub(var("z")), var("y").sub(var("z")),
                 var("a").isa(var("x")), var("b").isa(var("y")),
                 not(var("x").is("y")),
                 not(var("a").is("b"))
         );
 
-        assertQueryEquals(exepcted, parsed, query);
+        assertQueryEquals(expected, parsed, query);
     }
 
     @Test

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -1004,16 +1004,6 @@ public class ParserTest {
     }
 
     @Test
-    public void testQueryParserWithoutGraph() {
-        final String queryString = "match\n" +
-                "$x isa movie;\n" +
-                "get $x;";
-        TypeQLMatch query = parseQuery("match\n" +
-                                               "$x isa movie; get $x;").asMatch();
-        assertEquals(queryString, query.toString());
-    }
-
-    @Test
     public void testParseBoolean() {
         final String query = "insert\n$_ has flag true;";
         TypeQLInsert parsed = TypeQL.parseQuery(query).asInsert();


### PR DESCRIPTION
## What is the goal of this PR?

We remove a test that used to test functionality that is no longer supported, namely, `match` queries with no named variables.

## What are the changes implemented in this PR?

`testRoleTypeScopedSpecifically`: The test used to centre around the `match marriage relates spouse;` query at its conception. This is no longer supported, and the updated version is exactly equivalent to the preceding test.
`testQueryParserWithoutGraph`: This test was present in the initial commit, and it looks like it was testing that we can call a static method without referencing its class. Maybe it had a different use at some point prior, but that is lost to history.