### PR TITLE
Rule conclusion must explicitly specify role types

### DIFF
--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -87,14 +87,16 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
             new ErrorMessage(31, "Rule '%s' 'then' '%s' tries to assign type '%s' to variable '%s', but this variable already had a type assigned by the rule 'when'. Try omitting this type assignment.");
     public static final ErrorMessage INVALID_RULE_THEN_VARIABLES =
             new ErrorMessage(32, "Rule '%s' 'then' variables must be present in rule 'when'.");
+    public static final ErrorMessage INVALID_RULE_THEN_ROLES =
+            new ErrorMessage(33, "Rule '%s' 'then' '%s': all roles must be specified explicitly or using a variable.");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =
-            new ErrorMessage(33, "Invalid query containing redundant nested negations.");
+            new ErrorMessage(34, "Invalid query containing redundant nested negations.");
     public static final ErrorMessage INVALID_SORTING_ORDER =
-            new ErrorMessage(34, "Invalid sorting order. Valid options: '%s' or '%s'.");
+            new ErrorMessage(35, "Invalid sorting order. Valid options: '%s' or '%s'.");
     public static final ErrorMessage INVALID_COUNT_VARIABLE_ARGUMENT =
-            new ErrorMessage(35, "Aggregate COUNT does not accept a Variable.");
+            new ErrorMessage(36, "Aggregate COUNT does not accept a Variable.");
     public static final ErrorMessage ILLEGAL_GRAMMAR =
-            new ErrorMessage(36, "Illegal grammar!");
+            new ErrorMessage(37, "Illegal grammar!");
     public static final ErrorMessage ILLEGAL_CHAR_IN_LABEL =
             new ErrorMessage(47, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
 

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -88,7 +88,7 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
     public static final ErrorMessage INVALID_RULE_THEN_VARIABLES =
             new ErrorMessage(32, "Rule '%s' 'then' variables must be present in rule 'when'.");
     public static final ErrorMessage INVALID_RULE_THEN_ROLES =
-            new ErrorMessage(33, "Rule '%s' 'then' '%s': all roles must be specified explicitly or using a variable.");
+            new ErrorMessage(33, "Rule '%s' 'then' '%s' must specify all role types explicitly or by using a variable.");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =
             new ErrorMessage(34, "Invalid query containing redundant nested negations.");
     public static final ErrorMessage INVALID_SORTING_ORDER =

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -98,7 +98,7 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
     public static final ErrorMessage ILLEGAL_GRAMMAR =
             new ErrorMessage(37, "Illegal grammar!");
     public static final ErrorMessage ILLEGAL_CHAR_IN_LABEL =
-            new ErrorMessage(47, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
+            new ErrorMessage(38, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
 
 
     private static final String codePrefix = "TQL";

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -30,11 +30,13 @@ import com.vaticle.typeql.lang.pattern.Pattern;
 import com.vaticle.typeql.lang.pattern.variable.Reference;
 import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
 import com.vaticle.typeql.lang.pattern.variable.Variable;
+
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COLON;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.CURLY_CLOSE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.CURLY_OPEN;
@@ -46,6 +48,7 @@ import static com.vaticle.typeql.lang.common.TypeQLToken.Schema.THEN;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Schema.WHEN;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_HAS;
+import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_ROLES;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_VARIABLES;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_CONTAINS_DISJUNCTION;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_MISSING_PATTERNS;
@@ -156,6 +159,15 @@ public class Rule implements Definable {
             if (!whenReferences.containsAll(thenReferences)) {
                 throw TypeQLException.of(INVALID_RULE_THEN_VARIABLES.message(label));
             }
+        }
+
+        // Roles must be explicit
+        if (then.relation().isPresent() && !then.relation().get().players().stream()
+                .map(player -> {
+                    return player.roleType().isPresent();
+                })
+                .reduce(true, Boolean::logicalAnd)) {
+            throw TypeQLException.of(INVALID_RULE_THEN_ROLES.message(label, then));
         }
     }
 

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -163,9 +163,7 @@ public class Rule implements Definable {
 
         // Roles must be explicit
         if (then.relation().isPresent() && !then.relation().get().players().stream()
-                .map(player -> {
-                    return player.roleType().isPresent();
-                })
+                .map(player -> player.roleType().isPresent())
                 .reduce(true, Boolean::logicalAnd)) {
             throw TypeQLException.of(INVALID_RULE_THEN_ROLES.message(label, then));
         }


### PR DESCRIPTION
## What is the goal of this PR?
Enforce roles in the conclusion of a rule to be explicitly specified.
Since role-types in rule-conclusion must be unambiguous, requiring the user to explicitly specify them makes this clear to the reader and avoids nasty surprises.

## What are the changes implemented in this PR?
This PR adds a syntax validation check 
- requiring all roles in a conclusion to be explicitly specified
- throws a newly introduced `TypeDBException.INVALID_RULE_THEN_ROLES` if they are not