### PR TITLE
Bump typedb-common dependency

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "f0dd708adaea9fe1fdc3699180797a12166d33e8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "8400246456704657bfcaacbfac5ef2f6adbd8263", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():


### PR DESCRIPTION
## What is the goal of this PR?
Bump commit-marker to update outdated typedb-common.  

## What are the changes implemented in this PR?
Bumps commit-marker to recent master.  
