### PR TITLE
Feature complete match query handling in TypeQL Rust

### DIFF
--- a/rust/common/mod.rs
+++ b/rust/common/mod.rs
@@ -21,3 +21,5 @@
  */
 
 pub mod error;
+
+pub mod token;

--- a/rust/common/string.rs
+++ b/rust/common/string.rs
@@ -28,6 +28,10 @@ pub(crate) fn unquote_string(quoted_string: String) -> String {
     String::from(&quoted_string[1..quoted_string.len() - 1])
 }
 
+pub(crate) fn indent(multiline_string: String) -> String {
+    format!("    {}", multiline_string.replace('\n', "\n    "))
+}
+
 pub(crate) fn escape_regex(regex: &str) -> String {
     regex.replace('/', r#"\/"#)
 }

--- a/rust/common/string.rs
+++ b/rust/common/string.rs
@@ -20,15 +20,15 @@
  *
  */
 
-pub(crate) fn quote_string(string: String) -> String {
+pub(crate) fn quote(string: &str) -> String {
     format!("\"{}\"", string)
 }
 
-pub(crate) fn unquote_string(quoted_string: String) -> String {
+pub(crate) fn unquote(quoted_string: &str) -> String {
     String::from(&quoted_string[1..quoted_string.len() - 1])
 }
 
-pub(crate) fn indent(multiline_string: String) -> String {
+pub(crate) fn indent(multiline_string: &str) -> String {
     format!("    {}", multiline_string.replace('\n', "\n    "))
 }
 
@@ -36,6 +36,6 @@ pub(crate) fn escape_regex(regex: &str) -> String {
     regex.replace('/', r#"\/"#)
 }
 
-pub(crate) fn unescape_regex(regex: String) -> String {
+pub(crate) fn unescape_regex(regex: &str) -> String {
     regex.replace(r#"\/"#, "/")
 }

--- a/rust/common/string.rs
+++ b/rust/common/string.rs
@@ -20,6 +20,18 @@
  *
  */
 
-pub mod error;
-pub mod string;
-pub mod token;
+pub(crate) fn quote_string(string: String) -> String {
+    format!("\"{}\"", string)
+}
+
+pub(crate) fn unquote_string(quoted_string: String) -> String {
+    String::from(&quoted_string[1..quoted_string.len() - 1])
+}
+
+pub(crate) fn escape_regex(regex: &str) -> String {
+    regex.replace('/', r#"\/"#)
+}
+
+pub(crate) fn unescape_regex(regex: String) -> String {
+    regex.replace(r#"\/"#, "/")
+}

--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+use std::fmt;
+
+macro_rules! string_enum {
+    {$name:ident $($item:ident = $value:tt),* $(,)?} => {
+        #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+        pub enum $name {
+            $($item),*
+        }
+
+        impl From<&str> for $name {
+            fn from(string: &str) -> Self {
+                use $name::*;
+                match string {
+                    $($value => $item,)*
+                    _ => panic!(""),  // TODO TryFrom + ErrorMessage
+                }
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(string: String) -> Self {
+                Self::from(string.as_str())
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                use $name::*;
+                f.write_str(match self {
+                    $($item => $value,)*
+                })
+            }
+        }
+    }
+}
+
+string_enum! { Type
+    Thing = "thing",
+    Entity = "entity",
+    Relation = "relation",
+    Attribute = "attribute",
+    Role = "role",
+}
+
+string_enum! { Command
+    Define = "define",
+    Undefine = "undefine",
+    Insert = "insert",
+    Delete = "delete",
+    Match = "match",
+    Aggregate = "aggregate",
+    Group = "group",
+}
+
+string_enum! { Filter
+    Get = "get",
+    Sort = "sort",
+    Offset = "offset",
+    Limit = "limit",
+}
+
+string_enum! { Operator
+    And = "and",
+    Or = "or",
+    Not = "not",
+}
+
+string_enum! { Predicate
+    // equality
+    Eq = "=",
+    Neq = "!=",
+    Gt = ">",
+    Gte = ">=",
+    Lt = "<",
+    Lte = "<=",
+    // substring
+    Contains = "contains",
+    Like = "like",
+}
+
+impl Predicate {
+    pub fn is_equality(&self) -> bool {
+        use Predicate::*;
+        matches!(self, Eq | Neq | Gt | Gte | Lt | Lte)
+    }
+
+    pub fn is_substring(&self) -> bool {
+        use Predicate::*;
+        matches!(self, Contains | Like)
+    }
+}
+
+string_enum! { Schema
+    Rule = "rule",
+    When = "when",
+    Then = "then",
+}
+
+string_enum! { Constraint
+    Abstract = "abstract",
+    As = "as",
+    Has = "has",
+    Iid = "iid",
+    Is = "is",
+    IsKey = "@key",
+    Isa = "isa",
+    IsaX = "isa!",
+    Owns = "owns",
+    Plays = "plays",
+    Regex = "regex",
+    Relates = "relates",
+    Sub = "sub",
+    SubX = "sub!",
+    Type = "type",
+    ValueType = "value",
+}
+
+string_enum! { Aggregate
+    Count = "count",
+    Max = "max",
+    Mean = "mean",
+    Median = "median",
+    Min = "min",
+    Std = "std",
+    Sum = "sum",
+}

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -336,7 +336,7 @@ fn visit_variable_concept(ctx: Rc<Variable_conceptContext>) -> ParserResult<Conc
 fn visit_variable_type(ctx: Rc<Variable_typeContext>) -> ParserResult<TypeVariable> {
     let mut var_type = match visit_type_any(ctx.type_any().unwrap())? {
         Type::Variable(p) => p,
-        Type::Label(p) => UnboundVariable::hidden().type_(p)?.into_type(),
+        Type::Label(p) => UnboundVariable::hidden().type_(p)?,
     };
     for constraint in (0..).map_while(|i| ctx.type_constraint(i)) {
         if constraint.OWNS().is_some() {
@@ -361,7 +361,7 @@ fn visit_variable_type(ctx: Rc<Variable_typeContext>) -> ParserResult<TypeVariab
                 },
             );
         } else if constraint.REGEX().is_some() {
-            var_type = var_type.regex(get_regex(constraint.STRING_().unwrap()))?.into_type();
+            var_type = var_type.regex(get_regex(constraint.STRING_().unwrap()))?;
         } else if constraint.RELATES().is_some() {
             let _overridden: Option<()> = match constraint.AS() {
                 None => None,
@@ -380,7 +380,7 @@ fn visit_variable_type(ctx: Rc<Variable_typeContext>) -> ParserResult<TypeVariab
                 });
         } else if constraint.TYPE().is_some() {
             let scoped_label = visit_label_any(constraint.label_any().unwrap())?;
-            var_type = var_type.type_(scoped_label)?.into_type();
+            var_type = var_type.type_(scoped_label)?;
         } else {
             panic!("visit_variable_type: not implemented")
         }
@@ -411,7 +411,7 @@ fn visit_variable_thing_any(ctx: Rc<Variable_thing_anyContext>) -> ParserResult<
 fn visit_variable_thing(ctx: Rc<Variable_thingContext>) -> ParserResult<ThingVariable> {
     let mut var_thing = get_var(ctx.VAR_().unwrap()).into_thing();
     if let Some(iid) = ctx.IID_() {
-        var_thing = var_thing.iid(iid.get_text())?.into_thing();
+        var_thing = var_thing.iid(iid.get_text())?;
     }
     if let Some(isa) = ctx.ISA_() {
         var_thing = var_thing.constrain_isa(get_isa_constraint(isa, ctx.type_().unwrap())?)

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -506,6 +506,14 @@ fn visit_predicate(ctx: Rc<PredicateContext>) -> ParserResult<ValueConstraint> {
                 panic!("Unexpected predicate value: `{}`", predicate_value.get_text())
             }
         }))
+    } else if let Some(substring) = ctx.predicate_substring() {
+        Ok(ValueConstraint::new(Predicate::from(substring.get_text()), {
+            if let Some(_) = substring.LIKE() {
+                Value::from(get_regex(ctx.STRING_().unwrap()))
+            } else {
+                Value::from(get_string(ctx.STRING_().unwrap()))
+            }
+        }))
     } else {
         todo!()
     }

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -33,12 +33,11 @@ use chrono::{NaiveDate, NaiveDateTime, Timelike};
 use std::rc::Rc;
 
 use crate::common::error::{ErrorMessage, ILLEGAL_GRAMMAR};
-use typeql_grammar::typeqlrustparser::*;
 use crate::common::token::Predicate;
+use typeql_grammar::typeqlrustparser::*;
 
 use crate::pattern::*;
 use crate::query::*;
-use crate::typeql_match;
 
 #[derive(Debug)]
 pub struct Definable;
@@ -206,7 +205,8 @@ fn visit_query_update(_ctx: Rc<Query_updateContext>) -> ParserResult<()> {
 }
 
 fn visit_query_match(ctx: Rc<Query_matchContext>) -> ParserResult<TypeQLMatch> {
-    let mut match_query = typeql_match(visit_patterns(ctx.patterns().unwrap())?)?;
+    let mut match_query =
+        TypeQLMatch::new(Conjunction::from(visit_patterns(ctx.patterns().unwrap())?));
     if let Some(modifiers) = ctx.modifiers() {
         if let Some(filter) = modifiers.filter() {
             match_query = match_query.filter(visit_filter(filter)?);

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -53,11 +53,11 @@ enum Type {
 }
 
 fn get_string(string: Rc<TerminalNode>) -> String {
-    unquote_string(string.get_text())
+    unquote(&string.get_text())
 }
 
 fn get_regex(string: Rc<TerminalNode>) -> String {
-    unescape_regex(unquote_string(string.get_text()))
+    unescape_regex(&unquote(&string.get_text()))
 }
 
 fn get_long(long: Rc<TerminalNode>) -> ParserResult<i64> {

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -352,7 +352,7 @@ fn visit_variable_type(ctx: Rc<Variable_typeContext>) -> ParserResult<TypeVariab
                 None => None,
                 Some(_) => todo!(),
             };
-            let is_key = IsKey::from(constraint.IS_KEY().is_some());
+            let is_key = IsKeyAttribute::from(constraint.IS_KEY().is_some());
             var_type = var_type.constrain_owns(match visit_type(constraint.type_(0).unwrap())? {
                 Type::Label(label) => OwnsConstraint::from((label, is_key)),
                 Type::Variable(var) => OwnsConstraint::from((var, is_key)),

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -34,6 +34,7 @@ use std::rc::Rc;
 
 use crate::common::error::{ErrorMessage, ILLEGAL_GRAMMAR};
 use crate::common::token::Predicate;
+use crate::common::string::*;
 use typeql_grammar::typeqlrustparser::*;
 
 use crate::pattern::*;
@@ -51,16 +52,8 @@ enum Type {
     Variable(TypeVariable),
 }
 
-fn unquote_string(quoted_string: String) -> String {
-    String::from(&quoted_string[1..quoted_string.len() - 1])
-}
-
 fn get_string(string: Rc<TerminalNode>) -> String {
     unquote_string(string.get_text())
-}
-
-fn unescape_regex(regex: String) -> String {
-    regex.replace(r#"\\/"#, "/")
 }
 
 fn get_regex(string: Rc<TerminalNode>) -> String {

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -34,6 +34,7 @@ use std::rc::Rc;
 
 use crate::common::error::{ErrorMessage, ILLEGAL_GRAMMAR};
 use typeql_grammar::typeqlrustparser::*;
+use crate::common::token::Predicate;
 
 use crate::pattern::*;
 use crate::query::*;

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -250,11 +250,7 @@ fn visit_sort(ctx: Rc<SortContext>) -> Sorting {
 fn visit_var_order(ctx: Rc<Var_orderContext>) -> OrderedVariable {
     OrderedVariable {
         var: get_var(ctx.VAR_().unwrap()),
-        order: if let Some(order) = ctx.ORDER_() {
-            Some(order.get_text())
-        } else {
-            None
-        },
+        order: ctx.ORDER_().map(|order| order.get_text()),
     }
 }
 

--- a/rust/parser/syntax_error.rs
+++ b/rust/parser/syntax_error.rs
@@ -20,7 +20,7 @@
  *
  */
 
-use std::fmt::{Display, Formatter};
+use std::fmt;
 
 use crate::common::error::{SYNTAX_ERROR_DETAILED, SYNTAX_ERROR_NO_DETAILS};
 
@@ -31,8 +31,8 @@ pub struct SyntaxError {
     pub message: String,
 }
 
-impl Display for SyntaxError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for SyntaxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(query_line) = &self.query_line {
             // Error message appearance:
             //

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -21,8 +21,9 @@
  */
 
 use crate::{
-    parse_query, rel, type_, typeql_match, var, MatchQueryBuilder, Query, RelationVariableBuilder,
-    ThingVariableBuilder, TypeVariableBuilder, KEY,
+    parse_query, rel, type_, typeql_match, var, Conjunction, ErrorMessage, MatchQueryBuilder,
+    Pattern, Query, RelationVariableBuilder, ThingVariableBuilder, TypeQLMatch,
+    TypeVariableBuilder, KEY,
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
@@ -40,7 +41,7 @@ fn test_simple_query() {
 $x isa movie;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").isa("movie"));
+    let expected = typeql_match!(var("x").isa("movie"));
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -51,7 +52,7 @@ $a type attribute_label;
 get $a;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("a").type_("attribute_label")).get(["a"]);
+    let expected = typeql_match!(var("a").type_("attribute_label")).get(["a"]);
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -62,7 +63,7 @@ $x isa person,
     has name "alice/bob";"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").isa("person").has("name", "alice/bob"));
+    let expected = typeql_match!(var("x").isa("person").has("name", "alice/bob"));
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -74,10 +75,10 @@ $brando "Marl B" isa name;
 get $char, $prod;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match([
+    let expected = typeql_match!(
         var("brando").eq("Marl B").isa("name"),
         rel(("actor", "brando")).rel("char").rel(("production-with-cast", "prod")),
-    ])
+    )
     .get(["char", "prod"]);
 
     assert_query_eq!(expected, parsed, query);
@@ -89,7 +90,7 @@ fn test_role_type_scoped_globally() {
 $m relates spouse;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("m").relates("spouse"));
+    let expected = typeql_match!(var("m").relates("spouse"));
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -99,7 +100,7 @@ fn test_role_type_not_scoped() {
 marriage relates $s;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(type_("marriage").relates(var("s")));
+    let expected = typeql_match!(type_("marriage").relates(var("s")));
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -120,7 +121,7 @@ $x isa movie,
 $t != "Apocalypse Now";"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match([
+    let expected = typeql_match!([
         var("x").isa("movie").has("title", var("t")),
         or(
             var("t").eq("Apocalypse Now"),
@@ -146,7 +147,7 @@ $x isa movie,
 };"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match([
+    let expected = typeql_match!([
         var("x").isa("movie").has("title", var("t")),
         or(
             and(
@@ -173,7 +174,7 @@ $y isa person,
 };"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match([
+    let expected = typeql_match!([
         rel("x").rel("y"),
         var("y").isa("person").has("name", var("n")),
         or(var("n").contains("ar"), var("n").like("^M.*$")),
@@ -189,7 +190,7 @@ $y >= $z;
 $z 18 isa age;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match([
+    let expected = typeql_match!([
         var("x").has("age", var("y")),
         var("y").gte(var("z")),
         var("z").eq(18).isa("age"),
@@ -207,15 +208,13 @@ $b isa $y;
 not { $x is $y; };
 not { $a is $b; };"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match([
+    let expected = typeql_match!([
         var("x").sub(var("z")),
         var("y").sub(var("z")),
-        var("a").isa(var("x")),
+        var("a").isa(var("x")).sub("z"),
         var("b").isa(var("y")),
-        not(var("x").is("y")),
-        not(var("a").is("b")),
     ]);
+    let parsed = parse_query(query).map(Query::into_match);
     assert_query_eq!(expected, parsed, query);
 }
 */
@@ -226,7 +225,7 @@ fn test_value_equals_variable_query() {
 $s1 = $s2;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("s1").eq(var("s2")));
+    let expected = typeql_match!(var("s1").eq(var("s2")));
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -239,7 +238,7 @@ $_ has title "Spy",
     has release-date $r;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match([
+    let expected = typeql_match!([
         var("x").has("release-date", gte(var("r"))),
         var(()).has("title", "Spy").has("release-date", var("r")),
     ]);
@@ -254,7 +253,7 @@ $x has release-date < 1986-03-03T00:00,
     has tmdb-vote-average <= 9.0;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match([var("x")
+    let expected = typeql_match!([var("x")
         .has("release-date", lt(LocalDate.of(1986, 3, 3).atStartOfDay()))
         .has("tmdb-vote-count", 100)
         .has("tmdb-vote-average", lte(9.0))]);
@@ -269,7 +268,7 @@ fn when_parsing_date_handle_time() {
 $x has release-date 1000-11-12T13:14:15;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").has(
+    let expected = typeql_match!(var("x").has(
         "release-date",
         NaiveDateTime::new(NaiveDate::from_ymd(1000, 11, 12), NaiveTime::from_hms(13, 14, 15)),
     ));
@@ -283,7 +282,7 @@ fn when_parsing_date_handle_big_years() {
 $x has release-date +12345-12-25T00:00;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").has(
+    let expected = typeql_match!(var("x").has(
         "release-date",
         NaiveDateTime::new(NaiveDate::from_ymd(12345, 12, 25), NaiveTime::from_hms(0, 0, 0)),
     ));
@@ -297,7 +296,7 @@ fn when_parsing_date_handle_small_years() {
 $x has release-date 0867-01-01T00:00;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").has(
+    let expected = typeql_match!(var("x").has(
         "release-date",
         NaiveDateTime::new(NaiveDate::from_ymd(867, 1, 1), NaiveTime::from_hms(0, 0, 0)),
     ));
@@ -311,7 +310,7 @@ fn when_parsing_date_handle_negative_years() {
 $x has release-date -3200-01-01T00:00;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").has(
+    let expected = typeql_match!(var("x").has(
         "release-date",
         NaiveDateTime::new(NaiveDate::from_ymd(-3200, 1, 1), NaiveTime::from_hms(0, 0, 0)),
     ));
@@ -325,7 +324,7 @@ fn when_parsing_date_handle_millis() {
 $x has release-date 1000-11-12T13:14:15.123;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").has(
+    let expected = typeql_match!(var("x").has(
         "release-date",
         NaiveDateTime::new(
             NaiveDate::from_ymd(1000, 11, 12),
@@ -342,7 +341,7 @@ fn when_parsing_date_handle_millis_shorthand() {
 $x has release-date 1000-11-12T13:14:15.1;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").has(
+    let expected = typeql_match!(var("x").has(
         "release-date",
         NaiveDateTime::new(
             NaiveDate::from_ymd(1000, 11, 12),
@@ -370,7 +369,7 @@ $x has release-date 1000-11-12T13:14:15.000123456;"#;
 /*
 #[test]
 fn when_parsing_date_error_when_handling_overly_precise_nanos() {
-    let expected = typeql_match(var("x").has(
+    let expected = typeql_match!(var("x").has(
         "release-date",
         NaiveDateTime::new(
             NaiveDate::from_ymd(1000, 11, 12),
@@ -390,7 +389,7 @@ $x isa movie,
     has tmdb-vote-count <= 400;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").isa("movie").has("tmdb-vote-count", lte(400)));
+    let expected = typeql_match!(var("x").isa("movie").has("tmdb-vote-count", lte(400)));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -403,7 +402,7 @@ $x plays starring:actor;
 sort $x asc;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").plays(("starring", "actor"))).sort([("x", "asc")]);
+    let expected = typeql_match!(var("x").plays(("starring", "actor"))).sort([("x", "asc")]);
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -417,7 +416,7 @@ sort $r desc;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
     let expected =
-        typeql_match(var("x").isa("movie").has("rating", var("r"))).sort([("r", "desc")]);
+        typeql_match!(var("x").isa("movie").has("rating", var("r"))).sort([("r", "desc")]);
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -430,7 +429,7 @@ $x isa movie,
 sort $r; limit 10;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").isa("movie").has("rating", var("r"))).sort("r").limit(10);
+    let expected = typeql_match!(var("x").isa("movie").has("rating", var("r"))).sort("r").limit(10);
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -443,7 +442,7 @@ $x isa movie,
 sort $r desc; offset 10; limit 10;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").isa("movie").has("rating", var("r")))
+    let expected = typeql_match!(var("x").isa("movie").has("rating", var("r")))
         .sort([("r", "desc")])
         .offset(10)
         .limit(10);
@@ -459,7 +458,7 @@ $y isa movie,
 offset 2; limit 4;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("y").isa("movie").has("title", var("n"))).offset(2).limit(4);
+    let expected = typeql_match!(var("y").isa("movie").has("title", var("n"))).offset(2).limit(4);
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -474,13 +473,13 @@ $z sub production;
 has-genre relates $p;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match([
+    let expected = typeql_match!(
         rel((var("p"), var("x"))).rel("y"),
         var("x").isa(var("z")),
         var("y").eq("crime"),
         var("z").sub("production"),
         type_("has-genre").relates(var("p")),
-    ]);
+    );
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -491,7 +490,7 @@ fn test_parse_relates_type_variable() {
 $x isa $type;
 $type relates someRole;"#;
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match([var("x").isa(var("type")), var("type").relates("someRole")]);
+    let expected = typeql_match!(var("x").isa(var("type")), var("type").relates("someRole"));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -508,7 +507,7 @@ fn test_or_query() {
             "    $x 'The Muppets';\n" +
             "};";
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(
+    let expected = typeql_match!(
             var("x").isa("movie"),
             or(
                     and(
@@ -548,7 +547,7 @@ fn test_nested_conjunction_and_disjunction() {
             "    };\n" +
             "};";
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(
+    let expected = typeql_match!(
             var("y").isa(var("p")),
             or(rel("y").rel("q"),
                and(var("x").isa(var("p")),
@@ -572,7 +571,7 @@ fn test_aggregate_count_query() {
             "get $x, $y;\n" +
             "count;";
     let parsed = parse_query(query).unwrapAggregate();
-    let expected = typeql_match(rel("x").rel("y").isa("friendship")).get("x", "y").count();
+    let expected = typeql_match!(rel("x").rel("y").isa("friendship")).get("x", "y").count();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -584,7 +583,7 @@ fn test_aggregate_group_count_query() {
             "get $x, $y;\n" +
             "group $x; count;";
     let parsed = parse_query(query).unwrapGroupAggregate();
-    let expected = typeql_match(rel("x").rel("y").isa("friendship")).get("x", "y").group("x").count();
+    let expected = typeql_match!(rel("x").rel("y").isa("friendship")).get("x", "y").group("x").count();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -595,7 +594,7 @@ fn test_single_line_group_aggregate_max_query() {
             "$x has age $a;\n" +
             "group $x; max $a;";
     let parsed = parse_query(query).unwrapGroupAggregate();
-    let expected = typeql_match(var("x").has("age", var("a"))).group("x").max("a");
+    let expected = typeql_match!(var("x").has("age", var("a"))).group("x").max("a");
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -607,7 +606,7 @@ fn test_multi_line_group_aggregate_max_query() {
             "$y has age $z;\n" +
             "group $x; max $z;";
     let parsed = parse_query(query).unwrapGroupAggregate();
-    let expected = typeql_match(
+    let expected = typeql_match!(
             rel("x").rel("y").isa("friendship"),
             var("y").has("age", var("z"))
     ).group("x").max("z");
@@ -623,7 +622,7 @@ fn test_multi_line_filtered_group_aggregate_max_query() {
             "get $x, $y, $z;\n" +
             "group $x; max $z;";
     let parsed = parse_query(query).unwrapGroupAggregate();
-    let expected = typeql_match(
+    let expected = typeql_match!(
             rel("x").rel("y").isa("friendship"),
             var("y").has("age", var("z"))
     ).get("x", "y", "z").group("x").max("z");
@@ -638,7 +637,7 @@ fn when_comparing_count_query_using_typeql_and_java_typeql_they_are_equivalent()
             "    has title \"Godfather\";\n" +
             "count;";
     let parsed = parse_query(query).unwrapAggregate();
-    let expected = typeql_match(var("x").isa("movie").has("title", "Godfather")).count();
+    let expected = typeql_match!(var("x").isa("movie").has("title", "Godfather")).count();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -663,7 +662,7 @@ fn when_parsing_delete_query_result_is_same_as_java_type_ql() {
             "$x isa movie;\n" +
             "$y isa movie;";
     let parsed = parse_query(query).asDelete();
-    let expected = typeql_match(
+    let expected = typeql_match!(
             var("x").isa("movie").has("title", "The Title"),
             var("y").isa("movie")
     ).delete(var("x").isa("movie"), var("y").isa("movie"));
@@ -705,7 +704,7 @@ fn when_parsing_update_query_result_issame_as_java_type_ql() {
             "insert\n" +
             "$x has age 25;";
     let parsed = parse_query(query).asUpdate();
-    let expected = typeql_match(var("x").isa("person").has("name", "alice").has("age", var("a")))
+    let expected = typeql_match!(var("x").isa("person").has("name", "alice").has("age", var("a")))
             .delete(var("x").has(var("a")))
             .insert(var("x").has("age", 25));
     assert_query_eq!(expected, parsed, query.replace("'", "\""));
@@ -745,7 +744,7 @@ fn when_parsing_as_in_match_result_is_same_as_sub() {
             "    relates father as parent,\n" +
             "    relates son as child;";
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(
+    let expected = typeql_match!(
             var("f").sub("parenthood")
                     .relates("father", "parent")
                     .relates("son", "child")
@@ -874,7 +873,7 @@ fn test_match_insert_query() {
             "$x isa language;\n" +
             "insert\n$x has name \"HELLO\";";
     let parsed = parse_query(query).asInsert();
-    let expected = typeql_match(var("x").isa("language"))
+    let expected = typeql_match!(var("x").isa("language"))
             .insert(var("x").has("name", "HELLO"));
 
     assert_query_eq!(expected, parsed, query);
@@ -899,7 +898,7 @@ fn test_define_abstract_entity_query() {
 fn test_match_value_type_query() {
     let query = "match\n$x value double;";
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").value(TypeQLArg.ValueType.DOUBLE));
+    let expected = typeql_match!(var("x").value(TypeQLArg.ValueType.DOUBLE));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -912,16 +911,16 @@ $_ isa person;"#;
 
     let parsed = parse_query(query); // todo error
     assert!(parsed.is_err());
-    let built = typeql_match(var(()).isa("person")); // todo error
+    let built = typeql_match!(var(()).isa("person")); // todo error
     assert!(built.is_err());
 }
 
 /*
 #[test]
 fn when_parsing_date_keyword_parse_as_the_correct_value_type() {
-    let query = "typeql_match\n$x value datetime;";
+    let query = "match\n$x value datetime;";
     let parsed = parse_query(query).asMatch();
-    let expected = typeql_match(var("x").value(TypeQLArg.ValueType.DATETIME));
+    let expected = typeql_match!(var("x").value(TypeQLArg.ValueType.DATETIME));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -959,7 +958,7 @@ fn when_parsing_query_with_comments_they_are_ignored() {
     let uncommented = "match\n$x isa movie;\ncount;";
 
     let parsed = parse_query(query).asMatchAggregate();
-    let expected = typeql_match(var("x").isa("movie")).count();
+    let expected = typeql_match!(var("x").isa("movie")).count();
 
     assert_query_eq!(expected, parsed, uncommented);
 }
@@ -1017,7 +1016,7 @@ fn test_parse_aggregate_group() {
             "$x isa movie;\n" +
             "group $x;";
     let parsed = parse_query(query).asMatchGroup();
-    let expected = typeql_match(var("x").isa("movie")).group("x");
+    let expected = typeql_match!(var("x").isa("movie")).group("x");
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -1028,7 +1027,7 @@ fn test_parse_aggregate_group_count() {
             "$x isa movie;\n" +
             "group $x; count;";
     let parsed = parse_query(query).asMatchGroupAggregate();
-    let expected = typeql_match(var("x").isa("movie")).group("x").count();
+    let expected = typeql_match!(var("x").isa("movie")).group("x").count();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -1039,7 +1038,7 @@ fn test_parse_aggregate_std() {
             "$x isa movie;\n" +
             "std $x;";
     let parsed = parse_query(query).asMatchAggregate();
-    let expected = typeql_match(var("x").isa("movie")).std("x");
+    let expected = typeql_match!(var("x").isa("movie")).std("x");
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -1100,7 +1099,8 @@ $_ has title "Godfather",
     has tmdb-vote-count $x;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var(()).has("title", "Godfather").has("tmdb-vote-count", var("x")));
+    let expected =
+        typeql_match!(var(()).has("title", "Godfather").has("tmdb-vote-count", var("x")));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -1111,7 +1111,7 @@ fn test_regex_attribute_type() {
 $x regex "(fe)?male";"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").regex("(fe)?male"));
+    let expected = typeql_match!(var("x").regex("(fe)?male"));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -1128,7 +1128,7 @@ $x owns name @key;
 get $x;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").owns(("name", KEY))).get(["x"]);
+    let expected = typeql_match!(var("x").owns(("name", KEY))).get(["x"]);
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -1145,7 +1145,7 @@ fn test_parse_list_one_match() {
 $y isa movie;"#;
 
     let parsed = parse_queries(queries).collect();  // TODO parse_queries -> Iter
-    let expected = vec![typeql_match(var("y").isa("movie"))];
+    let expected = vec![typeql_match!(var("y").isa("movie"))];
 
     assert_eq!(parsed, expected);
 }
@@ -1181,7 +1181,7 @@ fn test_parse_list() {
     let match_string = "match\n$y isa movie;";
     let queries = parse_queries(insert_string + match_string).collect();
 
-    assertEquals(list(insert(var("x").isa("movie")), typeql_match(var("y").isa("movie"))), queries);
+    assertEquals(list(insert(var("x").isa("movie")), typeql_match!(var("y").isa("movie"))), queries);
 }
 
 #[test]
@@ -1194,7 +1194,7 @@ fn test_parse_many_match_insert_without_stack_overflow() {
     }
 
     let parsed = parse_queries(long_query).collect();
-    let expected = typeql_match(var("x").isa("person")).insert(var("x").has("name", "bob"));
+    let expected = typeql_match!(var("x").isa("person")).insert(var("x").has("name", "bob"));
 
     assert_eq!(vec![expected; num_queries], parsed);
 }
@@ -1267,7 +1267,7 @@ fn undefine_attribute_type_regex() {
 fn regex_predicate_parses_character_classes_correctly() {
     let query = "match\n$x like '\\d';";
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").like("\\d"));
+    let expected = typeql_match!(var("x").like("\\d"));
     assert_query_eq!(expected, parsed, query.replace("'", "\""));
 }
 
@@ -1275,7 +1275,7 @@ fn regex_predicate_parses_character_classes_correctly() {
 fn regex_predicate_parses_quotes_correctly() {
     let query = "match\n$x like '\\\"';";
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").like("\\\""));
+    let expected = typeql_match!(var("x").like("\\\""));
     assert_query_eq!(expected, parsed, query.replace("'", "\""));
 }
 
@@ -1283,7 +1283,7 @@ fn regex_predicate_parses_quotes_correctly() {
 fn regex_predicate_parses_backslashes_correctly() {
     let query = "match\n$x like '\\\\';";
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").like("\\\\"));
+    let expected = typeql_match!(var("x").like("\\\\"));
     assert_query_eq!(expected, parsed, query.replace("'", "\""));
 }
 
@@ -1291,7 +1291,7 @@ fn regex_predicate_parses_backslashes_correctly() {
 fn regex_predicate_parses_newline_correctly() {
     let query = "match\n$x like '\\n';";
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").like("\\n"));
+    let expected = typeql_match!(var("x").like("\\n"));
     assert_query_eq!(expected, parsed, query.replace("'", "\""));
 }
 
@@ -1299,7 +1299,7 @@ fn regex_predicate_parses_newline_correctly() {
 fn regex_predicate_parses_forward_slashes_correctly() {
     let query = "match\n$x like '\\/';";
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match(var("x").like("/"));
+    let expected = typeql_match!(var("x").like("/"));
     assert_query_eq!(expected, parsed, query.replace("'", "\""));
 }
  */
@@ -1307,7 +1307,7 @@ fn regex_predicate_parses_forward_slashes_correctly() {
 #[test]
 fn when_value_equality_to_string_create_valid_query_string() {
     // TODO no unwraps
-    let expected = typeql_match(var("x").eq(var("y"))).unwrap();
+    let expected = typeql_match!(var("x").eq(var("y"))).unwrap();
     let parsed = parse_query(&expected.to_string()).map(Query::into_match).unwrap();
 
     assert_eq!(expected, parsed);
@@ -1323,7 +1323,7 @@ $x iid {};"#,
     );
 
     let parsed = parse_query(&query).map(Query::into_match);
-    let expected = typeql_match(var("x").iid(iid));
+    let expected = typeql_match!(var("x").iid(iid));
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -1343,6 +1343,6 @@ $x iid {};"#,
 #[test]
 fn when_building_invalid_iid_throw() {
     let iid = "invalid";
-    let expected = typeql_match(var("x").iid(iid));
+    let expected = typeql_match!(var("x").iid(iid));
     assert!(expected.is_err());
 }

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -1275,39 +1275,41 @@ $x like "\d";"#;
     assert_query_eq!(expected, parsed, query);
 }
 
-/*
 #[test]
 fn regex_predicate_parses_quotes_correctly() {
-    let query = "match\n$x like '\\\"';";
+    let query = r#"match
+$x like "\"";"#;
     let parsed = parse_query(query).map(Query::into_match);
     let expected = typeql_match!(var("x").like("\\\""));
-    assert_query_eq!(expected, parsed, query.replace("'", "\""));
+    assert_query_eq!(expected, parsed, query);
 }
 
 #[test]
 fn regex_predicate_parses_backslashes_correctly() {
-    let query = "match\n$x like '\\\\';";
+    let query = r#"match
+$x like "\\";"#;
     let parsed = parse_query(query).map(Query::into_match);
     let expected = typeql_match!(var("x").like("\\\\"));
-    assert_query_eq!(expected, parsed, query.replace("'", "\""));
+    assert_query_eq!(expected, parsed, query);
 }
 
 #[test]
 fn regex_predicate_parses_newline_correctly() {
-    let query = "match\n$x like '\\n';";
+    let query = r#"match
+$x like "\n";"#;
     let parsed = parse_query(query).map(Query::into_match);
     let expected = typeql_match!(var("x").like("\\n"));
-    assert_query_eq!(expected, parsed, query.replace("'", "\""));
+    assert_query_eq!(expected, parsed, query);
 }
 
 #[test]
 fn regex_predicate_parses_forward_slashes_correctly() {
-    let query = "match\n$x like '\\/';";
+    let query = r#"match
+$x like "\/";"#;
     let parsed = parse_query(query).map(Query::into_match);
     let expected = typeql_match!(var("x").like("/"));
-    assert_query_eq!(expected, parsed, query.replace("'", "\""));
+    assert_query_eq!(expected, parsed, query);
 }
- */
 
 #[test]
 fn when_value_equality_to_string_create_valid_query_string() {

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -368,7 +368,6 @@ $x has release-date 1000-11-12T13:14:15.000123456;"#;
     }
 }
 
-/*
 #[test]
 fn when_parsing_date_error_when_handling_overly_precise_nanos() {
     let expected = typeql_match!(var("x").has(
@@ -379,11 +378,12 @@ fn when_parsing_date_error_when_handling_overly_precise_nanos() {
         ),
     ));
     match expected {
-        Err(err) => assert!(err.contains("more precise than 1 millisecond")),
+        Err(err) => assert!(err.message.contains("more precise than 1 millisecond")),
         Ok(_) => assert!(false),
     }
 }
 
+/*
 #[test]
 fn test_long_predicate_query() {
     let query = r#"match
@@ -1264,15 +1264,18 @@ fn undefine_attribute_type_regex() {
     let expected = undefine(type_("digit").regex("\\d"));
     assert_query_eq!(expected, parsed, query.replace("'", "\""));
 }
+*/
 
 #[test]
 fn regex_predicate_parses_character_classes_correctly() {
-    let query = "match\n$x like '\\d';";
+    let query = r#"match
+$x like "\d";"#;
     let parsed = parse_query(query).map(Query::into_match);
     let expected = typeql_match!(var("x").like("\\d"));
-    assert_query_eq!(expected, parsed, query.replace("'", "\""));
+    assert_query_eq!(expected, parsed, query);
 }
 
+/*
 #[test]
 fn regex_predicate_parses_quotes_correctly() {
     let query = "match\n$x like '\\\"';";

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -21,9 +21,9 @@
  */
 
 use crate::{
-    parse_query, rel, type_, typeql_match, var, Conjunction, ErrorMessage, MatchQueryBuilder,
-    Pattern, Query, RelationVariableBuilder, ThingVariableBuilder, TypeQLMatch,
-    TypeVariableBuilder, KEY,
+    not, parse_query, rel, type_, typeql_match, var, ConceptVariableBuilder, Conjunction,
+    ErrorMessage, MatchQueryBuilder, Query, RelationVariableBuilder, ThingVariableBuilder,
+    TypeQLMatch, TypeVariableBuilder, KEY,
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
@@ -197,6 +197,7 @@ $z 18 isa age;"#;
     ]);
     assert_query_eq!(expected, parsed, query);
 }
+*/
 
 #[test]
 fn test_concept_variable() {
@@ -208,16 +209,17 @@ $b isa $y;
 not { $x is $y; };
 not { $a is $b; };"#;
 
-    let expected = typeql_match!([
+    let expected = typeql_match!(
         var("x").sub(var("z")),
         var("y").sub(var("z")),
-        var("a").isa(var("x")).sub("z"),
+        var("a").isa(var("x")),
         var("b").isa(var("y")),
-    ]);
+        not(var("x").is(var("y"))),
+        not(var("a").is(var("b"))),
+    );
     let parsed = parse_query(query).map(Query::into_match);
     assert_query_eq!(expected, parsed, query);
 }
-*/
 
 #[test]
 fn test_value_equals_variable_query() {

--- a/rust/pattern/conjunction.rs
+++ b/rust/pattern/conjunction.rs
@@ -84,7 +84,7 @@ impl fmt::Display for Conjunction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("{\n")?;
         f.write_str(
-            &self.patterns.iter().map(|p| indent(p.to_string()) + ";\n").collect::<String>(),
+            &self.patterns.iter().map(|p| indent(&p.to_string()) + ";\n").collect::<String>(),
         )?;
         f.write_str("}")
     }

--- a/rust/pattern/conjunction.rs
+++ b/rust/pattern/conjunction.rs
@@ -20,6 +20,7 @@
  *
  */
 
+use crate::common::string::indent;
 use crate::pattern::Pattern;
 use crate::ErrorMessage;
 use std::fmt;
@@ -80,7 +81,11 @@ where
 }
 
 impl fmt::Display for Conjunction {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("{\n")?;
+        f.write_str(
+            &self.patterns.iter().map(|p| indent(p.to_string()) + ";\n").collect::<String>(),
+        )?;
+        f.write_str("}")
     }
 }

--- a/rust/pattern/conjunction.rs
+++ b/rust/pattern/conjunction.rs
@@ -33,6 +33,10 @@ impl Conjunction {
     pub fn new(patterns: &[Pattern]) -> Conjunction {
         Conjunction { patterns: patterns.to_vec() }
     }
+
+    pub fn into_pattern(self) -> Pattern {
+        Pattern::Conjunction(self)
+    }
 }
 
 impl<T: Into<Pattern>> From<T> for Conjunction {

--- a/rust/pattern/conjunction.rs
+++ b/rust/pattern/conjunction.rs
@@ -23,7 +23,6 @@
 use crate::pattern::Pattern;
 use crate::ErrorMessage;
 use std::fmt;
-use std::fmt::Display;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Conjunction {
@@ -76,7 +75,7 @@ where
     }
 }
 
-impl Display for Conjunction {
+impl fmt::Display for Conjunction {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
         todo!()
     }

--- a/rust/pattern/constraint/concept_constraint.rs
+++ b/rust/pattern/constraint/concept_constraint.rs
@@ -20,57 +20,41 @@
  *
  */
 
-mod conjunction;
-pub use conjunction::*;
-
-mod negation;
-pub use negation::*;
-
-mod variable;
-pub use variable::*;
-
-mod constraint;
-pub use constraint::*;
-
-#[cfg(test)]
-mod test;
-
-use crate::enum_getter;
+use crate::common::token::Constraint::Is;
+use crate::pattern::*;
+use crate::var;
 use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Pattern {
-    Conjunction(Conjunction),
-    Disjunction(()),
-    Negation(Negation),
-    Variable(Variable),
+pub struct IsConstraint {
+    variable: Box<ConceptVariable>,
 }
 
-impl Pattern {
-    enum_getter!(into_variable, Variable, Variable);
-
-    pub fn into_type_variable(self) -> TypeVariable {
-        self.into_variable().into_type()
+impl From<&str> for IsConstraint {
+    fn from(string: &str) -> IsConstraint {
+        Self::from(var(string))
+    }
+}
+impl From<String> for IsConstraint {
+    fn from(string: String) -> IsConstraint {
+        Self::from(var(string))
     }
 }
 
-impl<T> From<T> for Pattern
-where
-    Variable: From<T>,
-{
-    fn from(variable: T) -> Self {
-        Pattern::Variable(Variable::from(variable))
+impl From<UnboundVariable> for IsConstraint {
+    fn from(var: UnboundVariable) -> IsConstraint {
+        Self::from(var.into_concept())
     }
 }
 
-impl fmt::Display for Pattern {
+impl From<ConceptVariable> for IsConstraint {
+    fn from(var: ConceptVariable) -> IsConstraint {
+        Self { variable: Box::new(var) }
+    }
+}
+
+impl fmt::Display for IsConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Pattern::*;
-        match self {
-            Conjunction(conjunction) => write!(f, "{}", conjunction),
-            Disjunction(()) => todo!(),
-            Negation(negation) => write!(f, "{}", negation),
-            Variable(variable) => write!(f, "{}", variable),
-        }
+        write!(f, "{} {}", Is, self.variable)
     }
 }

--- a/rust/pattern/constraint/thing_constraint.rs
+++ b/rust/pattern/constraint/thing_constraint.rs
@@ -23,13 +23,13 @@
 use crate::common::error::{
     ErrorMessage, INVALID_CONSTRAINT_DATETIME_PRECISION, INVALID_IID_STRING,
 };
+use crate::common::token::Constraint::*;
+use crate::common::token::Predicate;
+use crate::common::token::Type::Relation;
 use crate::pattern::*;
 use crate::write_joined;
 use chrono::{NaiveDateTime, Timelike};
 use std::fmt;
-use crate::common::token::Constraint::*;
-use crate::common::token::Predicate;
-use crate::common::token::Type::Relation;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct IIDConstraint {

--- a/rust/pattern/constraint/thing_constraint.rs
+++ b/rust/pattern/constraint/thing_constraint.rs
@@ -30,6 +30,7 @@ use crate::pattern::*;
 use crate::write_joined;
 use chrono::{NaiveDateTime, Timelike};
 use std::fmt;
+use crate::common::string::escape_regex;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct IIDConstraint {
@@ -170,7 +171,10 @@ impl ValueConstraint {
 
 impl fmt::Display for ValueConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.predicate == Predicate::Eq && !matches!(self.value, Value::Variable(_)) {
+        if self.predicate == Predicate::Like {
+            assert!(matches!(self.value, Value::String(_)));
+            write!(f, "{} {}", self.predicate, escape_regex(&self.value.to_string()))
+        } else if self.predicate == Predicate::Eq && !matches!(self.value, Value::Variable(_)) {
             write!(f, "{}", self.value)
         } else {
             write!(f, "{} {}", self.predicate, self.value)

--- a/rust/pattern/constraint/thing_constraint.rs
+++ b/rust/pattern/constraint/thing_constraint.rs
@@ -81,7 +81,7 @@ pub struct IsaConstraint {
 impl<T: Into<Label>> From<T> for IsaConstraint {
     fn from(type_name: T) -> Self {
         IsaConstraint {
-            type_: UnboundVariable::hidden().type_(type_name).unwrap().into_type(),
+            type_: UnboundVariable::hidden().type_(type_name).unwrap(),
             is_explicit: false,
         }
     }
@@ -114,7 +114,7 @@ pub struct HasConstraint {
 impl From<(String, ValueConstraint)> for HasConstraint {
     fn from((type_name, value_constraint): (String, ValueConstraint)) -> Self {
         HasConstraint {
-            type_: Some(UnboundVariable::hidden().type_(type_name).unwrap().into_type()),
+            type_: Some(UnboundVariable::hidden().type_(type_name).unwrap()),
             attribute: UnboundVariable::hidden().constrain_value(value_constraint),
         }
     }
@@ -123,7 +123,7 @@ impl From<(String, ValueConstraint)> for HasConstraint {
 impl From<(String, UnboundVariable)> for HasConstraint {
     fn from((type_name, variable): (String, UnboundVariable)) -> Self {
         HasConstraint {
-            type_: Some(UnboundVariable::hidden().type_(type_name).unwrap().into_type()),
+            type_: Some(UnboundVariable::hidden().type_(type_name).unwrap()),
             attribute: variable.into_thing(),
         }
     }
@@ -132,7 +132,7 @@ impl From<(String, UnboundVariable)> for HasConstraint {
 impl From<(String, ThingVariable)> for HasConstraint {
     fn from((type_name, variable): (String, ThingVariable)) -> Self {
         HasConstraint {
-            type_: Some(UnboundVariable::hidden().type_(type_name).unwrap().into_type()),
+            type_: Some(UnboundVariable::hidden().type_(type_name).unwrap()),
             attribute: variable,
         }
     }
@@ -350,13 +350,13 @@ impl From<UnboundVariable> for RolePlayerConstraint {
 
 impl From<(String, UnboundVariable)> for RolePlayerConstraint {
     fn from((role_type, player_var): (String, UnboundVariable)) -> Self {
-        Self::from((UnboundVariable::hidden().type_(role_type).unwrap().into_type(), player_var))
+        Self::from((UnboundVariable::hidden().type_(role_type).unwrap(), player_var))
     }
 }
 
 impl From<(Label, UnboundVariable)> for RolePlayerConstraint {
     fn from((role_type, player_var): (Label, UnboundVariable)) -> Self {
-        Self::from((UnboundVariable::hidden().type_(role_type).unwrap().into_type(), player_var))
+        Self::from((UnboundVariable::hidden().type_(role_type).unwrap(), player_var))
     }
 }
 

--- a/rust/pattern/constraint/thing_constraint.rs
+++ b/rust/pattern/constraint/thing_constraint.rs
@@ -27,7 +27,6 @@ use crate::pattern::*;
 use crate::write_joined;
 use chrono::{NaiveDateTime, Timelike};
 use std::fmt;
-use std::fmt::{Display, Write};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct IIDConstraint {
@@ -64,7 +63,7 @@ impl TryFrom<String> for IIDConstraint {
     }
 }
 
-impl Display for IIDConstraint {
+impl fmt::Display for IIDConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "iid {}", self.iid)
     }
@@ -97,7 +96,7 @@ impl From<TypeVariable> for IsaConstraint {
     }
 }
 
-impl Display for IsaConstraint {
+impl fmt::Display for IsaConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "isa {}", self.type_)
     }
@@ -136,7 +135,7 @@ impl From<(String, ThingVariable)> for HasConstraint {
     }
 }
 
-impl Display for HasConstraint {
+impl fmt::Display for HasConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("has")?;
         if let Some(type_) = &self.type_ {
@@ -166,7 +165,7 @@ impl ValueConstraint {
     }
 }
 
-impl Display for ValueConstraint {
+impl fmt::Display for ValueConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.predicate == Predicate::Eq && !matches!(self.value, Value::Variable(_)) {
             write!(f, "{}", self.value)
@@ -212,7 +211,7 @@ impl From<String> for Predicate {
     }
 }
 
-impl Display for Predicate {
+impl fmt::Display for Predicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Predicate::*;
         write!(
@@ -298,7 +297,7 @@ impl From<Variable> for Value {
     }
 }
 
-impl Display for Value {
+impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Value::*;
         match self {
@@ -340,11 +339,11 @@ impl From<RolePlayerConstraint> for RelationConstraint {
     }
 }
 
-impl Display for RelationConstraint {
+impl fmt::Display for RelationConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_char('(')?;
+        f.write_str("(")?;
         write_joined!(f, self.role_players, ", ")?;
-        f.write_char(')')
+        f.write_str(")")
     }
 }
 
@@ -421,7 +420,7 @@ impl From<(TypeVariable, UnboundVariable)> for RolePlayerConstraint {
     }
 }
 
-impl Display for RolePlayerConstraint {
+impl fmt::Display for RolePlayerConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(role_type) = &self.role_type {
             if role_type.reference.is_visible() {

--- a/rust/pattern/constraint/thing_constraint.rs
+++ b/rust/pattern/constraint/thing_constraint.rs
@@ -247,12 +247,6 @@ impl From<ThingVariable> for Value {
     }
 }
 
-impl From<Variable> for Value {
-    fn from(variable: Variable) -> Value {
-        Value::Variable(Box::new(variable.into_thing()))
-    }
-}
-
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Value::*;

--- a/rust/pattern/constraint/thing_constraint.rs
+++ b/rust/pattern/constraint/thing_constraint.rs
@@ -342,7 +342,7 @@ impl From<RolePlayerConstraint> for RelationConstraint {
 impl fmt::Display for RelationConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("(")?;
-        write_joined!(f, self.role_players, ", ")?;
+        write_joined!(f, ", ", self.role_players)?;
         f.write_str(")")
     }
 }

--- a/rust/pattern/constraint/thing_constraint.rs
+++ b/rust/pattern/constraint/thing_constraint.rs
@@ -23,6 +23,7 @@
 use crate::common::error::{
     ErrorMessage, INVALID_CONSTRAINT_DATETIME_PRECISION, INVALID_IID_STRING,
 };
+use crate::common::string::escape_regex;
 use crate::common::token::Constraint::*;
 use crate::common::token::Predicate;
 use crate::common::token::Type::Relation;
@@ -30,7 +31,6 @@ use crate::pattern::*;
 use crate::write_joined;
 use chrono::{NaiveDateTime, Timelike};
 use std::fmt;
-use crate::common::string::escape_regex;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct IIDConstraint {
@@ -257,6 +257,10 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Value::*;
         match self {
+            Long(long) => write!(f, "{}", long),
+            Double(double) => write!(f, "{}", double),
+            Boolean(boolean) => write!(f, "{}", boolean),
+            String(string) => write!(f, "\"{}\"", string),
             DateTime(date_time) => write!(f, "{}", {
                 if date_time.time().nanosecond() > 0 {
                     date_time.format("%Y-%m-%dT%H:%M:%S.%3f")
@@ -266,9 +270,7 @@ impl fmt::Display for Value {
                     date_time.format("%Y-%m-%dT%H:%M")
                 }
             }),
-            String(string) => write!(f, "\"{}\"", string),
             Variable(var) => write!(f, "{}", var.reference),
-            _ => panic!(""),
         }
     }
 }

--- a/rust/pattern/constraint/thing_constraint.rs
+++ b/rust/pattern/constraint/thing_constraint.rs
@@ -27,6 +27,9 @@ use crate::pattern::*;
 use crate::write_joined;
 use chrono::{NaiveDateTime, Timelike};
 use std::fmt;
+use crate::common::token::Constraint::*;
+use crate::common::token::Predicate;
+use crate::common::token::Type::Relation;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct IIDConstraint {
@@ -65,7 +68,7 @@ impl TryFrom<String> for IIDConstraint {
 
 impl fmt::Display for IIDConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "iid {}", self.iid)
+        write!(f, "{} {}", Iid, self.iid)
     }
 }
 
@@ -98,7 +101,7 @@ impl From<TypeVariable> for IsaConstraint {
 
 impl fmt::Display for IsaConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "isa {}", self.type_)
+        write!(f, "{} {}", Isa, self.type_)
     }
 }
 
@@ -137,7 +140,7 @@ impl From<(String, ThingVariable)> for HasConstraint {
 
 impl fmt::Display for HasConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("has")?;
+        write!(f, "{}", Has)?;
         if let Some(type_) = &self.type_ {
             write!(f, " {}", &type_.label.as_ref().unwrap().label)?;
         }
@@ -172,57 +175,6 @@ impl fmt::Display for ValueConstraint {
         } else {
             write!(f, "{} {}", self.predicate, self.value)
         }
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Predicate {
-    // equality
-    Eq,
-    Neq,
-    Gt,
-    Gte,
-    Lt,
-    Lte,
-    // substring
-    Contains,
-    Like,
-}
-
-impl Predicate {
-    pub fn is_equality(&self) -> bool {
-        use Predicate::*;
-        matches!(self, Eq | Neq | Gt | Gte | Lt | Lte)
-    }
-
-    pub fn is_substring(&self) -> bool {
-        use Predicate::*;
-        matches!(self, Contains | Like)
-    }
-}
-
-impl From<String> for Predicate {
-    fn from(string: String) -> Self {
-        use Predicate::*;
-        match string.as_str() {
-            "=" => Eq,
-            _ => todo!(),
-        }
-    }
-}
-
-impl fmt::Display for Predicate {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Predicate::*;
-        write!(
-            f,
-            "{}",
-            match self {
-                Eq => "=",
-                Neq => "!=",
-                _ => todo!(),
-            }
-        )
     }
 }
 
@@ -325,7 +277,7 @@ pub struct RelationConstraint {
 
 impl RelationConstraint {
     pub fn new(role_players: Vec<RolePlayerConstraint>) -> Self {
-        RelationConstraint { role_players, scope: String::from("relation") }
+        RelationConstraint { role_players, scope: Relation.to_string() }
     }
 
     pub fn add(&mut self, role_player: RolePlayerConstraint) {

--- a/rust/pattern/constraint/type_constraint.rs
+++ b/rust/pattern/constraint/type_constraint.rs
@@ -20,10 +20,10 @@
  *
  */
 
+use crate::common::string::escape_regex;
 use crate::common::token::Constraint::*;
 use crate::{TypeVariable, TypeVariableBuilder, UnboundVariable};
 use std::fmt;
-use crate::common::string::escape_regex;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Label {
@@ -76,9 +76,7 @@ pub struct SubConstraint {
 
 impl<T: Into<Label>> From<T> for SubConstraint {
     fn from(scoped_type: T) -> Self {
-        SubConstraint {
-            type_: Box::new(UnboundVariable::hidden().type_(scoped_type).unwrap()),
-        }
+        SubConstraint { type_: Box::new(UnboundVariable::hidden().type_(scoped_type).unwrap()) }
     }
 }
 
@@ -179,10 +177,7 @@ impl From<(String, String)> for PlaysConstraint {
 
 impl From<Label> for PlaysConstraint {
     fn from(scoped_type: Label) -> Self {
-        PlaysConstraint::new(
-            UnboundVariable::hidden().type_(scoped_type).unwrap(),
-            None,
-        )
+        PlaysConstraint::new(UnboundVariable::hidden().type_(scoped_type).unwrap(), None)
     }
 }
 
@@ -267,10 +262,7 @@ impl From<(String, IsKey)> for OwnsConstraint {
 
 impl From<(Label, IsKey)> for OwnsConstraint {
     fn from((attribute_type, is_key): (Label, IsKey)) -> Self {
-        OwnsConstraint::from((
-            UnboundVariable::hidden().type_(attribute_type).unwrap(),
-            is_key,
-        ))
+        OwnsConstraint::from((UnboundVariable::hidden().type_(attribute_type).unwrap(), is_key))
     }
 }
 

--- a/rust/pattern/constraint/type_constraint.rs
+++ b/rust/pattern/constraint/type_constraint.rs
@@ -23,6 +23,7 @@
 use crate::common::token::Constraint::*;
 use crate::{TypeVariable, TypeVariableBuilder, UnboundVariable};
 use std::fmt;
+use crate::common::string::escape_regex;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Label {
@@ -306,10 +307,6 @@ impl From<String> for RegexConstraint {
     fn from(regex: String) -> Self {
         RegexConstraint { regex }
     }
-}
-
-fn escape_regex(regex: &str) -> String {
-    regex.replace('/', r#"\\/"#)
 }
 
 impl fmt::Display for RegexConstraint {

--- a/rust/pattern/constraint/type_constraint.rs
+++ b/rust/pattern/constraint/type_constraint.rs
@@ -21,6 +21,7 @@
  */
 
 use crate::{TypeVariable, TypeVariableBuilder, UnboundVariable};
+use crate::common::token::Constraint::*;
 use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -50,9 +51,7 @@ impl From<(String, String)> for Label {
 impl fmt::Display for Label {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(scope) = &self.scope {
-            if scope != "relation" {
-                write!(f, "{}:", scope)?;
-            }
+            write!(f, "{}:", scope)?;
         }
         write!(f, "{}", self.name)
     }
@@ -65,7 +64,7 @@ pub struct LabelConstraint {
 
 impl fmt::Display for LabelConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "type {}", self.label)
+        write!(f, "{} {}", Type, self.label)
     }
 }
 
@@ -95,7 +94,7 @@ impl From<TypeVariable> for SubConstraint {
 
 impl fmt::Display for SubConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "sub {}", self.type_)
+        write!(f, "{} {}", Sub, self.type_)
     }
 }
 
@@ -140,7 +139,7 @@ impl From<TypeVariable> for RelatesConstraint {
 
 impl fmt::Display for RelatesConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "relates {}", self.role_type)
+        write!(f, "{} {}", Relates, self.role_type)
     }
 }
 
@@ -201,7 +200,7 @@ impl From<TypeVariable> for PlaysConstraint {
 
 impl fmt::Display for PlaysConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "plays {}", self.role_type)
+        write!(f, "{} {}", Plays, self.role_type)
     }
 }
 
@@ -225,7 +224,7 @@ pub const KEY: IsKey = IsKey::Yes;
 impl fmt::Display for IsKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if *self == IsKey::Yes {
-            f.write_str(" @key")?;
+            write!(f, " {}", IsKey)?;
         }
         Ok(())
     }
@@ -289,7 +288,7 @@ impl From<(TypeVariable, IsKey)> for OwnsConstraint {
 
 impl fmt::Display for OwnsConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "owns {}{}", self.attribute_type, self.is_key)
+        write!(f, "{} {}{}", Owns, self.attribute_type, self.is_key)
     }
 }
 
@@ -316,6 +315,6 @@ fn escape_regex(regex: &str) -> String {
 
 impl fmt::Display for RegexConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, r#"regex "{}""#, escape_regex(&self.regex))
+        write!(f, r#"{} "{}""#, Regex, escape_regex(&self.regex))
     }
 }

--- a/rust/pattern/constraint/type_constraint.rs
+++ b/rust/pattern/constraint/type_constraint.rs
@@ -22,7 +22,6 @@
 
 use crate::{TypeVariable, TypeVariableBuilder, UnboundVariable};
 use std::fmt;
-use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Label {
@@ -48,7 +47,7 @@ impl From<(String, String)> for Label {
     }
 }
 
-impl Display for Label {
+impl fmt::Display for Label {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(scope) = &self.scope {
             if scope != "relation" {
@@ -64,7 +63,7 @@ pub struct LabelConstraint {
     pub label: Label,
 }
 
-impl Display for LabelConstraint {
+impl fmt::Display for LabelConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "type {}", self.label)
     }
@@ -94,7 +93,7 @@ impl From<TypeVariable> for SubConstraint {
     }
 }
 
-impl Display for SubConstraint {
+impl fmt::Display for SubConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "sub {}", self.type_)
     }
@@ -139,7 +138,7 @@ impl From<TypeVariable> for RelatesConstraint {
     }
 }
 
-impl Display for RelatesConstraint {
+impl fmt::Display for RelatesConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "relates {}", self.role_type)
     }
@@ -200,8 +199,8 @@ impl From<TypeVariable> for PlaysConstraint {
     }
 }
 
-impl Display for PlaysConstraint {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for PlaysConstraint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "plays {}", self.role_type)
     }
 }
@@ -223,8 +222,8 @@ impl From<bool> for IsKey {
 
 pub const KEY: IsKey = IsKey::Yes;
 
-impl Display for IsKey {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for IsKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if *self == IsKey::Yes {
             f.write_str(" @key")?;
         }
@@ -288,8 +287,8 @@ impl From<(TypeVariable, IsKey)> for OwnsConstraint {
     }
 }
 
-impl Display for OwnsConstraint {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for OwnsConstraint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "owns {}{}", self.attribute_type, self.is_key)
     }
 }
@@ -315,8 +314,8 @@ fn escape_regex(regex: &str) -> String {
     regex.replace('/', r#"\\/"#)
 }
 
-impl Display for RegexConstraint {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for RegexConstraint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, r#"regex "{}""#, escape_regex(&self.regex))
     }
 }

--- a/rust/pattern/constraint/type_constraint.rs
+++ b/rust/pattern/constraint/type_constraint.rs
@@ -200,25 +200,25 @@ impl fmt::Display for PlaysConstraint {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum IsKey {
+pub enum IsKeyAttribute {
     Yes,
     No,
 }
 
-impl From<bool> for IsKey {
+impl From<bool> for IsKeyAttribute {
     fn from(is_key: bool) -> Self {
         match is_key {
-            true => IsKey::Yes,
-            false => IsKey::No,
+            true => IsKeyAttribute::Yes,
+            false => IsKeyAttribute::No,
         }
     }
 }
 
-pub const KEY: IsKey = IsKey::Yes;
+pub const KEY: IsKeyAttribute = IsKeyAttribute::Yes;
 
-impl fmt::Display for IsKey {
+impl fmt::Display for IsKeyAttribute {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if *self == IsKey::Yes {
+        if *self == IsKeyAttribute::Yes {
             write!(f, " {}", IsKey)?;
         }
         Ok(())
@@ -229,14 +229,14 @@ impl fmt::Display for IsKey {
 pub struct OwnsConstraint {
     pub attribute_type: TypeVariable,
     pub overridden_attribute_type: Option<TypeVariable>,
-    pub is_key: IsKey,
+    pub is_key: IsKeyAttribute,
 }
 
 impl OwnsConstraint {
     fn new(
         attribute_type: TypeVariable,
         overridden_attribute_type: Option<TypeVariable>,
-        is_key: IsKey,
+        is_key: IsKeyAttribute,
     ) -> Self {
         OwnsConstraint { attribute_type, overridden_attribute_type, is_key }
     }
@@ -244,36 +244,36 @@ impl OwnsConstraint {
 
 impl From<&str> for OwnsConstraint {
     fn from(attribute_type: &str) -> Self {
-        OwnsConstraint::from((attribute_type, IsKey::No))
+        OwnsConstraint::from((attribute_type, IsKeyAttribute::No))
     }
 }
 
-impl From<(&str, IsKey)> for OwnsConstraint {
-    fn from((attribute_type, is_key): (&str, IsKey)) -> Self {
+impl From<(&str, IsKeyAttribute)> for OwnsConstraint {
+    fn from((attribute_type, is_key): (&str, IsKeyAttribute)) -> Self {
         OwnsConstraint::from((Label::from(attribute_type), is_key))
     }
 }
 
-impl From<(String, IsKey)> for OwnsConstraint {
-    fn from((attribute_type, is_key): (String, IsKey)) -> Self {
+impl From<(String, IsKeyAttribute)> for OwnsConstraint {
+    fn from((attribute_type, is_key): (String, IsKeyAttribute)) -> Self {
         OwnsConstraint::from((Label::from(attribute_type), is_key))
     }
 }
 
-impl From<(Label, IsKey)> for OwnsConstraint {
-    fn from((attribute_type, is_key): (Label, IsKey)) -> Self {
+impl From<(Label, IsKeyAttribute)> for OwnsConstraint {
+    fn from((attribute_type, is_key): (Label, IsKeyAttribute)) -> Self {
         OwnsConstraint::from((UnboundVariable::hidden().type_(attribute_type).unwrap(), is_key))
     }
 }
 
-impl From<(UnboundVariable, IsKey)> for OwnsConstraint {
-    fn from((attribute_type, is_key): (UnboundVariable, IsKey)) -> Self {
+impl From<(UnboundVariable, IsKeyAttribute)> for OwnsConstraint {
+    fn from((attribute_type, is_key): (UnboundVariable, IsKeyAttribute)) -> Self {
         OwnsConstraint::from((attribute_type.into_type(), is_key))
     }
 }
 
-impl From<(TypeVariable, IsKey)> for OwnsConstraint {
-    fn from((attribute_type, is_key): (TypeVariable, IsKey)) -> Self {
+impl From<(TypeVariable, IsKeyAttribute)> for OwnsConstraint {
+    fn from((attribute_type, is_key): (TypeVariable, IsKeyAttribute)) -> Self {
         OwnsConstraint::new(attribute_type, None, is_key)
     }
 }

--- a/rust/pattern/constraint/type_constraint.rs
+++ b/rust/pattern/constraint/type_constraint.rs
@@ -76,7 +76,7 @@ pub struct SubConstraint {
 impl<T: Into<Label>> From<T> for SubConstraint {
     fn from(scoped_type: T) -> Self {
         SubConstraint {
-            type_: Box::new(UnboundVariable::hidden().type_(scoped_type).unwrap().into_type()),
+            type_: Box::new(UnboundVariable::hidden().type_(scoped_type).unwrap()),
         }
     }
 }
@@ -119,7 +119,7 @@ impl From<String> for RelatesConstraint {
 impl From<Label> for RelatesConstraint {
     fn from(type_: Label) -> Self {
         RelatesConstraint {
-            role_type: UnboundVariable::hidden().type_(type_).unwrap().into_type(),
+            role_type: UnboundVariable::hidden().type_(type_).unwrap(),
             overridden_role_type: None,
         }
     }
@@ -157,7 +157,6 @@ impl PlaysConstraint {
                 UnboundVariable::hidden()
                     .type_(label.label.scope.as_ref().cloned().unwrap())
                     .unwrap()
-                    .into_type()
             }),
             role_type,
             overridden_role_type,
@@ -180,7 +179,7 @@ impl From<(String, String)> for PlaysConstraint {
 impl From<Label> for PlaysConstraint {
     fn from(scoped_type: Label) -> Self {
         PlaysConstraint::new(
-            UnboundVariable::hidden().type_(scoped_type).unwrap().into_type(),
+            UnboundVariable::hidden().type_(scoped_type).unwrap(),
             None,
         )
     }
@@ -268,7 +267,7 @@ impl From<(String, IsKey)> for OwnsConstraint {
 impl From<(Label, IsKey)> for OwnsConstraint {
     fn from((attribute_type, is_key): (Label, IsKey)) -> Self {
         OwnsConstraint::from((
-            UnboundVariable::hidden().type_(attribute_type).unwrap().into_type(),
+            UnboundVariable::hidden().type_(attribute_type).unwrap(),
             is_key,
         ))
     }

--- a/rust/pattern/constraint/type_constraint.rs
+++ b/rust/pattern/constraint/type_constraint.rs
@@ -20,8 +20,8 @@
  *
  */
 
-use crate::{TypeVariable, TypeVariableBuilder, UnboundVariable};
 use crate::common::token::Constraint::*;
+use crate::{TypeVariable, TypeVariableBuilder, UnboundVariable};
 use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/rust/pattern/disjunction.rs
+++ b/rust/pattern/disjunction.rs
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+use crate::common::string::indent;
+use crate::common::token::Operator::Or;
+use crate::Pattern;
+use std::fmt;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Disjunction {
+    pub patterns: Vec<Pattern>,
+}
+
+impl Disjunction {
+    pub fn into_pattern(self) -> Pattern {
+        Pattern::Disjunction(self)
+    }
+}
+
+impl From<Vec<Pattern>> for Disjunction {
+    fn from(patterns: Vec<Pattern>) -> Self {
+        Disjunction { patterns }
+    }
+}
+
+impl fmt::Display for Disjunction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut iter = self.patterns.iter();
+        let mut next = iter.next();
+        while next.is_some() {
+            match next.unwrap() {
+                Pattern::Conjunction(conjunction) => write!(f, "{}", conjunction)?,
+                other => write!(f, "{{\n{};\n}}", indent(other.to_string()))?,
+            }
+            next = iter.next();
+            if next.is_some() {
+                write!(f, " {} ", Or)?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/rust/pattern/disjunction.rs
+++ b/rust/pattern/disjunction.rs
@@ -49,7 +49,7 @@ impl fmt::Display for Disjunction {
         while next.is_some() {
             match next.unwrap() {
                 Pattern::Conjunction(conjunction) => write!(f, "{}", conjunction)?,
-                other => write!(f, "{{\n{};\n}}", indent(other.to_string()))?,
+                other => write!(f, "{{\n{};\n}}", indent(&other.to_string()))?,
             }
             next = iter.next();
             if next.is_some() {

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -34,7 +34,6 @@ mod test;
 
 use crate::enum_getter;
 use std::fmt;
-use std::fmt::Display;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Pattern {
@@ -61,7 +60,7 @@ where
     }
 }
 
-impl Display for Pattern {
+impl fmt::Display for Pattern {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Pattern::*;
         match self {

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -38,7 +38,6 @@ pub use constraint::*;
 #[cfg(test)]
 mod test;
 
-use crate::enum_getter;
 use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -47,14 +46,6 @@ pub enum Pattern {
     Disjunction(Disjunction),
     Negation(Negation),
     Variable(Variable),
-}
-
-impl Pattern {
-    enum_getter!(into_variable, Variable, Variable);
-
-    pub fn into_type_variable(self) -> TypeVariable {
-        self.into_variable().into_type()
-    }
 }
 
 impl<T> From<T> for Pattern

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -23,6 +23,9 @@
 mod conjunction;
 pub use conjunction::*;
 
+mod disjunction;
+pub use disjunction::*;
+
 mod negation;
 pub use negation::*;
 
@@ -41,7 +44,7 @@ use std::fmt;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Pattern {
     Conjunction(Conjunction),
-    Disjunction(()),
+    Disjunction(Disjunction),
     Negation(Negation),
     Variable(Variable),
 }
@@ -68,7 +71,7 @@ impl fmt::Display for Pattern {
         use Pattern::*;
         match self {
             Conjunction(conjunction) => write!(f, "{}", conjunction),
-            Disjunction(()) => todo!(),
+            Disjunction(disjunction) => write!(f, "{}", disjunction),
             Negation(negation) => write!(f, "{}", negation),
             Variable(variable) => write!(f, "{}", variable),
         }

--- a/rust/pattern/variable/builder/concept_variable_builder.rs
+++ b/rust/pattern/variable/builder/concept_variable_builder.rs
@@ -20,11 +20,25 @@
  *
  */
 
-mod concept_constraint;
-pub use concept_constraint::*;
+use crate::pattern::*;
+use crate::ErrorMessage;
 
-mod type_constraint;
-pub use type_constraint::*;
+pub trait ConceptConstrainable {
+    fn constrain_is(self, is: IsConstraint) -> ConceptVariable;
+}
 
-mod thing_constraint;
-pub use thing_constraint::*;
+pub trait ConceptVariableBuilder: Sized {
+    fn is(self, is: impl Into<IsConstraint>) -> Result<ConceptVariable, ErrorMessage>;
+}
+
+impl<U: ConceptConstrainable> ConceptVariableBuilder for U {
+    fn is(self, is: impl Into<IsConstraint>) -> Result<ConceptVariable, ErrorMessage> {
+        Ok(self.constrain_is(is.into()))
+    }
+}
+
+impl<U: ConceptVariableBuilder> ConceptVariableBuilder for Result<U, ErrorMessage> {
+    fn is(self, is: impl Into<IsConstraint>) -> Result<ConceptVariable, ErrorMessage> {
+        self?.is(is)
+    }
+}

--- a/rust/pattern/variable/builder/mod.rs
+++ b/rust/pattern/variable/builder/mod.rs
@@ -20,6 +20,9 @@
  *
  */
 
+mod concept_variable_builder;
+pub use concept_variable_builder::*;
+
 mod thing_variable_builder;
 pub use thing_variable_builder::*;
 

--- a/rust/pattern/variable/builder/thing_variable_builder.rs
+++ b/rust/pattern/variable/builder/thing_variable_builder.rs
@@ -37,17 +37,17 @@ pub trait ThingVariableBuilder {
         self,
         type_name: impl Into<String>,
         value: T,
-    ) -> Result<Variable, ErrorMessage>
+    ) -> Result<ThingVariable, ErrorMessage>
     where
         ErrorMessage: From<<T as TryInto<Value>>::Error>;
 
-    fn iid<T: TryInto<IIDConstraint>>(self, iid: T) -> Result<Variable, ErrorMessage>
+    fn iid<T: TryInto<IIDConstraint>>(self, iid: T) -> Result<ThingVariable, ErrorMessage>
     where
         ErrorMessage: From<<T as TryInto<IIDConstraint>>::Error>;
 
-    fn isa(self, isa: impl Into<IsaConstraint>) -> Result<Variable, ErrorMessage>;
+    fn isa(self, isa: impl Into<IsaConstraint>) -> Result<ThingVariable, ErrorMessage>;
 
-    fn eq(self, value: impl Into<Value>) -> Result<Variable, ErrorMessage>;
+    fn eq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
 }
 
 impl<U: ThingConstrainable> ThingVariableBuilder for U {
@@ -55,7 +55,7 @@ impl<U: ThingConstrainable> ThingVariableBuilder for U {
         self,
         type_name: impl Into<String>,
         value: T,
-    ) -> Result<Variable, ErrorMessage>
+    ) -> Result<ThingVariable, ErrorMessage>
     where
         ErrorMessage: From<<T as TryInto<Value>>::Error>,
     {
@@ -67,22 +67,22 @@ impl<U: ThingConstrainable> ThingVariableBuilder for U {
                     ValueConstraint::new(Predicate::Eq, value),
                 )),
             })
-            .into_variable())
+        )
     }
 
-    fn iid<T: TryInto<IIDConstraint>>(self, iid: T) -> Result<Variable, ErrorMessage>
+    fn iid<T: TryInto<IIDConstraint>>(self, iid: T) -> Result<ThingVariable, ErrorMessage>
     where
         ErrorMessage: From<<T as TryInto<IIDConstraint>>::Error>,
     {
-        Ok(self.constrain_iid(iid.try_into()?).into_variable())
+        Ok(self.constrain_iid(iid.try_into()?))
     }
 
-    fn isa(self, isa: impl Into<IsaConstraint>) -> Result<Variable, ErrorMessage> {
-        Ok(self.constrain_isa(isa.into()).into_variable())
+    fn isa(self, isa: impl Into<IsaConstraint>) -> Result<ThingVariable, ErrorMessage> {
+        Ok(self.constrain_isa(isa.into()))
     }
 
-    fn eq(self, value: impl Into<Value>) -> Result<Variable, ErrorMessage> {
-        Ok(self.constrain_value(ValueConstraint::new(Predicate::Eq, value.into())).into_variable())
+    fn eq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
+        Ok(self.constrain_value(ValueConstraint::new(Predicate::Eq, value.into())))
     }
 }
 
@@ -91,25 +91,25 @@ impl<U: ThingVariableBuilder> ThingVariableBuilder for Result<U, ErrorMessage> {
         self,
         type_name: impl Into<String>,
         value: T,
-    ) -> Result<Variable, ErrorMessage>
+    ) -> Result<ThingVariable, ErrorMessage>
     where
         ErrorMessage: From<<T as TryInto<Value>>::Error>,
     {
         self?.has(type_name, value)
     }
 
-    fn iid<T: TryInto<IIDConstraint>>(self, iid: T) -> Result<Variable, ErrorMessage>
+    fn iid<T: TryInto<IIDConstraint>>(self, iid: T) -> Result<ThingVariable, ErrorMessage>
     where
         ErrorMessage: From<<T as TryInto<IIDConstraint>>::Error>,
     {
         self?.iid(iid)
     }
 
-    fn isa(self, isa: impl Into<IsaConstraint>) -> Result<Variable, ErrorMessage> {
+    fn isa(self, isa: impl Into<IsaConstraint>) -> Result<ThingVariable, ErrorMessage> {
         self?.isa(isa)
     }
 
-    fn eq(self, value: impl Into<Value>) -> Result<Variable, ErrorMessage> {
+    fn eq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
         self?.eq(value)
     }
 }
@@ -119,17 +119,17 @@ pub trait RelationConstrainable {
 }
 
 pub trait RelationVariableBuilder {
-    fn rel(self, value: impl Into<RolePlayerConstraint>) -> Result<Variable, ErrorMessage>;
+    fn rel(self, value: impl Into<RolePlayerConstraint>) -> Result<ThingVariable, ErrorMessage>;
 }
 
 impl<U: RelationConstrainable> RelationVariableBuilder for U {
-    fn rel(self, value: impl Into<RolePlayerConstraint>) -> Result<Variable, ErrorMessage> {
-        Ok(self.constrain_role_player(value.into()).into_variable())
+    fn rel(self, value: impl Into<RolePlayerConstraint>) -> Result<ThingVariable, ErrorMessage> {
+        Ok(self.constrain_role_player(value.into()))
     }
 }
 
 impl<U: RelationVariableBuilder> RelationVariableBuilder for Result<U, ErrorMessage> {
-    fn rel(self, value: impl Into<RolePlayerConstraint>) -> Result<Variable, ErrorMessage> {
+    fn rel(self, value: impl Into<RolePlayerConstraint>) -> Result<ThingVariable, ErrorMessage> {
         self?.rel(value)
     }
 }

--- a/rust/pattern/variable/builder/thing_variable_builder.rs
+++ b/rust/pattern/variable/builder/thing_variable_builder.rs
@@ -48,6 +48,7 @@ pub trait ThingVariableBuilder {
     fn isa(self, isa: impl Into<IsaConstraint>) -> Result<ThingVariable, ErrorMessage>;
 
     fn eq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
+    fn like(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage>;
 }
 
 impl<U: ThingConstrainable> ThingVariableBuilder for U {
@@ -84,6 +85,10 @@ impl<U: ThingConstrainable> ThingVariableBuilder for U {
     fn eq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
         Ok(self.constrain_value(ValueConstraint::new(Predicate::Eq, value.into())))
     }
+
+    fn like(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
+        Ok(self.constrain_value(ValueConstraint::new(Predicate::Like, value.into().into())))
+    }
 }
 
 impl<U: ThingVariableBuilder> ThingVariableBuilder for Result<U, ErrorMessage> {
@@ -111,6 +116,10 @@ impl<U: ThingVariableBuilder> ThingVariableBuilder for Result<U, ErrorMessage> {
 
     fn eq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
         self?.eq(value)
+    }
+
+    fn like(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
+        self?.like(value)
     }
 }
 

--- a/rust/pattern/variable/builder/thing_variable_builder.rs
+++ b/rust/pattern/variable/builder/thing_variable_builder.rs
@@ -21,6 +21,7 @@
  */
 
 use crate::common::error::ErrorMessage;
+use crate::common::token::Predicate;
 use crate::pattern::*;
 
 pub trait ThingConstrainable {

--- a/rust/pattern/variable/builder/thing_variable_builder.rs
+++ b/rust/pattern/variable/builder/thing_variable_builder.rs
@@ -53,8 +53,8 @@ pub trait ThingVariableBuilder {
     fn gte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
     fn lt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
     fn lte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
-    fn contains(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage>;
-    fn like(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage>;
+    fn contains(self, string: impl Into<String>) -> Result<ThingVariable, ErrorMessage>;
+    fn like(self, string: impl Into<String>) -> Result<ThingVariable, ErrorMessage>;
 }
 
 impl<U: ThingConstrainable> ThingVariableBuilder for U {
@@ -109,12 +109,13 @@ impl<U: ThingConstrainable> ThingVariableBuilder for U {
         Ok(self.constrain_value(ValueConstraint::new(Predicate::Lte, value.into())))
     }
 
-    fn contains(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
-        Ok(self.constrain_value(ValueConstraint::new(Predicate::Contains, value.into().into())))
+    fn contains(self, string: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
+        Ok(self
+            .constrain_value(ValueConstraint::new(Predicate::Contains, Value::from(string.into()))))
     }
 
-    fn like(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
-        Ok(self.constrain_value(ValueConstraint::new(Predicate::Like, value.into().into())))
+    fn like(self, string: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
+        Ok(self.constrain_value(ValueConstraint::new(Predicate::Like, Value::from(string.into()))))
     }
 }
 
@@ -165,12 +166,12 @@ impl<U: ThingVariableBuilder> ThingVariableBuilder for Result<U, ErrorMessage> {
         self?.lte(value)
     }
 
-    fn contains(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
-        self?.contains(value)
+    fn contains(self, string: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
+        self?.contains(string)
     }
 
-    fn like(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
-        self?.like(value)
+    fn like(self, string: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
+        self?.like(string)
     }
 }
 

--- a/rust/pattern/variable/builder/thing_variable_builder.rs
+++ b/rust/pattern/variable/builder/thing_variable_builder.rs
@@ -48,6 +48,12 @@ pub trait ThingVariableBuilder {
     fn isa(self, isa: impl Into<IsaConstraint>) -> Result<ThingVariable, ErrorMessage>;
 
     fn eq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
+    fn neq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
+    fn gt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
+    fn gte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
+    fn lt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
+    fn lte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
+    fn contains(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage>;
     fn like(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage>;
 }
 
@@ -60,15 +66,12 @@ impl<U: ThingConstrainable> ThingVariableBuilder for U {
     where
         ErrorMessage: From<<T as TryInto<Value>>::Error>,
     {
-        Ok(self
-            .constrain_has(match value.try_into()? {
-                Value::Variable(variable) => HasConstraint::from((type_name.into(), *variable)),
-                value => HasConstraint::from((
-                    type_name.into(),
-                    ValueConstraint::new(Predicate::Eq, value),
-                )),
-            })
-        )
+        Ok(self.constrain_has(match value.try_into()? {
+            Value::Variable(variable) => HasConstraint::from((type_name.into(), *variable)),
+            value => {
+                HasConstraint::from((type_name.into(), ValueConstraint::new(Predicate::Eq, value)))
+            }
+        }))
     }
 
     fn iid<T: TryInto<IIDConstraint>>(self, iid: T) -> Result<ThingVariable, ErrorMessage>
@@ -84,6 +87,30 @@ impl<U: ThingConstrainable> ThingVariableBuilder for U {
 
     fn eq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
         Ok(self.constrain_value(ValueConstraint::new(Predicate::Eq, value.into())))
+    }
+
+    fn neq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
+        Ok(self.constrain_value(ValueConstraint::new(Predicate::Neq, value.into())))
+    }
+
+    fn gt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
+        Ok(self.constrain_value(ValueConstraint::new(Predicate::Gt, value.into())))
+    }
+
+    fn gte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
+        Ok(self.constrain_value(ValueConstraint::new(Predicate::Gte, value.into())))
+    }
+
+    fn lt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
+        Ok(self.constrain_value(ValueConstraint::new(Predicate::Lt, value.into())))
+    }
+
+    fn lte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
+        Ok(self.constrain_value(ValueConstraint::new(Predicate::Lte, value.into())))
+    }
+
+    fn contains(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
+        Ok(self.constrain_value(ValueConstraint::new(Predicate::Contains, value.into().into())))
     }
 
     fn like(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
@@ -116,6 +143,30 @@ impl<U: ThingVariableBuilder> ThingVariableBuilder for Result<U, ErrorMessage> {
 
     fn eq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
         self?.eq(value)
+    }
+
+    fn neq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
+        self?.neq(value)
+    }
+
+    fn gt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
+        self?.gt(value)
+    }
+
+    fn gte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
+        self?.gte(value)
+    }
+
+    fn lt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
+        self?.lt(value)
+    }
+
+    fn lte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
+        self?.lte(value)
+    }
+
+    fn contains(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
+        self?.contains(value)
     }
 
     fn like(self, value: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {

--- a/rust/pattern/variable/builder/type_variable_builder.rs
+++ b/rust/pattern/variable/builder/type_variable_builder.rs
@@ -33,62 +33,62 @@ pub trait TypeConstrainable {
 }
 
 pub trait TypeVariableBuilder: Sized {
-    fn owns(self, owns: impl Into<OwnsConstraint>) -> Result<Variable, ErrorMessage>;
-    fn plays(self, plays: impl Into<PlaysConstraint>) -> Result<Variable, ErrorMessage>;
-    fn regex(self, regex: impl Into<RegexConstraint>) -> Result<Variable, ErrorMessage>;
-    fn relates(self, relates: impl Into<RelatesConstraint>) -> Result<Variable, ErrorMessage>;
-    fn sub(self, sub: impl Into<SubConstraint>) -> Result<Variable, ErrorMessage>;
-    fn type_(self, type_name: impl Into<Label>) -> Result<Variable, ErrorMessage>;
+    fn owns(self, owns: impl Into<OwnsConstraint>) -> Result<TypeVariable, ErrorMessage>;
+    fn plays(self, plays: impl Into<PlaysConstraint>) -> Result<TypeVariable, ErrorMessage>;
+    fn regex(self, regex: impl Into<RegexConstraint>) -> Result<TypeVariable, ErrorMessage>;
+    fn relates(self, relates: impl Into<RelatesConstraint>) -> Result<TypeVariable, ErrorMessage>;
+    fn sub(self, sub: impl Into<SubConstraint>) -> Result<TypeVariable, ErrorMessage>;
+    fn type_(self, type_name: impl Into<Label>) -> Result<TypeVariable, ErrorMessage>;
 }
 
 impl<U: TypeConstrainable> TypeVariableBuilder for U {
-    fn owns(self, owns: impl Into<OwnsConstraint>) -> Result<Variable, ErrorMessage> {
-        Ok(self.constrain_owns(owns.into()).into_variable())
+    fn owns(self, owns: impl Into<OwnsConstraint>) -> Result<TypeVariable, ErrorMessage> {
+        Ok(self.constrain_owns(owns.into()))
     }
 
-    fn plays(self, plays: impl Into<PlaysConstraint>) -> Result<Variable, ErrorMessage> {
-        Ok(self.constrain_plays(plays.into()).into_variable())
+    fn plays(self, plays: impl Into<PlaysConstraint>) -> Result<TypeVariable, ErrorMessage> {
+        Ok(self.constrain_plays(plays.into()))
     }
 
-    fn regex(self, regex: impl Into<RegexConstraint>) -> Result<Variable, ErrorMessage> {
-        Ok(self.constrain_regex(regex.into()).into_variable())
+    fn regex(self, regex: impl Into<RegexConstraint>) -> Result<TypeVariable, ErrorMessage> {
+        Ok(self.constrain_regex(regex.into()))
     }
 
-    fn relates(self, relates: impl Into<RelatesConstraint>) -> Result<Variable, ErrorMessage> {
-        Ok(self.constrain_relates(relates.into()).into_variable())
+    fn relates(self, relates: impl Into<RelatesConstraint>) -> Result<TypeVariable, ErrorMessage> {
+        Ok(self.constrain_relates(relates.into()))
     }
 
-    fn sub(self, sub: impl Into<SubConstraint>) -> Result<Variable, ErrorMessage> {
-        Ok(self.constrain_sub(sub.into()).into_variable())
+    fn sub(self, sub: impl Into<SubConstraint>) -> Result<TypeVariable, ErrorMessage> {
+        Ok(self.constrain_sub(sub.into()))
     }
 
-    fn type_(self, type_name: impl Into<Label>) -> Result<Variable, ErrorMessage> {
-        Ok(self.constrain_label(LabelConstraint { label: type_name.into() }).into_variable())
+    fn type_(self, type_name: impl Into<Label>) -> Result<TypeVariable, ErrorMessage> {
+        Ok(self.constrain_label(LabelConstraint { label: type_name.into() }))
     }
 }
 
 impl<U: TypeVariableBuilder> TypeVariableBuilder for Result<U, ErrorMessage> {
-    fn owns(self, owns: impl Into<OwnsConstraint>) -> Result<Variable, ErrorMessage> {
+    fn owns(self, owns: impl Into<OwnsConstraint>) -> Result<TypeVariable, ErrorMessage> {
         self?.owns(owns)
     }
 
-    fn plays(self, plays: impl Into<PlaysConstraint>) -> Result<Variable, ErrorMessage> {
+    fn plays(self, plays: impl Into<PlaysConstraint>) -> Result<TypeVariable, ErrorMessage> {
         self?.plays(plays)
     }
 
-    fn regex(self, regex: impl Into<RegexConstraint>) -> Result<Variable, ErrorMessage> {
+    fn regex(self, regex: impl Into<RegexConstraint>) -> Result<TypeVariable, ErrorMessage> {
         self?.regex(regex)
     }
 
-    fn relates(self, relates: impl Into<RelatesConstraint>) -> Result<Variable, ErrorMessage> {
+    fn relates(self, relates: impl Into<RelatesConstraint>) -> Result<TypeVariable, ErrorMessage> {
         self?.relates(relates)
     }
 
-    fn sub(self, sub: impl Into<SubConstraint>) -> Result<Variable, ErrorMessage> {
+    fn sub(self, sub: impl Into<SubConstraint>) -> Result<TypeVariable, ErrorMessage> {
         self?.sub(sub)
     }
 
-    fn type_(self, type_name: impl Into<Label>) -> Result<Variable, ErrorMessage> {
+    fn type_(self, type_name: impl Into<Label>) -> Result<TypeVariable, ErrorMessage> {
         self?.type_(type_name)
     }
 }

--- a/rust/pattern/variable/concept_variable.rs
+++ b/rust/pattern/variable/concept_variable.rs
@@ -20,57 +20,41 @@
  *
  */
 
-mod conjunction;
-pub use conjunction::*;
-
-mod negation;
-pub use negation::*;
-
-mod variable;
-pub use variable::*;
-
-mod constraint;
-pub use constraint::*;
-
-#[cfg(test)]
-mod test;
-
-use crate::enum_getter;
+use crate::pattern::*;
 use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Pattern {
-    Conjunction(Conjunction),
-    Disjunction(()),
-    Negation(Negation),
-    Variable(Variable),
+pub struct ConceptVariable {
+    pub reference: Reference,
+    pub is_constraint: Option<IsConstraint>,
 }
 
-impl Pattern {
-    enum_getter!(into_variable, Variable, Variable);
+impl ConceptVariable {
+    pub fn into_pattern(self) -> Pattern {
+        self.into_variable().into_pattern()
+    }
 
-    pub fn into_type_variable(self) -> TypeVariable {
-        self.into_variable().into_type()
+    pub fn into_variable(self) -> Variable {
+        Variable::Concept(self)
+    }
+
+    pub fn new(reference: Reference) -> ConceptVariable {
+        ConceptVariable { reference, is_constraint: None }
     }
 }
 
-impl<T> From<T> for Pattern
-where
-    Variable: From<T>,
-{
-    fn from(variable: T) -> Self {
-        Pattern::Variable(Variable::from(variable))
+impl ConceptConstrainable for ConceptVariable {
+    fn constrain_is(self, is: IsConstraint) -> ConceptVariable {
+        Self { is_constraint: Some(is), ..self }
     }
 }
 
-impl fmt::Display for Pattern {
+impl fmt::Display for ConceptVariable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Pattern::*;
-        match self {
-            Conjunction(conjunction) => write!(f, "{}", conjunction),
-            Disjunction(()) => todo!(),
-            Negation(negation) => write!(f, "{}", negation),
-            Variable(variable) => write!(f, "{}", variable),
+        write!(f, "{}", self.reference)?;
+        if let Some(is) = &self.is_constraint {
+            write!(f, " {}", is)?;
         }
+        Ok(())
     }
 }

--- a/rust/pattern/variable/mod.rs
+++ b/rust/pattern/variable/mod.rs
@@ -38,7 +38,6 @@ pub use builder::*;
 use crate::pattern::*;
 
 use std::fmt;
-use std::fmt::Display;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Variable {
@@ -143,7 +142,7 @@ impl TypeConstrainable for Variable {
     }
 }
 
-impl Display for Variable {
+impl fmt::Display for Variable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Variable::*;
         match self {

--- a/rust/pattern/variable/mod.rs
+++ b/rust/pattern/variable/mod.rs
@@ -54,33 +54,6 @@ impl Variable {
     pub fn into_pattern(self) -> Pattern {
         Pattern::Variable(self)
     }
-
-    pub fn into_concept(self) -> ConceptVariable {
-        use Variable::*;
-        match self {
-            Concept(var) => var,
-            Unbound(var) => var.into_concept(),
-            _ => panic!(""),
-        }
-    }
-
-    pub fn into_type(self) -> TypeVariable {
-        use Variable::*;
-        match self {
-            Type(var) => var,
-            Unbound(var) => var.into_type(),
-            _ => panic!(""),
-        }
-    }
-
-    pub fn into_thing(self) -> ThingVariable {
-        use Variable::*;
-        match self {
-            Thing(var) => var,
-            Unbound(var) => var.into_thing(),
-            _ => panic!(""),
-        }
-    }
 }
 
 impl From<UnboundVariable> for Variable {
@@ -104,66 +77,6 @@ impl From<ThingVariable> for Variable {
 impl From<TypeVariable> for Variable {
     fn from(var: TypeVariable) -> Self {
         Variable::Type(var)
-    }
-}
-
-impl ConceptConstrainable for Variable {
-    fn constrain_is(self, is: IsConstraint) -> ConceptVariable {
-        self.into_concept().constrain_is(is)
-    }
-}
-
-impl ThingConstrainable for Variable {
-    fn constrain_has(self, has: HasConstraint) -> ThingVariable {
-        self.into_thing().constrain_has(has)
-    }
-
-    fn constrain_iid(self, iid: IIDConstraint) -> ThingVariable {
-        self.into_thing().constrain_iid(iid)
-    }
-
-    fn constrain_isa(self, isa: IsaConstraint) -> ThingVariable {
-        self.into_thing().constrain_isa(isa)
-    }
-
-    fn constrain_value(self, value: ValueConstraint) -> ThingVariable {
-        self.into_thing().constrain_value(value)
-    }
-
-    fn constrain_relation(self, relation: RelationConstraint) -> ThingVariable {
-        self.into_thing().constrain_relation(relation)
-    }
-}
-
-impl RelationConstrainable for Variable {
-    fn constrain_role_player(self, constraint: RolePlayerConstraint) -> ThingVariable {
-        self.into_thing().constrain_role_player(constraint)
-    }
-}
-
-impl TypeConstrainable for Variable {
-    fn constrain_label(self, label: LabelConstraint) -> TypeVariable {
-        self.into_type().constrain_label(label)
-    }
-
-    fn constrain_owns(self, owns: OwnsConstraint) -> TypeVariable {
-        self.into_type().constrain_owns(owns)
-    }
-
-    fn constrain_plays(self, plays: PlaysConstraint) -> TypeVariable {
-        self.into_type().constrain_plays(plays)
-    }
-
-    fn constrain_regex(self, regex: RegexConstraint) -> TypeVariable {
-        self.into_type().constrain_regex(regex)
-    }
-
-    fn constrain_relates(self, relates: RelatesConstraint) -> TypeVariable {
-        self.into_type().constrain_relates(relates)
-    }
-
-    fn constrain_sub(self, sub: SubConstraint) -> TypeVariable {
-        self.into_type().constrain_sub(sub)
     }
 }
 

--- a/rust/pattern/variable/mod.rs
+++ b/rust/pattern/variable/mod.rs
@@ -23,6 +23,9 @@
 mod reference;
 pub use reference::*;
 
+mod concept_variable;
+pub use concept_variable::*;
+
 mod thing_variable;
 pub use thing_variable::*;
 
@@ -41,6 +44,7 @@ use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Variable {
+    Concept(ConceptVariable),
     Thing(ThingVariable),
     Type(TypeVariable),
     Unbound(UnboundVariable),
@@ -49,6 +53,15 @@ pub enum Variable {
 impl Variable {
     pub fn into_pattern(self) -> Pattern {
         Pattern::Variable(self)
+    }
+
+    pub fn into_concept(self) -> ConceptVariable {
+        use Variable::*;
+        match self {
+            Concept(var) => var,
+            Unbound(var) => var.into_concept(),
+            _ => panic!(""),
+        }
     }
 
     pub fn into_type(self) -> TypeVariable {
@@ -76,6 +89,12 @@ impl From<UnboundVariable> for Variable {
     }
 }
 
+impl From<ConceptVariable> for Variable {
+    fn from(var: ConceptVariable) -> Self {
+        Variable::Concept(var)
+    }
+}
+
 impl From<ThingVariable> for Variable {
     fn from(var: ThingVariable) -> Self {
         Variable::Thing(var)
@@ -85,6 +104,12 @@ impl From<ThingVariable> for Variable {
 impl From<TypeVariable> for Variable {
     fn from(var: TypeVariable) -> Self {
         Variable::Type(var)
+    }
+}
+
+impl ConceptConstrainable for Variable {
+    fn constrain_is(self, is: IsConstraint) -> ConceptVariable {
+        self.into_concept().constrain_is(is)
     }
 }
 
@@ -147,6 +172,7 @@ impl fmt::Display for Variable {
         use Variable::*;
         match self {
             Unbound(unbound) => write!(f, "{}", unbound),
+            Concept(concept) => write!(f, "{}", concept),
             Thing(thing) => write!(f, "{}", thing),
             Type(type_) => write!(f, "{}", type_),
         }

--- a/rust/pattern/variable/reference.rs
+++ b/rust/pattern/variable/reference.rs
@@ -21,7 +21,6 @@
  */
 
 use std::fmt;
-use std::fmt::Display;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Visibility {
@@ -45,7 +44,7 @@ impl Reference {
     }
 }
 
-impl Display for Reference {
+impl fmt::Display for Reference {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Reference::*;
         write!(

--- a/rust/pattern/variable/thing_variable.rs
+++ b/rust/pattern/variable/thing_variable.rs
@@ -53,6 +53,27 @@ impl ThingVariable {
             relation: None,
         }
     }
+
+    fn fmt_thing_syntax(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.reference.is_visible() {
+            write!(f, "{}", self.reference)?;
+            if self.value.is_some() || self.relation.is_some() {
+                f.write_str(" ")?;
+            }
+        }
+
+        if let Some(value) = &self.value {
+            write!(f, "{}", value)?;
+        } else if let Some(relation) = &self.relation {
+            write!(f, "{}", relation)?;
+        }
+
+        Ok(())
+    }
+
+    fn is_thing_constrained(&self) -> bool {
+        self.isa.is_some() || self.iid.is_some() || !self.has.is_empty()
+    }
 }
 
 impl ThingConstrainable for ThingVariable {
@@ -90,39 +111,13 @@ impl RelationConstrainable for ThingVariable {
 
 impl fmt::Display for ThingVariable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.reference.is_visible() {
-            write!(f, "{}", self.reference)?;
+        self.fmt_thing_syntax(f)?;
+
+        if self.is_thing_constrained() {
+            f.write_str(" ")?;
+            write_joined!(f, ",\n    ", self.isa, self.iid, self.has)?;
         }
 
-        if let Some(value) = &self.value {
-            if self.reference.is_visible() {
-                f.write_str(" ")?;
-            }
-            write!(f, "{}", value)?;
-        }
-        if let Some(relation) = &self.relation {
-            if self.reference.is_visible() {
-                f.write_str(" ")?;
-            }
-            write!(f, "{}", relation)?;
-        }
-
-        if let Some(iid) = &self.iid {
-            write!(f, " {}", iid)?;
-        }
-
-        if let Some(isa) = &self.isa {
-            write!(f, " {}", isa)?;
-        }
-
-        if !self.has.is_empty() {
-            if self.isa.is_some() {
-                f.write_str(",\n    ")?;
-            } else {
-                f.write_str(" ")?;
-            }
-            write_joined!(f, ",\n    ", self.has)?;
-        }
         Ok(())
     }
 }

--- a/rust/pattern/variable/thing_variable.rs
+++ b/rust/pattern/variable/thing_variable.rs
@@ -23,7 +23,6 @@
 use crate::pattern::*;
 use crate::write_joined;
 use std::fmt;
-use std::fmt::{Debug, Display, Write};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ThingVariable {
@@ -89,7 +88,7 @@ impl RelationConstrainable for ThingVariable {
     }
 }
 
-impl Display for ThingVariable {
+impl fmt::Display for ThingVariable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.reference.is_visible() {
             write!(f, "{}", self.reference)?;
@@ -97,13 +96,13 @@ impl Display for ThingVariable {
 
         if let Some(value) = &self.value {
             if self.reference.is_visible() {
-                f.write_char(' ')?;
+                f.write_str(" ")?;
             }
             write!(f, "{}", value)?;
         }
         if let Some(relation) = &self.relation {
             if self.reference.is_visible() {
-                f.write_char(' ')?;
+                f.write_str(" ")?;
             }
             write!(f, "{}", relation)?;
         }
@@ -120,7 +119,7 @@ impl Display for ThingVariable {
             if self.isa.is_some() {
                 f.write_str(",\n    ")?;
             } else {
-                f.write_char(' ')?;
+                f.write_str(" ")?;
             }
             write_joined!(f, self.has, ",\n    ")?;
         }

--- a/rust/pattern/variable/thing_variable.rs
+++ b/rust/pattern/variable/thing_variable.rs
@@ -121,7 +121,7 @@ impl fmt::Display for ThingVariable {
             } else {
                 f.write_str(" ")?;
             }
-            write_joined!(f, self.has, ",\n    ")?;
+            write_joined!(f, ",\n    ", self.has)?;
         }
         Ok(())
     }

--- a/rust/pattern/variable/type_variable.rs
+++ b/rust/pattern/variable/type_variable.rs
@@ -23,7 +23,6 @@
 use crate::pattern::*;
 use crate::write_joined;
 use std::fmt;
-use std::fmt::{Display, Write};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TypeVariable {
@@ -87,7 +86,7 @@ impl TypeConstrainable for TypeVariable {
     }
 }
 
-impl Display for TypeVariable {
+impl fmt::Display for TypeVariable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.reference.is_visible() {
             write!(f, "{}", self.reference)?;
@@ -104,15 +103,15 @@ impl Display for TypeVariable {
             write!(f, " {}", regex)?;
         }
         if !self.relates.is_empty() {
-            f.write_char(' ')?;
+            f.write_str(" ")?;
             write_joined!(f, self.relates, ",\n    ")?;
         }
         if !self.plays.is_empty() {
-            f.write_char(' ')?;
+            f.write_str(" ")?;
             write_joined!(f, self.plays, ",\n    ")?;
         }
         if !self.owns.is_empty() {
-            f.write_char(' ')?;
+            f.write_str(" ")?;
             write_joined!(f, self.owns, ",\n    ")?;
         }
         Ok(())

--- a/rust/pattern/variable/type_variable.rs
+++ b/rust/pattern/variable/type_variable.rs
@@ -104,15 +104,15 @@ impl fmt::Display for TypeVariable {
         }
         if !self.relates.is_empty() {
             f.write_str(" ")?;
-            write_joined!(f, self.relates, ",\n    ")?;
+            write_joined!(f, ",\n    ", self.relates)?;
         }
         if !self.plays.is_empty() {
             f.write_str(" ")?;
-            write_joined!(f, self.plays, ",\n    ")?;
+            write_joined!(f, ",\n    ", self.plays)?;
         }
         if !self.owns.is_empty() {
             f.write_str(" ")?;
-            write_joined!(f, self.owns, ",\n    ")?;
+            write_joined!(f, ",\n    ", self.owns)?;
         }
         Ok(())
     }

--- a/rust/pattern/variable/unbound_variable.rs
+++ b/rust/pattern/variable/unbound_variable.rs
@@ -38,6 +38,10 @@ impl UnboundVariable {
         Variable::Unbound(self)
     }
 
+    pub fn into_concept(self) -> ConceptVariable {
+        ConceptVariable::new(self.reference)
+    }
+
     pub fn into_thing(self) -> ThingVariable {
         ThingVariable::new(self.reference)
     }
@@ -56,6 +60,12 @@ impl UnboundVariable {
 
     pub fn hidden() -> UnboundVariable {
         UnboundVariable { reference: Reference::Anonymous(Visibility::Invisible) }
+    }
+}
+
+impl ConceptConstrainable for UnboundVariable {
+    fn constrain_is(self, is: IsConstraint) -> ConceptVariable {
+        self.into_concept().constrain_is(is)
     }
 }
 

--- a/rust/pattern/variable/unbound_variable.rs
+++ b/rust/pattern/variable/unbound_variable.rs
@@ -23,7 +23,6 @@
 use crate::pattern::*;
 
 use std::fmt;
-use std::fmt::{Debug, Display};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct UnboundVariable {
@@ -132,7 +131,7 @@ impl From<String> for UnboundVariable {
     }
 }
 
-impl Display for UnboundVariable {
+impl fmt::Display for UnboundVariable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.reference)
     }

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -21,7 +21,6 @@
  */
 
 use std::fmt;
-use std::fmt::{Display, Formatter};
 
 use crate::pattern::*;
 use crate::{enum_getter, var, ErrorMessage};
@@ -73,7 +72,7 @@ impl MatchQueryBuilder for Query {
     }
 }
 
-impl Display for Query {
+impl fmt::Display for Query {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Query::*;
         match self {

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -21,6 +21,8 @@
  */
 
 use std::fmt;
+use crate::common::token::Command::Match;
+use crate::common::token::Filter::*;
 
 use crate::query::*;
 use crate::write_joined;
@@ -65,7 +67,7 @@ impl MatchQueryBuilder for TypeQLMatch {
 
 impl fmt::Display for TypeQLMatch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("match")?;
+        write!(f, "{}", Match)?;
 
         for pattern in &self.conjunction.patterns {
             write!(f, "\n{};", pattern)?;
@@ -126,7 +128,7 @@ pub struct Filter {
 
 impl fmt::Display for Filter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("get ")?;
+        write!(f, "{} ", Get)?;
         write_joined!(f, ", ", self.vars)
     }
 }
@@ -190,7 +192,7 @@ impl From<Vec<UnboundVariable>> for Sorting {
 
 impl fmt::Display for Sorting {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("sort ")?;
+        write!(f, "{} ", Sort)?;
         write_joined!(f, ", ", self.vars)
     }
 }
@@ -202,7 +204,7 @@ pub struct Limit {
 
 impl fmt::Display for Limit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "limit {}", self.limit)
+        write!(f, "{} {}", Limit, self.limit)
     }
 }
 
@@ -213,6 +215,6 @@ pub struct Offset {
 
 impl fmt::Display for Offset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "offset {}", self.offset)
+        write!(f, "{} {}", Offset, self.offset)
     }
 }

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -20,9 +20,9 @@
  *
  */
 
-use std::fmt;
 use crate::common::token::Command::Match;
 use crate::common::token::Filter::*;
+use std::fmt;
 
 use crate::query::*;
 use crate::write_joined;

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -21,7 +21,6 @@
  */
 
 use std::fmt;
-use std::fmt::Display;
 
 use crate::query::*;
 use crate::write_joined;
@@ -64,8 +63,8 @@ impl MatchQueryBuilder for TypeQLMatch {
     }
 }
 
-impl Display for TypeQLMatch {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for TypeQLMatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("match")?;
 
         for pattern in &self.conjunction.patterns {
@@ -113,8 +112,8 @@ impl Modifiers {
     }
 }
 
-impl Display for Modifiers {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for Modifiers {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut trail = "";
         if !self.filter.is_empty() {
             f.write_str("get ")?;
@@ -155,8 +154,8 @@ impl OrderedVariable {
     }
 }
 
-impl Display for OrderedVariable {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for OrderedVariable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.var)?;
         if let Some(order) = &self.order {
             write!(f, " {}", order)?;
@@ -194,8 +193,8 @@ impl From<Vec<UnboundVariable>> for Sorting {
     }
 }
 
-impl Display for Sorting {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for Sorting {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write_joined!(f, self.vars, ", ")
     }
 }

--- a/rust/typeql_lang.rs
+++ b/rust/typeql_lang.rs
@@ -60,6 +60,28 @@ macro_rules! typeql_match {
     }}
 }
 
+#[macro_export]
+macro_rules! and {
+    ($($pattern:expr),* $(,)?) => {{
+        let patterns = [$($pattern.map(|p| p.into_pattern())),*].into_iter().collect::<Result<Vec<_>, ErrorMessage>>();
+        match patterns {
+            Ok(patterns) => Ok(Conjunction::from(patterns)),
+            Err(err) => Err(err),
+        }
+    }}
+}
+
+#[macro_export]
+macro_rules! or {
+    ($($pattern:expr),* $(,)?) => {{
+        let patterns = [$($pattern.map(|p| p.into_pattern())),*].into_iter().collect::<Result<Vec<_>, ErrorMessage>>();
+        match patterns {
+            Ok(patterns) => Ok(Disjunction::from(patterns)),
+            Err(err) => Err(err),
+        }
+    }}
+}
+
 pub fn var(var: impl Into<UnboundVariable>) -> UnboundVariable {
     var.into()
 }

--- a/rust/typeql_lang.rs
+++ b/rust/typeql_lang.rs
@@ -64,11 +64,11 @@ pub fn var(var: impl Into<UnboundVariable>) -> UnboundVariable {
     var.into()
 }
 
-pub fn type_(name: impl Into<String>) -> Result<Variable, ErrorMessage> {
+pub fn type_(name: impl Into<String>) -> Result<TypeVariable, ErrorMessage> {
     UnboundVariable::hidden().type_(name.into())
 }
 
-pub fn rel<T: Into<RolePlayerConstraint>>(value: T) -> Result<Variable, ErrorMessage> {
+pub fn rel<T: Into<RolePlayerConstraint>>(value: T) -> Result<ThingVariable, ErrorMessage> {
     UnboundVariable::hidden().rel(value)
 }
 

--- a/rust/typeql_lang.rs
+++ b/rust/typeql_lang.rs
@@ -72,6 +72,13 @@ pub fn rel<T: Into<RolePlayerConstraint>>(value: T) -> Result<Variable, ErrorMes
     UnboundVariable::hidden().rel(value)
 }
 
+pub fn not<T: TryInto<Negation>>(pattern: T) -> Result<Negation, ErrorMessage>
+where
+    ErrorMessage: From<<T as TryInto<Negation>>::Error>,
+{
+    Ok(pattern.try_into()?)
+}
+
 pub fn parse_eof_query(query_string: &str) -> Result<Query, String> {
     let lexer = TypeQLRustLexer::new(InputStream::new(query_string));
     let mut parser = TypeQLRustParser::new(CommonTokenStream::new(lexer));

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -34,7 +34,7 @@ macro_rules! enum_getter {
 
 #[macro_export]
 macro_rules! write_joined {
-    ($f:ident, $joiner:tt, $($iterable:expr),* $(,)*) => {{
+    ($f:ident, $joiner:expr, $($iterable:expr),* $(,)*) => {{
         let mut result: std::fmt::Result = Ok(());
         let mut _is_first = true;
         $(

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -39,7 +39,7 @@ macro_rules! write_joined {
         let mut _is_first = true;
         $(
         let mut iter = $iterable.iter();
-        if _is_first {
+        if result.is_ok() && _is_first {
             if let Some(head) = iter.next() {
                 _is_first = false;
                 result = write!($f, "{}", head);

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -34,11 +34,21 @@ macro_rules! enum_getter {
 
 #[macro_export]
 macro_rules! write_joined {
-    ($f:ident, $iterable:expr, $joiner:tt) => {{
+    ($f:ident, $joiner:tt, $($iterable:expr),* $(,)*) => {{
+        let mut result: std::fmt::Result = Ok(());
+        let mut _is_first = true;
+        $(
         let mut iter = $iterable.iter();
-        iter.next().map_or(Ok(()), |head| {
-            write!($f, "{}", head)
-                .and_then(|()| iter.map(|x| write!($f, "{}{}", $joiner, x)).collect())
-        })
+        if _is_first {
+            if let Some(head) = iter.next() {
+                _is_first = false;
+                result = write!($f, "{}", head);
+            }
+        }
+        if result.is_ok() {
+            result = iter.map(|x| write!($f, "{}{}", $joiner, x)).collect();
+        }
+        )*
+        result
     }};
 }


### PR DESCRIPTION
## What is the goal of this PR?

We complete the implementation of the match query building and parsing by adding handlers for inequality and string predicates and logical operations (and, or, not).

## What are the changes implemented in this PR?

- Features:
  - implement Concept variables along with the `is` constraint;
  - implement Disjunction and Negation, finish Conjunction;
  - handle non-equality (non-`=`) predicates;
- Refactoring:
  - use concrete structs (not wrapped in enum) everywhere;
  - unify `Display` trait implementations;
  - clean up string formatting;
  - replace hardcoded strings with string enumerations for keywords and operators;
  - provide top-level builder macros that can handle arbitrary number of arguments that may be of different types.