### PR TITLE
Allow sorting per-variable

### DIFF
--- a/grammar/TypeQL.g4
+++ b/grammar/TypeQL.g4
@@ -57,10 +57,11 @@ query_match_group_agg :   query_match   match_group       match_aggregate  ;
 
 modifiers             : ( filter ';' )? ( sort ';' )? ( offset ';' )? ( limit ';' )?;
 
-filter                :   GET         VAR_  ( ',' VAR_ )*           ;
-sort                  :   SORT        VAR_  ( ',' VAR_ )*   ORDER_? ;
-offset                :   OFFSET      LONG_                         ;
-limit                 :   LIMIT       LONG_                         ;
+filter                :   GET         VAR_      ( ',' VAR_ )*                   ;
+sort                  :   SORT        var_order ( ',' var_order )*              ;
+var_order             :   VAR_ ORDER_?                                          ;
+offset                :   OFFSET      LONG_                                     ;
+limit                 :   LIMIT       LONG_                                     ;
 
 
 // GET AGGREGATE QUERY =========================================================

--- a/java/common/TypeQLArg.java
+++ b/java/common/TypeQLArg.java
@@ -21,6 +21,10 @@
 
 package com.vaticle.typeql.lang.common;
 
+import com.vaticle.typeql.lang.common.exception.TypeQLException;
+
+import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_SORTING_ORDER;
+
 public class TypeQLArg {
 
     public enum QueryType {
@@ -96,7 +100,7 @@ public class TypeQLArg {
                     return c;
                 }
             }
-            return null;
+            throw TypeQLException.of(INVALID_SORTING_ORDER.message(value, ASC.order, DESC.order));
         }
     }
 }

--- a/java/common/TypeQLToken.java
+++ b/java/common/TypeQLToken.java
@@ -22,8 +22,10 @@
 package com.vaticle.typeql.lang.common;
 
 import com.vaticle.typeql.lang.common.exception.TypeQLException;
+
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
+
 import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_CASTING;
 

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -92,7 +92,7 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =
             new ErrorMessage(34, "Invalid query containing redundant nested negations.");
     public static final ErrorMessage INVALID_SORTING_ORDER =
-            new ErrorMessage(35, "Invalid sorting order. Valid options: '%s' or '%s'.");
+            new ErrorMessage(35, "Invalid sorting order '%s'. Valid options: '%s' or '%s'.");
     public static final ErrorMessage INVALID_COUNT_VARIABLE_ARGUMENT =
             new ErrorMessage(36, "Aggregate COUNT does not accept a Variable.");
     public static final ErrorMessage ILLEGAL_GRAMMAR =

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -91,14 +91,16 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
             new ErrorMessage(33, "Rule '%s' 'then' '%s' must specify all role types explicitly or by using a variable.");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =
             new ErrorMessage(34, "Invalid query containing redundant nested negations.");
+    public static final ErrorMessage VARIABLE_NOT_SORTED =
+            new ErrorMessage(35, "Variable '%s' does not exist in the sorting clause.");
     public static final ErrorMessage INVALID_SORTING_ORDER =
-            new ErrorMessage(35, "Invalid sorting order '%s'. Valid options: '%s' or '%s'.");
+            new ErrorMessage(36, "Invalid sorting order '%s'. Valid options: '%s' or '%s'.");
     public static final ErrorMessage INVALID_COUNT_VARIABLE_ARGUMENT =
-            new ErrorMessage(36, "Aggregate COUNT does not accept a Variable.");
+            new ErrorMessage(37, "Aggregate COUNT does not accept a Variable.");
     public static final ErrorMessage ILLEGAL_GRAMMAR =
-            new ErrorMessage(37, "Illegal grammar!");
+            new ErrorMessage(38, "Illegal grammar!");
     public static final ErrorMessage ILLEGAL_CHAR_IN_LABEL =
-            new ErrorMessage(38, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
+            new ErrorMessage(39, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
 
 
     private static final String codePrefix = "TQL";

--- a/java/common/util/Strings.java
+++ b/java/common/util/Strings.java
@@ -25,6 +25,7 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
 import java.util.Locale;
+
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.INDENTATION;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.NEW_LINE;
 

--- a/java/parser/ErrorListener.java
+++ b/java/parser/ErrorListener.java
@@ -21,13 +21,15 @@
 
 package com.vaticle.typeql.lang.parser;
 
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import org.antlr.v4.runtime.BaseErrorListener;
-import org.antlr.v4.runtime.RecognitionException;
-import org.antlr.v4.runtime.Recognizer;
+
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.SYNTAX_ERROR_DETAILED;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.SYNTAX_ERROR_NO_DETAILS;

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -382,7 +382,7 @@ public class Parser extends TypeQLBaseVisitor {
 
     @Override
     public Pair<UnboundVariable, TypeQLArg.Order> visitVar_order(TypeQLParser.Var_orderContext ctx) {
-        return new Pair<>(getVar(ctx.VAR_()), ctx.ORDER_() == null ? TypeQLArg.Order.ASC : TypeQLArg.Order.of(ctx.ORDER_().getText()));
+        return new Pair<>(getVar(ctx.VAR_()), ctx.ORDER_() == null ? null : TypeQLArg.Order.of(ctx.ORDER_().getText()));
     }
 
 

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -414,7 +414,7 @@ public class ParserTest {
                 "$x plays starring:actor;\n" +
                 "sort $x asc;";
         TypeQLMatch parsed = TypeQL.parseQuery(query).asMatch();
-        TypeQLMatch expected = match(var("x").plays("starring", "actor")).sort("x", "asc");
+        TypeQLMatch expected = match(var("x").plays("starring", "actor")).sort(pair("x", "asc"));
 
         assertQueryEquals(expected, parsed, query);
     }

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -34,15 +34,18 @@ import com.vaticle.typeql.lang.query.TypeQLMatch;
 import com.vaticle.typeql.lang.query.TypeQLQuery;
 import com.vaticle.typeql.lang.query.TypeQLUndefine;
 import com.vaticle.typeql.lang.query.TypeQLUpdate;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
 import static com.vaticle.typedb.common.collection.Collections.list;
+import static com.vaticle.typedb.common.collection.Collections.pair;
 import static com.vaticle.typeql.lang.TypeQL.and;
 import static com.vaticle.typeql.lang.TypeQL.define;
 import static com.vaticle.typeql.lang.TypeQL.gte;
@@ -411,7 +414,7 @@ public class ParserTest {
                 "$x plays starring:actor;\n" +
                 "sort $x asc;";
         TypeQLMatch parsed = TypeQL.parseQuery(query).asMatch();
-        TypeQLMatch expected = match(var("x").plays("starring", "actor")).sort(list("x"), "asc");
+        TypeQLMatch expected = match(var("x").plays("starring", "actor")).sort("x", "asc");
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -425,7 +428,7 @@ public class ParserTest {
         TypeQLMatch parsed = TypeQL.parseQuery(query).asMatch();
         TypeQLMatch expected = match(
                 var("x").isa("movie").has("rating", var("r"))
-        ).sort(list("r"), "desc");
+        ).sort(pair("r", "desc")) ;
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -453,7 +456,7 @@ public class ParserTest {
         TypeQLMatch parsed = TypeQL.parseQuery(query).asMatch();
         TypeQLMatch expected = match(
                 var("x").isa("movie").has("rating", var("r"))
-        ).sort(list("r"), "desc").offset(10).limit(10);
+        ).sort(pair("r", "desc")).offset(10).limit(10);
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -558,9 +561,9 @@ public class ParserTest {
         TypeQLMatch expected = match(
                 var("y").isa(var("p")),
                 or(rel("y").rel("q"),
-                   and(var("x").isa(var("p")),
-                       or(var("x").has("first-name", var("y")),
-                          var("x").has("last-name", var("z"))))));
+                        and(var("x").isa(var("p")),
+                                or(var("x").has("first-name", var("y")),
+                                        var("x").has("last-name", var("z"))))));
         assertQueryEquals(expected, parsed, query);
     }
 

--- a/java/pattern/Conjunction.java
+++ b/java/pattern/Conjunction.java
@@ -27,6 +27,7 @@ import com.vaticle.typeql.lang.common.exception.TypeQLException;
 import com.vaticle.typeql.lang.pattern.variable.BoundVariable;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
 import com.vaticle.typeql.lang.pattern.variable.Variable;
+
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,6 +38,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.CURLY_CLOSE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.CURLY_OPEN;

--- a/java/pattern/Negation.java
+++ b/java/pattern/Negation.java
@@ -25,9 +25,11 @@ import com.vaticle.typeql.lang.common.TypeQLToken;
 import com.vaticle.typeql.lang.common.exception.ErrorMessage;
 import com.vaticle.typeql.lang.common.exception.TypeQLException;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.CURLY_CLOSE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.CURLY_OPEN;

--- a/java/pattern/constraint/ThingConstraint.java
+++ b/java/pattern/constraint/ThingConstraint.java
@@ -30,6 +30,8 @@ import com.vaticle.typeql.lang.pattern.variable.BoundVariable;
 import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
 import com.vaticle.typeql.lang.pattern.variable.TypeVariable;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
+
+import javax.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,7 +43,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
-import javax.annotation.Nullable;
+
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.pair;
 import static com.vaticle.typedb.common.collection.Collections.set;

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -31,6 +31,7 @@ import com.vaticle.typeql.lang.pattern.variable.Reference;
 import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
 import com.vaticle.typeql.lang.pattern.variable.Variable;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -35,7 +35,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COLON;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.CURLY_CLOSE;

--- a/java/pattern/variable/ThingVariable.java
+++ b/java/pattern/variable/ThingVariable.java
@@ -25,11 +25,13 @@ import com.vaticle.typeql.lang.common.exception.TypeQLException;
 import com.vaticle.typeql.lang.pattern.constraint.ConceptConstraint;
 import com.vaticle.typeql.lang.pattern.constraint.ThingConstraint;
 import com.vaticle.typeql.lang.pattern.variable.builder.ThingVariableBuilder;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
+
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COMMA_NEW_LINE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.SPACE;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.ILLEGAL_CONSTRAINT_REPETITION;

--- a/java/pattern/variable/TypeVariable.java
+++ b/java/pattern/variable/TypeVariable.java
@@ -26,11 +26,13 @@ import com.vaticle.typeql.lang.pattern.Definable;
 import com.vaticle.typeql.lang.pattern.constraint.Constraint;
 import com.vaticle.typeql.lang.pattern.constraint.TypeConstraint;
 import com.vaticle.typeql.lang.pattern.variable.builder.TypeVariableBuilder;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
+
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COMMA_NEW_LINE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.SPACE;

--- a/java/query/TypeQLDefinable.java
+++ b/java/query/TypeQLDefinable.java
@@ -28,10 +28,12 @@ import com.vaticle.typeql.lang.common.exception.TypeQLException;
 import com.vaticle.typeql.lang.pattern.Definable;
 import com.vaticle.typeql.lang.pattern.schema.Rule;
 import com.vaticle.typeql.lang.pattern.variable.TypeVariable;
+
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+
 import static com.vaticle.typeql.lang.common.TypeQLToken.Command.DEFINE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Command.UNDEFINE;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.MISSING_DEFINABLES;

--- a/java/query/TypeQLMatch.java
+++ b/java/query/TypeQLMatch.java
@@ -32,13 +32,15 @@ import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
 import com.vaticle.typeql.lang.query.builder.Aggregatable;
 import com.vaticle.typeql.lang.query.builder.Sortable;
+
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import javax.annotation.Nullable;
+
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COMMA_SPACE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.NEW_LINE;
@@ -206,8 +208,8 @@ public class TypeQLMatch extends TypeQLQuery implements Aggregatable<TypeQLMatch
 
     private void sortVarsAreInScope() {
         List<UnboundVariable> sortableVars = modifiers.filter.isEmpty() ? namedVariablesUnbound() : modifiers.filter;
-        if (modifiers.sorting != null && modifiers.sorting.vars().stream().anyMatch(v -> !sortableVars.contains(v))) {
-            throw TypeQLException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(modifiers.sorting.vars()));
+        if (modifiers.sorting != null && modifiers.sorting.variables().stream().anyMatch(v -> !sortableVars.contains(v))) {
+            throw TypeQLException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(modifiers.sorting.variables()));
         }
     }
 

--- a/java/query/TypeQLQuery.java
+++ b/java/query/TypeQLQuery.java
@@ -24,7 +24,9 @@ package com.vaticle.typeql.lang.query;
 import com.vaticle.typeql.lang.common.TypeQLArg;
 import com.vaticle.typeql.lang.common.TypeQLToken;
 import com.vaticle.typeql.lang.common.exception.TypeQLException;
+
 import java.util.List;
+
 import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.NEW_LINE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.SEMICOLON;

--- a/java/query/TypeQLUpdate.java
+++ b/java/query/TypeQLUpdate.java
@@ -25,9 +25,11 @@ import com.vaticle.typeql.lang.pattern.variable.BoundVariable;
 import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
 import com.vaticle.typeql.lang.pattern.variable.Variable;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
+
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.NEW_LINE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Command.DELETE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Command.INSERT;

--- a/java/query/TypeQLWritable.java
+++ b/java/query/TypeQLWritable.java
@@ -28,10 +28,12 @@ import com.vaticle.typeql.lang.pattern.variable.BoundVariable;
 import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
 import com.vaticle.typeql.lang.pattern.variable.Variable;
+
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
+
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.NEW_LINE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Command.DELETE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Command.INSERT;

--- a/java/query/test/TypeQLQueryTest.java
+++ b/java/query/test/TypeQLQueryTest.java
@@ -28,6 +28,7 @@ import com.vaticle.typeql.lang.query.TypeQLInsert;
 import com.vaticle.typeql.lang.query.TypeQLMatch;
 import com.vaticle.typeql.lang.query.TypeQLQuery;
 import org.junit.Test;
+
 import static com.vaticle.typeql.lang.TypeQL.and;
 import static com.vaticle.typeql.lang.TypeQL.lte;
 import static com.vaticle.typeql.lang.TypeQL.match;
@@ -59,7 +60,7 @@ public class TypeQLQueryTest {
                         )
                 ),
                 var("y").has("name", var("n"))
-        ).get("x", "y", "n").sort("n").offset(4).limit(8);
+        ).get("x", "y", "n").sort("n", "asc").offset(4).limit(8);
 
         assertEquivalent(query, query.toString());
     }


### PR DESCRIPTION
## What is the goal of this PR?

TypeQL can support sorting each variable in either `Ascending` or `Descending` order independently. Previously, TypeQL only supported ordering all the variables in the same order.

## What are the changes implemented in this PR?

* Update grammar and parser to allow a sort order per-variable in the `sort` block
* Update language builders to allow a different sort order per variable
* Update tests to reflect the new capabilities
