### PR TITLE
Split delete_or_update in the grammar into separate parser rules

### DIFF
--- a/grammar/TypeQL.g4
+++ b/grammar/TypeQL.g4
@@ -32,18 +32,17 @@ eof_schema_rule       :   schema_rule      EOF ;
 // TYPEQL QUERY LANGUAGE ========================================================
 
 query                 :   query_define      |   query_undefine
-                      |   query_update      |   query_insert      |   query_delete
+                      |   query_insert      |   query_update      |   query_delete
                       |   query_match       |   query_match_aggregate
                       |   query_match_group |   query_match_group_agg           ;
 
 query_define          :   DEFINE      definables  ;
 query_undefine        :   UNDEFINE    definables  ;
 
-query_update          :   MATCH       patterns      DELETE  variable_things
-                                                    INSERT  variable_things     ;
 query_insert          :   MATCH       patterns      INSERT  variable_things
                       |                             INSERT  variable_things     ;
-query_delete          :   MATCH       patterns      DELETE  variable_things;
+query_update          :   query_delete              INSERT  variable_things     ;
+query_delete          :   MATCH       patterns      DELETE  variable_things     ;
 
 query_match           :   MATCH       patterns            ( modifiers )         ;
 

--- a/grammar/TypeQL.g4
+++ b/grammar/TypeQL.g4
@@ -32,18 +32,18 @@ eof_schema_rule       :   schema_rule      EOF ;
 // TYPEQL QUERY LANGUAGE ========================================================
 
 query                 :   query_define      |   query_undefine
-                      |   query_insert      |   query_delete_or_update
+                      |   query_update      |   query_insert      |   query_delete
                       |   query_match       |   query_match_aggregate
                       |   query_match_group |   query_match_group_agg           ;
 
 query_define          :   DEFINE      definables  ;
 query_undefine        :   UNDEFINE    definables  ;
 
+query_update          :   MATCH       patterns      DELETE  variable_things
+                                                    INSERT  variable_things     ;
 query_insert          :   MATCH       patterns      INSERT  variable_things
                       |                             INSERT  variable_things     ;
-query_delete_or_update:   MATCH       patterns      DELETE  variable_things
-                                                  ( INSERT  variable_things )?  ;
-// TODO: The above feels like a hack. Find a clean way to split delete and update
+query_delete          :   MATCH       patterns      DELETE  variable_things;
 
 query_match           :   MATCH       patterns            ( modifiers )         ;
 
@@ -118,8 +118,6 @@ type_constraint       :   ABSTRACT
                       |   PLAYS       type_scoped  ( AS type )?
                       |   VALUE       value_type
                       |   REGEX       STRING_
-                      |   WHEN    '{' patterns        '}'
-                      |   THEN    '{' variable_things '}'
                       |   TYPE        label_any
                       ;
 
@@ -179,8 +177,6 @@ type                  :   label                         | VAR_          ;       
 label_any             :   label_scoped  | label         ;
 label_scoped          :   LABEL_SCOPED_ ;
 label                 :   LABEL_        | schema_native | type_native   | unreserved    ;
-labels                :   label         | label_array   ;
-label_array           :   '[' label ( ',' label )* ']'  ;
 
 // LITERAL INPUT VALUES =======================================================
 

--- a/grammar/TypeQL.g4
+++ b/grammar/TypeQL.g4
@@ -31,10 +31,11 @@ eof_schema_rule       :   schema_rule      EOF ;
 
 // TYPEQL QUERY LANGUAGE ========================================================
 
-query                 :   query_define      |   query_undefine
-                      |   query_insert      |   query_update      |   query_delete
-                      |   query_match       |   query_match_aggregate
-                      |   query_match_group |   query_match_group_agg           ;
+query                 :   query_define           |   query_undefine
+                      |   query_insert           |   query_update
+                      |   query_delete           |   query_match
+                      |   query_match_aggregate  |   query_match_group
+                      |   query_match_group_agg                                 ;
 
 query_define          :   DEFINE      definables  ;
 query_undefine        :   UNDEFINE    definables  ;

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -249,8 +249,10 @@ public class Parser extends TypeQLBaseVisitor {
         } else if (ctx.query_insert() != null) {
             return visitQuery_insert(ctx.query_insert());
 
-        } else if (ctx.query_delete_or_update() != null) {
-            return visitQuery_delete_or_update(ctx.query_delete_or_update()).apply(q -> q, q -> q);
+        } else if (ctx.query_delete() != null) {
+            return visitQuery_delete(ctx.query_delete());
+        } else if (ctx.query_update() != null) {
+            return visitQuery_update(ctx.query_update());
         } else if (ctx.query_match() != null) {
             return visitQuery_match(ctx.query_match());
 
@@ -303,15 +305,17 @@ public class Parser extends TypeQLBaseVisitor {
     }
 
     @Override
-    public Either<TypeQLDelete, TypeQLUpdate> visitQuery_delete_or_update(TypeQLParser.Query_delete_or_updateContext ctx) {
-        TypeQLDelete delete = new TypeQLMatch.Unfiltered(visitPatterns(ctx.patterns()))
-                .delete(visitVariable_things(ctx.variable_things(0)));
-        if (ctx.INSERT() == null) {
-            return Either.first(delete);
-        } else {
-            assert ctx.variable_things().size() == 2;
-            return Either.second(delete.insert(visitVariable_things(ctx.variable_things(1))));
-        }
+    public TypeQLDelete visitQuery_delete(TypeQLParser.Query_deleteContext ctx) {
+        return new TypeQLMatch.Unfiltered(visitPatterns(ctx.patterns()))
+                .delete(visitVariable_things(ctx.variable_things()));
+    }
+
+    @Override
+    public TypeQLUpdate visitQuery_update(TypeQLParser.Query_updateContext ctx) {
+        assert ctx.variable_things().size() == 2;
+        return new TypeQLMatch.Unfiltered(visitPatterns(ctx.patterns()))
+                .delete(visitVariable_things(ctx.variable_things(0)))
+                .insert(visitVariable_things(ctx.variable_things(1)));
     }
 
     @Override
@@ -668,14 +672,6 @@ public class Parser extends TypeQLBaseVisitor {
     public Pair<String, String> visitLabel_scoped(TypeQLParser.Label_scopedContext ctx) {
         String[] scopedLabel = ctx.getText().split(":");
         return pair(scopedLabel[0], scopedLabel[1]);
-    }
-
-    @Override
-    public List<String> visitLabels(TypeQLParser.LabelsContext ctx) {
-        List<TypeQLParser.LabelContext> labelsList = new ArrayList<>();
-        if (ctx.label() != null) labelsList.add(ctx.label());
-        else if (ctx.label_array() != null) labelsList.addAll(ctx.label_array().label());
-        return labelsList.stream().map(RuleContext::getText).collect(toList());
     }
 
     // ATTRIBUTE OPERATION CONSTRUCTS ==========================================

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -312,10 +312,8 @@ public class Parser extends TypeQLBaseVisitor {
 
     @Override
     public TypeQLUpdate visitQuery_update(TypeQLParser.Query_updateContext ctx) {
-        assert ctx.variable_things().size() == 2;
-        return new TypeQLMatch.Unfiltered(visitPatterns(ctx.patterns()))
-                .delete(visitVariable_things(ctx.variable_things(0)))
-                .insert(visitVariable_things(ctx.variable_things(1)));
+        return visitQuery_delete(ctx.query_delete())
+                .insert(visitVariable_things(ctx.variable_things()));
     }
 
     @Override

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -196,7 +196,11 @@ fn visit_query_insert(_ctx: Rc<Query_insertContext>) -> ParserResult<()> {
     todo!()
 }
 
-fn visit_query_delete_or_update(_ctx: Rc<Query_delete_or_updateContext>) -> ParserResult<()> {
+fn visit_query_delete(_ctx: Rc<Query_deleteContext>) -> ParserResult<()> {
+    todo!()
+}
+
+fn visit_query_update(_ctx: Rc<Query_updateContext>) -> ParserResult<()> {
     todo!()
 }
 
@@ -562,14 +566,6 @@ fn visit_label_scoped(ctx: Rc<Label_scopedContext>) -> ParserResult<Label> {
 }
 
 fn visit_label(_ctx: Rc<LabelContext>) -> ParserResult<()> {
-    todo!()
-}
-
-fn visit_labels(_ctx: Rc<LabelsContext>) -> ParserResult<()> {
-    todo!()
-}
-
-fn visit_label_array(_ctx: Rc<Label_arrayContext>) -> ParserResult<()> {
     todo!()
 }
 


### PR DESCRIPTION
## What is the goal of this PR?

We split the `delete` and `update` queries into separate parser rules in the TypeQL grammar, resolving a TODO in the process.

## What are the changes implemented in this PR?

Split `delete` and `update` structures on grammar level, and modified the libraries accordingly.

Drive-by: remove unused `label_array` and `labels`.
