### PR TITLE
Implement Insert and Delete queries in Rust

### DIFF
--- a/rust/common/date_time.rs
+++ b/rust/common/date_time.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+use chrono::{NaiveDateTime, Timelike};
+
+pub(crate) fn parse_date_time(date_time_text: &str) -> Option<NaiveDateTime> {
+    let has_seconds = date_time_text.matches(':').count() == 2;
+    if has_seconds {
+        let has_nanos = date_time_text.matches('.').count() == 1;
+        if has_nanos {
+            let parts: Vec<&str> = date_time_text.splitn(2, '.').collect();
+            let (date_time, nanos) = (parts[0], parts[1]);
+            NaiveDateTime::parse_from_str(date_time, "%Y-%m-%dT%H:%M:%S")
+                .ok()?
+                .with_nanosecond(format!("{}{}", nanos, "0".repeat(9 - nanos.len())).parse().ok()?)
+        } else {
+            NaiveDateTime::parse_from_str(date_time_text, "%Y-%m-%dT%H:%M:%S").ok()
+        }
+    } else {
+        NaiveDateTime::parse_from_str(date_time_text, "%Y-%m-%dT%H:%M").ok()
+    }
+}
+
+pub(crate) fn format_date_time(date_time: &NaiveDateTime) -> String {
+    if date_time.time().nanosecond() > 0 {
+        date_time.format("%Y-%m-%dT%H:%M:%S.%3f").to_string()
+    } else if date_time.time().second() > 0 {
+        date_time.format("%Y-%m-%dT%H:%M:%S").to_string()
+    } else {
+        date_time.format("%Y-%m-%dT%H:%M").to_string()
+    }
+}

--- a/rust/common/date_time.rs
+++ b/rust/common/date_time.rs
@@ -22,7 +22,7 @@
 
 use chrono::{NaiveDateTime, Timelike};
 
-pub(crate) fn parse_date_time(date_time_text: &str) -> Option<NaiveDateTime> {
+pub(crate) fn parse(date_time_text: &str) -> Option<NaiveDateTime> {
     let has_seconds = date_time_text.matches(':').count() == 2;
     if has_seconds {
         let has_nanos = date_time_text.matches('.').count() == 1;
@@ -40,7 +40,7 @@ pub(crate) fn parse_date_time(date_time_text: &str) -> Option<NaiveDateTime> {
     }
 }
 
-pub(crate) fn format_date_time(date_time: &NaiveDateTime) -> String {
+pub(crate) fn format(date_time: &NaiveDateTime) -> String {
     if date_time.time().nanosecond() > 0 {
         date_time.format("%Y-%m-%dT%H:%M:%S.%3f").to_string()
     } else if date_time.time().second() > 0 {

--- a/rust/common/mod.rs
+++ b/rust/common/mod.rs
@@ -20,6 +20,7 @@
  *
  */
 
+pub mod date_time;
 pub mod error;
 pub mod string;
 pub mod token;

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -32,11 +32,11 @@ use antlr_rust::tree::TerminalNode as ANTLRTerminalNode;
 use chrono::{NaiveDate, NaiveDateTime};
 use std::rc::Rc;
 
+use crate::common::date_time::parse_date_time;
 use crate::common::error::{ErrorMessage, ILLEGAL_GRAMMAR};
 use crate::common::string::*;
 use crate::common::token::Predicate;
 use typeql_grammar::typeqlrustparser::*;
-use crate::common::date_time::parse_date_time;
 
 use crate::pattern::*;
 use crate::query::*;
@@ -197,8 +197,8 @@ fn visit_query_delete(ctx: Rc<Query_deleteContext>) -> ParserResult<TypeQLDelete
 }
 
 fn visit_query_update(ctx: Rc<Query_updateContext>) -> ParserResult<TypeQLUpdate> {
-    Ok(visit_query_delete(ctx.query_delete().unwrap())?
-        .insert(visit_variable_things(ctx.variable_things().unwrap())?)?)
+    visit_query_delete(ctx.query_delete().unwrap())?
+        .insert(visit_variable_things(ctx.variable_things().unwrap())?)
 }
 
 fn visit_query_match(ctx: Rc<Query_matchContext>) -> ParserResult<TypeQLMatch> {
@@ -487,7 +487,7 @@ fn visit_attributes(ctx: Rc<AttributesContext>) -> ParserResult<Vec<HasConstrain
 fn visit_attribute(ctx: Rc<AttributeContext>) -> ParserResult<HasConstraint> {
     if let Some(label) = ctx.label() {
         if let Some(var) = ctx.VAR_() {
-            Ok(HasConstraint::try_from((label.get_text(), get_var(var)))?)
+            HasConstraint::try_from((label.get_text(), get_var(var)))
         } else if let Some(predicate) = ctx.predicate() {
             Ok(HasConstraint::new((label.get_text(), visit_predicate(predicate)?)))
         } else {

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -32,7 +32,7 @@ use antlr_rust::tree::TerminalNode as ANTLRTerminalNode;
 use chrono::{NaiveDate, NaiveDateTime};
 use std::rc::Rc;
 
-use crate::common::date_time::parse_date_time;
+use crate::common::date_time;
 use crate::common::error::{ErrorMessage, ILLEGAL_GRAMMAR};
 use crate::common::string::*;
 use crate::common::token::Predicate;
@@ -79,7 +79,7 @@ fn get_date(date: Rc<TerminalNode>) -> ParserResult<NaiveDate> {
 }
 
 fn get_date_time(date_time: Rc<TerminalNode>) -> ParserResult<NaiveDateTime> {
-    parse_date_time(&date_time.get_text())
+    date_time::parse(&date_time.get_text())
         .ok_or_else(|| ILLEGAL_GRAMMAR.format(&[date_time.get_text().as_str()]))
 }
 

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -189,11 +189,8 @@ fn visit_query_insert(ctx: Rc<Query_insertContext>) -> ParserResult<TypeQLInsert
 
 fn visit_query_delete(ctx: Rc<Query_deleteContext>) -> ParserResult<TypeQLDelete> {
     let variable_things = visit_variable_things(ctx.variable_things().unwrap())?;
-    if let Some(patterns) = ctx.patterns() {
-        TypeQLMatch::new(Conjunction::from(visit_patterns(patterns)?)).delete(variable_things)
-    } else {
-        Ok(TypeQLDelete::new(variable_things))
-    }
+    TypeQLMatch::new(Conjunction::from(visit_patterns(ctx.patterns().unwrap())?))
+        .delete(variable_things)
 }
 
 fn visit_query_update(ctx: Rc<Query_updateContext>) -> ParserResult<TypeQLUpdate> {

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -178,6 +178,8 @@ fn visit_query(ctx: Rc<QueryContext>) -> ParserResult<Query> {
         Ok(visit_query_match(query_match)?.into_query())
     } else if let Some(query_insert) = ctx.query_insert() {
         Ok(visit_query_insert(query_insert)?.into_query())
+    } else if let Some(query_delete) = ctx.query_delete() {
+        Ok(visit_query_delete(query_delete)?.into_query())
     } else {
         Err(ILLEGAL_GRAMMAR.format(&[&ctx.get_text()]))
     }
@@ -200,8 +202,13 @@ fn visit_query_insert(ctx: Rc<Query_insertContext>) -> ParserResult<TypeQLInsert
     }
 }
 
-fn visit_query_delete(_ctx: Rc<Query_deleteContext>) -> ParserResult<()> {
-    todo!()
+fn visit_query_delete(ctx: Rc<Query_deleteContext>) -> ParserResult<TypeQLDelete> {
+    let variable_things = visit_variable_things(ctx.variable_things().unwrap())?;
+    if let Some(patterns) = ctx.patterns() {
+        TypeQLMatch::new(Conjunction::from(visit_patterns(patterns)?)).delete(variable_things)
+    } else {
+        Ok(TypeQLDelete::new(variable_things))
+    }
 }
 
 fn visit_query_update(_ctx: Rc<Query_updateContext>) -> ParserResult<()> {

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -29,13 +29,14 @@ mod test;
 use antlr_rust::token::Token;
 use antlr_rust::tree::ParseTree;
 use antlr_rust::tree::TerminalNode as ANTLRTerminalNode;
-use chrono::{NaiveDate, NaiveDateTime, Timelike};
+use chrono::{NaiveDate, NaiveDateTime};
 use std::rc::Rc;
 
 use crate::common::error::{ErrorMessage, ILLEGAL_GRAMMAR};
 use crate::common::string::*;
 use crate::common::token::Predicate;
 use typeql_grammar::typeqlrustparser::*;
+use crate::common::date_time::parse_date_time;
 
 use crate::pattern::*;
 use crate::query::*;
@@ -75,24 +76,6 @@ fn get_boolean(boolean: Rc<TerminalNode>) -> ParserResult<bool> {
 fn get_date(date: Rc<TerminalNode>) -> ParserResult<NaiveDate> {
     NaiveDate::parse_from_str(&date.get_text(), "%Y-%m-%d")
         .map_err(|_| ILLEGAL_GRAMMAR.format(&[date.get_text().as_str()]))
-}
-
-fn parse_date_time(date_time_text: &str) -> Option<NaiveDateTime> {
-    let has_seconds = date_time_text.matches(':').count() == 2;
-    if has_seconds {
-        let has_nanos = date_time_text.matches('.').count() == 1;
-        if has_nanos {
-            let parts: Vec<&str> = date_time_text.splitn(2, '.').collect();
-            let (date_time, nanos) = (parts[0], parts[1]);
-            NaiveDateTime::parse_from_str(date_time, "%Y-%m-%dT%H:%M:%S")
-                .ok()?
-                .with_nanosecond(format!("{}{}", nanos, "0".repeat(9 - nanos.len())).parse().ok()?)
-        } else {
-            NaiveDateTime::parse_from_str(date_time_text, "%Y-%m-%dT%H:%M:%S").ok()
-        }
-    } else {
-        NaiveDateTime::parse_from_str(date_time_text, "%Y-%m-%dT%H:%M").ok()
-    }
 }
 
 fn get_date_time(date_time: Rc<TerminalNode>) -> ParserResult<NaiveDateTime> {

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -507,7 +507,7 @@ fn visit_attribute(ctx: Rc<AttributeContext>) -> ParserResult<HasConstraint> {
         } else {
             Err(ILLEGAL_GRAMMAR.format(&[&ctx.get_text()]))?
         }
-    } else if let Some(_) = ctx.VAR_() {
+    } else if let Some(_var) = ctx.VAR_() {
         todo!()
     } else {
         Err(ILLEGAL_GRAMMAR.format(&[&ctx.get_text()]))
@@ -530,7 +530,7 @@ fn visit_predicate(ctx: Rc<PredicateContext>) -> ParserResult<ValueConstraint> {
         }))
     } else if let Some(substring) = ctx.predicate_substring() {
         Ok(ValueConstraint::new(Predicate::from(substring.get_text()), {
-            if let Some(_) = substring.LIKE() {
+            if substring.LIKE().is_some() {
                 Value::from(get_regex(ctx.STRING_().unwrap()))
             } else {
                 Value::from(get_string(ctx.STRING_().unwrap()))

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     and, not, or, parse_query, rel, type_, typeql_insert, typeql_match, var,
     ConceptVariableBuilder, Conjunction, DeleteQueryBuilder, Disjunction, ErrorMessage,
     InsertQueryBuilder, MatchQueryBuilder, Query, RelationVariableBuilder, ThingVariableBuilder,
-    TypeQLInsert, TypeQLMatch, TypeVariableBuilder, KEY,
+    TypeQLInsert, TypeQLMatch, TypeVariableBuilder, UpdateQueryBuilder, KEY,
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
@@ -64,7 +64,7 @@ $x isa person,
     has name "alice/bob";"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").isa("person").has("name", "alice/bob"));
+    let expected = typeql_match!(var("x").isa("person").has(("name", "alice/bob")));
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -122,7 +122,7 @@ $t != "Apocalypse Now";"#;
 
     let parsed = parse_query(query).map(Query::into_match);
     let expected = typeql_match!(
-        var("x").isa("movie").has("title", var("t")),
+        var("x").isa("movie").has(("title", var("t"))),
         or!(
             var("t").eq("Apocalypse Now"),
             and!(var("t").lt("Juno"), var("t").gt("Godfather")),
@@ -148,7 +148,7 @@ $x isa movie,
 
     let parsed = parse_query(query).map(Query::into_match);
     let expected = typeql_match!(
-        var("x").isa("movie").has("title", var("t")),
+        var("x").isa("movie").has(("title", var("t"))),
         or!(
             and!(var("t").lte("Juno"), var("t").gte("Godfather"), var("t").neq("Heat"),),
             var("t").eq("The Muppets"),
@@ -172,7 +172,7 @@ $y isa person,
     let parsed = parse_query(query).map(Query::into_match);
     let expected = typeql_match!(
         rel("x").rel("y"),
-        var("y").isa("person").has("name", var("n")),
+        var("y").isa("person").has(("name", var("n"))),
         or!(var("n").contains("ar"), var("n").like("^M.*$")),
     );
     assert_query_eq!(expected, parsed, query);
@@ -187,7 +187,7 @@ $z 18 isa age;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
     let expected = typeql_match!(
-        var("x").has("age", var("y")),
+        var("x").has(("age", var("y"))),
         var("y").gte(var("z")),
         var("z").eq(18).isa("age"),
     );
@@ -236,8 +236,8 @@ $_ has title "Spy",
 
     let parsed = parse_query(query).map(Query::into_match);
     let expected = typeql_match!(
-        var("x").has("release-date", gte(var("r"))),
-        var(()).has("title", "Spy").has("release-date", var("r")),
+        var("x").has(("release-date", gte(var("r")))),
+        var(()).has(("title", "Spy")).has(("release-date", var("r"))),
     );
     assert_query_eq!(expected, parsed, query);
 }
@@ -251,9 +251,9 @@ $x has release-date < 1986-03-03T00:00,
 
     let parsed = parse_query(query).map(Query::into_match);
     let expected = typeql_match!([var("x")
-        .has("release-date", lt(LocalDate.of(1986, 3, 3).atStartOfDay()))
-        .has("tmdb-vote-count", 100)
-        .has("tmdb-vote-average", lte(9.0))]);
+        .has(("release-date", lt(LocalDate.of(1986, 3, 3).atStartOfDay())))
+        .has(("tmdb-vote-count", 100))
+        .has(("tmdb-vote-average", lte(9.0)))]);
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -265,10 +265,10 @@ fn when_parsing_date_handle_time() {
 $x has release-date 1000-11-12T13:14:15;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").has(
+    let expected = typeql_match!(var("x").has((
         "release-date",
         NaiveDateTime::new(NaiveDate::from_ymd(1000, 11, 12), NaiveTime::from_hms(13, 14, 15)),
-    ));
+    )));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -279,10 +279,10 @@ fn when_parsing_date_handle_big_years() {
 $x has release-date +12345-12-25T00:00;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").has(
+    let expected = typeql_match!(var("x").has((
         "release-date",
         NaiveDateTime::new(NaiveDate::from_ymd(12345, 12, 25), NaiveTime::from_hms(0, 0, 0)),
-    ));
+    )));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -293,10 +293,10 @@ fn when_parsing_date_handle_small_years() {
 $x has release-date 0867-01-01T00:00;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").has(
+    let expected = typeql_match!(var("x").has((
         "release-date",
         NaiveDateTime::new(NaiveDate::from_ymd(867, 1, 1), NaiveTime::from_hms(0, 0, 0)),
-    ));
+    )));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -307,10 +307,10 @@ fn when_parsing_date_handle_negative_years() {
 $x has release-date -3200-01-01T00:00;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").has(
+    let expected = typeql_match!(var("x").has((
         "release-date",
         NaiveDateTime::new(NaiveDate::from_ymd(-3200, 1, 1), NaiveTime::from_hms(0, 0, 0)),
-    ));
+    )));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -321,13 +321,13 @@ fn when_parsing_date_handle_millis() {
 $x has release-date 1000-11-12T13:14:15.123;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").has(
+    let expected = typeql_match!(var("x").has((
         "release-date",
         NaiveDateTime::new(
             NaiveDate::from_ymd(1000, 11, 12),
             NaiveTime::from_hms_milli(13, 14, 15, 123),
         ),
-    ));
+    )));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -338,13 +338,13 @@ fn when_parsing_date_handle_millis_shorthand() {
 $x has release-date 1000-11-12T13:14:15.1;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").has(
+    let expected = typeql_match!(var("x").has((
         "release-date",
         NaiveDateTime::new(
             NaiveDate::from_ymd(1000, 11, 12),
             NaiveTime::from_hms_milli(13, 14, 15, 100),
         ),
-    ));
+    )));
 
     let parsed_query = r#"match
 $x has release-date 1000-11-12T13:14:15.100;"#;
@@ -365,13 +365,13 @@ $x has release-date 1000-11-12T13:14:15.000123456;"#;
 
 #[test]
 fn when_parsing_date_error_when_handling_overly_precise_nanos() {
-    let expected = typeql_match!(var("x").has(
+    let expected = typeql_match!(var("x").has((
         "release-date",
         NaiveDateTime::new(
             NaiveDate::from_ymd(1000, 11, 12),
             NaiveTime::from_hms_nano(13, 14, 15, 123450000),
         ),
-    ));
+    )));
     match expected {
         Err(err) => assert!(err.message.contains("more precise than 1 millisecond")),
         Ok(_) => assert!(false),
@@ -386,7 +386,7 @@ $x isa movie,
     has tmdb-vote-count <= 400;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").isa("movie").has("tmdb-vote-count", lte(400)));
+    let expected = typeql_match!(var("x").isa("movie").has(("tmdb-vote-count", lte(400))));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -413,7 +413,7 @@ sort $r desc;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
     let expected =
-        typeql_match!(var("x").isa("movie").has("rating", var("r"))).sort([("r", "desc")]);
+        typeql_match!(var("x").isa("movie").has(("rating", var("r")))).sort([("r", "desc")]);
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -426,7 +426,8 @@ $x isa movie,
 sort $r; limit 10;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").isa("movie").has("rating", var("r"))).sort("r").limit(10);
+    let expected =
+        typeql_match!(var("x").isa("movie").has(("rating", var("r")))).sort("r").limit(10);
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -439,7 +440,7 @@ $x isa movie,
 sort $r desc; offset 10; limit 10;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").isa("movie").has("rating", var("r")))
+    let expected = typeql_match!(var("x").isa("movie").has(("rating", var("r"))))
         .sort([("r", "desc")])
         .offset(10)
         .limit(10);
@@ -455,7 +456,7 @@ $y isa movie,
 offset 2; limit 4;"#;
 
     let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("y").isa("movie").has("title", var("n"))).offset(2).limit(4);
+    let expected = typeql_match!(var("y").isa("movie").has(("title", var("n")))).offset(2).limit(4);
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -547,7 +548,7 @@ $y isa $p;
             rel("y").rel("q"),
             and!(
                 var("x").isa(var("p")),
-                or!(var("x").has("first-name", var("y")), var("x").has("last-name", var("z")))
+                or!(var("x").has(("first-name", var("y"))), var("x").has(("last-name", var("z"))))
             )
         )
     );
@@ -594,7 +595,7 @@ fn test_single_line_group_aggregate_max_query() {
             "$x has age $a;\n" +
             "group $x; max $a;";
     let parsed = parse_query(query).unwrapGroupAggregate();
-    let expected = typeql_match!(var("x").has("age", var("a"))).group("x").max("a");
+    let expected = typeql_match!(var("x").has(("age", var("a")))).group("x").max("a");
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -608,7 +609,7 @@ fn test_multi_line_group_aggregate_max_query() {
     let parsed = parse_query(query).unwrapGroupAggregate();
     let expected = typeql_match!(
             rel("x").rel("y").isa("friendship"),
-            var("y").has("age", var("z"))
+            var("y").has(("age", var("z")))
     ).group("x").max("z");
 
     assert_query_eq!(expected, parsed, query);
@@ -624,7 +625,7 @@ fn test_multi_line_filtered_group_aggregate_max_query() {
     let parsed = parse_query(query).unwrapGroupAggregate();
     let expected = typeql_match!(
             rel("x").rel("y").isa("friendship"),
-            var("y").has("age", var("z"))
+            var("y").has(("age", var("z")))
     ).get("x", "y", "z").group("x").max("z");
 
     assert_query_eq!(expected, parsed, query);
@@ -637,7 +638,7 @@ fn when_comparing_count_query_using_typeql_and_java_typeql_they_are_equivalent()
             "    has title \"Godfather\";\n" +
             "count;";
     let parsed = parse_query(query).unwrapAggregate();
-    let expected = typeql_match!(var("x").isa("movie").has("title", "Godfather")).count();
+    let expected = typeql_match!(var("x").isa("movie").has(("title", "Godfather"))).count();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -650,7 +651,7 @@ $_ isa movie,
     has title "The Title";"#;
 
     let parsed = parse_query(query).map(Query::into_insert);
-    let expected = typeql_insert!(var(()).isa("movie").has("title", "The Title"));
+    let expected = typeql_insert!(var(()).isa("movie").has(("title", "The Title")));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -667,7 +668,7 @@ $y isa movie;"#;
 
     let parsed = parse_query(query).map(Query::into_delete);
     let expected =
-        typeql_match!(var("x").isa("movie").has("title", "The Title"), var("y").isa("movie"))
+        typeql_match!(var("x").isa("movie").has(("title", "The Title")), var("y").isa("movie"))
             .delete([var("x").isa("movie"), var("y").isa("movie")]);
 
     assert_query_eq!(expected, parsed, query);
@@ -687,9 +688,9 @@ $z isa pokemon,
 
     let parsed = parse_query(query).map(Query::into_insert);
     let expected = typeql_insert!(
-        var("x").isa("pokemon").has("name", "Pichu"),
-        var("y").isa("pokemon").has("name", "Pikachu"),
-        var("z").isa("pokemon").has("name", "Raichu"),
+        var("x").isa("pokemon").has(("name", "Pichu")),
+        var("y").isa("pokemon").has(("name", "Pikachu")),
+        var("z").isa("pokemon").has(("name", "Raichu")),
         rel(("evolves-from", "x")).rel(("evolves-to", "y")).isa("evolution"),
         rel(("evolves-from", "y")).rel(("evolves-to", "z")).isa("evolution")
     );
@@ -697,24 +698,26 @@ $z isa pokemon,
     assert_query_eq!(expected, parsed, query);
 }
 
-/*
 #[test]
-fn when_parsing_update_query_result_issame_as_java_type_ql() {
-    String query = "match\n" +
-            "$x isa person,\n" +
-            "    has name 'alice',\n" +
-            "    has age $a;\n" +
-            "delete\n" +
-            "$x has $a;\n" +
-            "insert\n" +
-            "$x has age 25;";
-    let parsed = parse_query(query).asUpdate();
-    let expected = typeql_match!(var("x").isa("person").has("name", "alice").has("age", var("a")))
+fn when_parsing_update_query_result_is_same_as_java_typeql() {
+    let query = r#"match
+$x isa person,
+    has name "alice",
+    has age $a;
+delete
+$x has $a;
+insert
+$x has age 25;"#;
+
+    let parsed = parse_query(query).map(Query::into_update);
+    let expected =
+        typeql_match!(var("x").isa("person").has(("name", "alice")).has(("age", var("a"))))
             .delete(var("x").has(var("a")))
-            .insert(var("x").has("age", 25));
-    assert_query_eq!(expected, parsed, query.replace("'", "\""));
+            .insert(var("x").has(("age", 25)));
+    assert_query_eq!(expected, parsed, query);
 }
 
+/*
 #[test]
 fn when_parsing_as_in_define_result_is_same_as_sub() {
     let query = "define\n" +
@@ -881,7 +884,7 @@ insert
 $x has name "HELLO";"#;
 
     let parsed = parse_query(query).map(Query::into_insert);
-    let expected = typeql_match!(var("x").isa("language")).insert(var("x").has("name", "HELLO"));
+    let expected = typeql_match!(var("x").isa("language")).insert(var("x").has(("name", "HELLO")));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -959,7 +962,7 @@ $_ isa movie,
     );
 
     let parsed = parse_query(&query).map(Query::into_insert);
-    let expected = typeql_insert!(var(()).isa("movie").has("title", input));
+    let expected = typeql_insert!(var(()).isa("movie").has(("title", input)));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -987,8 +990,8 @@ fn test_parsing_pattern() {
     let parsed = parse_pattern(pattern);
     let expected = and(
             rel("wife", "a").rel("husband", "b").isa("marriage"),
-            var("a").has("gender", "male"),
-            var("b").has("gender", "female")
+            var("a").has(("gender", "male")),
+            var("b").has(("gender", "female"))
     );
 
     assert_query_eq!(expected, parsed, pattern.replace("'", "\""));
@@ -999,7 +1002,7 @@ fn test_define_rules() {
     let when = "$x isa movie;";
     let then = "$x has genre 'drama';";
     let when_pattern = and((var("x").isa("movie")));
-    let then_pattern = var("x").has("genre", "drama");
+    let then_pattern = var("x").has(("genre", "drama"));
 
     let expected = define(rule("all-movies-are-drama").when(when_pattern).then(then_pattern));
     let query = "define\n" +
@@ -1022,7 +1025,7 @@ fn test_parse_boolean() {
 $_ has flag true;"#;
 
     let parsed = parse_query(query).map(Query::into_insert);
-    let expected = typeql_insert!(var(()).has("flag", true));
+    let expected = typeql_insert!(var(()).has(("flag", true)));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -1118,7 +1121,7 @@ $_ has title "Godfather",
 
     let parsed = parse_query(query).map(Query::into_match);
     let expected =
-        typeql_match!(var(()).has("title", "Godfather").has("tmdb-vote-count", var("x")));
+        typeql_match!(var(()).has(("title", "Godfather")).has(("tmdb-vote-count", var("x"))));
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -1212,7 +1215,7 @@ fn test_parse_many_match_insert_without_stack_overflow() {
     }
 
     let parsed = parse_queries(long_query).collect();
-    let expected = typeql_match!(var("x").isa("person")).insert(var("x").has("name", "bob"));
+    let expected = typeql_match!(var("x").isa("person")).insert(var("x").has(("name", "bob")));
 
     assert_eq!(vec![expected; num_queries], parsed);
 }

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -22,9 +22,9 @@
 
 use crate::{
     and, not, or, parse_query, rel, type_, typeql_insert, typeql_match, var,
-    ConceptVariableBuilder, Conjunction, Disjunction, ErrorMessage, InsertQueryBuilder,
-    MatchQueryBuilder, Query, RelationVariableBuilder, ThingVariableBuilder, TypeQLInsert,
-    TypeQLMatch, TypeVariableBuilder, KEY,
+    ConceptVariableBuilder, Conjunction, DeleteQueryBuilder, Disjunction, ErrorMessage,
+    InsertQueryBuilder, MatchQueryBuilder, Query, RelationVariableBuilder, ThingVariableBuilder,
+    TypeQLInsert, TypeQLMatch, TypeVariableBuilder, KEY,
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
@@ -655,25 +655,23 @@ $_ isa movie,
     assert_query_eq!(expected, parsed, query);
 }
 
-/*
 #[test]
-fn when_parsing_delete_query_result_is_same_as_java_type_ql() {
-    let query = "match\n" +
-            "$x isa movie,\n" +
-            "    has title 'The Title';\n" +
-            "$y isa movie;\n" +
-            "delete\n" +
-            "$x isa movie;\n" +
-            "$y isa movie;";
-    let parsed = parse_query(query).asDelete();
-    let expected = typeql_match!(
-            var("x").isa("movie").has("title", "The Title"),
-            var("y").isa("movie")
-    ).delete(var("x").isa("movie"), var("y").isa("movie"));
+fn when_parsing_delete_query_result_is_same_as_java_typeql() {
+    let query = r#"match
+$x isa movie,
+    has title "The Title";
+$y isa movie;
+delete
+$x isa movie;
+$y isa movie;"#;
 
-    assert_query_eq!(expected, parsed, query.replace("'", "\""));
+    let parsed = parse_query(query).map(Query::into_delete);
+    let expected =
+        typeql_match!(var("x").isa("movie").has("title", "The Title"), var("y").isa("movie"))
+            .delete([var("x").isa("movie"), var("y").isa("movie")]);
+
+    assert_query_eq!(expected, parsed, query);
 }
-*/
 
 #[test]
 fn when_parsing_insert_query_result_is_same_as_java_typeql() {
@@ -953,9 +951,12 @@ fn test_escape_string() {
     // "This has \"double quotes\" and a single-quoted backslash: '\\'"
     let input = r#"This has \"double quotes\" and a single-quoted backslash: '\\'"#;
 
-    let query = format!(r#"insert
+    let query = format!(
+        r#"insert
 $_ isa movie,
-    has title "{}";"#, input);
+    has title "{}";"#,
+        input
+    );
 
     let parsed = parse_query(&query).map(Query::into_insert);
     let expected = typeql_insert!(var(()).isa("movie").has("title", input));

--- a/rust/pattern/constraint/thing_constraint.rs
+++ b/rust/pattern/constraint/thing_constraint.rs
@@ -20,7 +20,7 @@
  *
  */
 
-use crate::common::date_time::format_date_time;
+use crate::common::date_time;
 use crate::common::error::{
     ErrorMessage, INVALID_CONSTRAINT_DATETIME_PRECISION, INVALID_IID_STRING,
 };
@@ -265,7 +265,7 @@ impl fmt::Display for Value {
             Double(double) => write!(f, "{}", double),
             Boolean(boolean) => write!(f, "{}", boolean),
             String(string) => write!(f, "\"{}\"", string),
-            DateTime(date_time) => write!(f, "{}", format_date_time(date_time)),
+            DateTime(date_time) => write!(f, "{}", date_time::format(date_time)),
             Variable(var) => write!(f, "{}", var.reference),
         }
     }

--- a/rust/pattern/constraint/thing_constraint.rs
+++ b/rust/pattern/constraint/thing_constraint.rs
@@ -23,6 +23,7 @@
 use crate::common::error::{
     ErrorMessage, INVALID_CONSTRAINT_DATETIME_PRECISION, INVALID_IID_STRING,
 };
+use crate::common::date_time::format_date_time;
 use crate::common::string::escape_regex;
 use crate::common::token::Constraint::*;
 use crate::common::token::Predicate;
@@ -30,7 +31,6 @@ use crate::common::token::Type::Relation;
 use crate::pattern::*;
 use crate::write_joined;
 use chrono::{NaiveDateTime, Timelike};
-use std::convert::Infallible;
 use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -265,15 +265,7 @@ impl fmt::Display for Value {
             Double(double) => write!(f, "{}", double),
             Boolean(boolean) => write!(f, "{}", boolean),
             String(string) => write!(f, "\"{}\"", string),
-            DateTime(date_time) => write!(f, "{}", {
-                if date_time.time().nanosecond() > 0 {
-                    date_time.format("%Y-%m-%dT%H:%M:%S.%3f")
-                } else if date_time.time().second() > 0 {
-                    date_time.format("%Y-%m-%dT%H:%M:%S")
-                } else {
-                    date_time.format("%Y-%m-%dT%H:%M")
-                }
-            }),
+            DateTime(date_time) => write!(f, "{}", format_date_time(date_time)),
             Variable(var) => write!(f, "{}", var.reference),
         }
     }

--- a/rust/pattern/constraint/thing_constraint.rs
+++ b/rust/pattern/constraint/thing_constraint.rs
@@ -20,10 +20,10 @@
  *
  */
 
+use crate::common::date_time::format_date_time;
 use crate::common::error::{
     ErrorMessage, INVALID_CONSTRAINT_DATETIME_PRECISION, INVALID_IID_STRING,
 };
-use crate::common::date_time::format_date_time;
 use crate::common::string::escape_regex;
 use crate::common::token::Constraint::*;
 use crate::common::token::Predicate;

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -57,6 +57,12 @@ where
     }
 }
 
+impl From<Negation> for Pattern {
+    fn from(negation: Negation) -> Self {
+        Pattern::Negation(negation)
+    }
+}
+
 impl fmt::Display for Pattern {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Pattern::*;

--- a/rust/pattern/negation.rs
+++ b/rust/pattern/negation.rs
@@ -35,12 +35,6 @@ impl Negation {
     }
 }
 
-impl Into<Pattern> for Negation {
-    fn into(self) -> Pattern {
-        Pattern::Negation(self)
-    }
-}
-
 impl From<Pattern> for Negation {
     fn from(pattern: Pattern) -> Self {
         Negation { pattern: Box::new(pattern) }

--- a/rust/pattern/variable/builder/thing_variable_builder.rs
+++ b/rust/pattern/variable/builder/thing_variable_builder.rs
@@ -33,13 +33,9 @@ pub trait ThingConstrainable {
 }
 
 pub trait ThingVariableBuilder {
-    fn has<T: TryInto<Value>>(
-        self,
-        type_name: impl Into<String>,
-        value: T,
-    ) -> Result<ThingVariable, ErrorMessage>
+    fn has<T: TryInto<HasConstraint>>(self, has: T) -> Result<ThingVariable, ErrorMessage>
     where
-        ErrorMessage: From<<T as TryInto<Value>>::Error>;
+        ErrorMessage: From<<T as TryInto<HasConstraint>>::Error>;
 
     fn iid<T: TryInto<IIDConstraint>>(self, iid: T) -> Result<ThingVariable, ErrorMessage>
     where
@@ -58,20 +54,11 @@ pub trait ThingVariableBuilder {
 }
 
 impl<U: ThingConstrainable> ThingVariableBuilder for U {
-    fn has<T: TryInto<Value>>(
-        self,
-        type_name: impl Into<String>,
-        value: T,
-    ) -> Result<ThingVariable, ErrorMessage>
+    fn has<T: TryInto<HasConstraint>>(self, has: T) -> Result<ThingVariable, ErrorMessage>
     where
-        ErrorMessage: From<<T as TryInto<Value>>::Error>,
+        ErrorMessage: From<<T as TryInto<HasConstraint>>::Error>,
     {
-        Ok(self.constrain_has(match value.try_into()? {
-            Value::Variable(variable) => HasConstraint::from((type_name.into(), *variable)),
-            value => {
-                HasConstraint::from((type_name.into(), ValueConstraint::new(Predicate::Eq, value)))
-            }
-        }))
+        Ok(self.constrain_has(has.try_into()?))
     }
 
     fn iid<T: TryInto<IIDConstraint>>(self, iid: T) -> Result<ThingVariable, ErrorMessage>
@@ -120,15 +107,11 @@ impl<U: ThingConstrainable> ThingVariableBuilder for U {
 }
 
 impl<U: ThingVariableBuilder> ThingVariableBuilder for Result<U, ErrorMessage> {
-    fn has<T: TryInto<Value>>(
-        self,
-        type_name: impl Into<String>,
-        value: T,
-    ) -> Result<ThingVariable, ErrorMessage>
+    fn has<T: TryInto<HasConstraint>>(self, has: T) -> Result<ThingVariable, ErrorMessage>
     where
-        ErrorMessage: From<<T as TryInto<Value>>::Error>,
+        ErrorMessage: From<<T as TryInto<HasConstraint>>::Error>,
     {
-        self?.has(type_name, value)
+        self?.has(has)
     }
 
     fn iid<T: TryInto<IIDConstraint>>(self, iid: T) -> Result<ThingVariable, ErrorMessage>

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -25,51 +25,21 @@ use std::fmt;
 use crate::pattern::*;
 use crate::{enum_getter, var, ErrorMessage};
 
+mod typeql_insert;
+pub use typeql_insert::*;
+
 mod typeql_match;
 pub use typeql_match::*;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Query {
     Match(TypeQLMatch),
-    Dud(()),
+    Insert(TypeQLInsert),
 }
 
 impl Query {
     enum_getter!(into_match, Match, TypeQLMatch);
-}
-
-impl MatchQueryBuilder for Query {
-    fn get<T: Into<String>, const N: usize>(self, vars: [T; N]) -> Self {
-        use Query::*;
-        match self {
-            Match(query) => Match(query.get(vars)),
-            _ => todo!(),
-        }
-    }
-
-    fn sort(self, sorting: impl Into<Sorting>) -> Self {
-        use Query::*;
-        match self {
-            Match(query) => Match(query.sort(sorting)),
-            _ => todo!(),
-        }
-    }
-
-    fn limit(self, limit: usize) -> Self {
-        use Query::*;
-        match self {
-            Match(query) => Match(query.limit(limit)),
-            _ => todo!(),
-        }
-    }
-
-    fn offset(self, offset: usize) -> Self {
-        use Query::*;
-        match self {
-            Match(query) => Match(query.offset(offset)),
-            _ => todo!(),
-        }
-    }
+    enum_getter!(into_insert, Insert, TypeQLInsert);
 }
 
 impl fmt::Display for Query {
@@ -77,7 +47,7 @@ impl fmt::Display for Query {
         use Query::*;
         match self {
             Match(query) => write!(f, "{}", query),
-            _ => todo!(),
+            Insert(query) => write!(f, "{}", query),
         }
     }
 }

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -34,17 +34,22 @@ pub use typeql_insert::*;
 mod typeql_match;
 pub use typeql_match::*;
 
+mod typeql_update;
+pub use typeql_update::*;
+
 #[derive(Debug, Eq, PartialEq)]
 pub enum Query {
     Match(TypeQLMatch),
     Insert(TypeQLInsert),
     Delete(TypeQLDelete),
+    Update(TypeQLUpdate),
 }
 
 impl Query {
     enum_getter!(into_match, Match, TypeQLMatch);
     enum_getter!(into_insert, Insert, TypeQLInsert);
     enum_getter!(into_delete, Delete, TypeQLDelete);
+    enum_getter!(into_update, Update, TypeQLUpdate);
 }
 
 impl fmt::Display for Query {
@@ -54,6 +59,7 @@ impl fmt::Display for Query {
             Match(query) => write!(f, "{}", query),
             Insert(query) => write!(f, "{}", query),
             Delete(query) => write!(f, "{}", query),
+            Update(query) => write!(f, "{}", query),
         }
     }
 }

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -37,6 +37,9 @@ pub use typeql_match::*;
 mod typeql_update;
 pub use typeql_update::*;
 
+mod writable;
+pub use writable::*;
+
 #[derive(Debug, Eq, PartialEq)]
 pub enum Query {
     Match(TypeQLMatch),

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -25,6 +25,9 @@ use std::fmt;
 use crate::pattern::*;
 use crate::{enum_getter, var, ErrorMessage};
 
+mod typeql_delete;
+pub use typeql_delete::*;
+
 mod typeql_insert;
 pub use typeql_insert::*;
 
@@ -35,11 +38,13 @@ pub use typeql_match::*;
 pub enum Query {
     Match(TypeQLMatch),
     Insert(TypeQLInsert),
+    Delete(TypeQLDelete),
 }
 
 impl Query {
     enum_getter!(into_match, Match, TypeQLMatch);
     enum_getter!(into_insert, Insert, TypeQLInsert);
+    enum_getter!(into_delete, Delete, TypeQLDelete);
 }
 
 impl fmt::Display for Query {
@@ -48,6 +53,7 @@ impl fmt::Display for Query {
         match self {
             Match(query) => write!(f, "{}", query),
             Insert(query) => write!(f, "{}", query),
+            Delete(query) => write!(f, "{}", query),
         }
     }
 }

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -51,28 +51,3 @@ impl fmt::Display for Query {
         }
     }
 }
-
-pub trait MatchQueryBuilder {
-    fn get<T: Into<String>, const N: usize>(self, vars: [T; N]) -> Self;
-    fn sort(self, sorting: impl Into<Sorting>) -> Self;
-    fn limit(self, limit: usize) -> Self;
-    fn offset(self, offset: usize) -> Self;
-}
-
-impl<U: MatchQueryBuilder> MatchQueryBuilder for Result<U, ErrorMessage> {
-    fn get<T: Into<String>, const N: usize>(self, vars: [T; N]) -> Self {
-        Ok(self?.get(vars))
-    }
-
-    fn sort(self, sorting: impl Into<Sorting>) -> Self {
-        Ok(self?.sort(sorting))
-    }
-
-    fn limit(self, limit: usize) -> Self {
-        Ok(self?.limit(limit))
-    }
-
-    fn offset(self, offset: usize) -> Self {
-        Ok(self?.offset(offset))
-    }
-}

--- a/rust/query/typeql_delete.rs
+++ b/rust/query/typeql_delete.rs
@@ -22,22 +22,18 @@
 
 use crate::common::token::Command::Delete;
 use crate::{
-    write_joined, ErrorMessage, Writable, Query, ThingVariable, TypeQLMatch, TypeQLUpdate,
-    UpdateQueryBuilder,
+    write_joined, ErrorMessage, Query, ThingVariable, TypeQLMatch, TypeQLUpdate,
+    UpdateQueryBuilder, Writable,
 };
 use std::fmt;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct TypeQLDelete {
-    pub match_query: Option<TypeQLMatch>,
+    pub match_query: TypeQLMatch,
     pub variables: Vec<ThingVariable>,
 }
 
 impl TypeQLDelete {
-    pub fn new(variables: Vec<ThingVariable>) -> Self {
-        TypeQLDelete { match_query: None, variables }
-    }
-
     pub fn into_query(self) -> Query {
         Query::Delete(self)
     }
@@ -45,10 +41,7 @@ impl TypeQLDelete {
 
 impl fmt::Display for TypeQLDelete {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(match_query) = &self.match_query {
-            writeln!(f, "{}", match_query)?;
-        }
-
+        writeln!(f, "{}", self.match_query)?;
         writeln!(f, "{}", Delete)?;
         write_joined!(f, ";\n", self.variables)?;
         f.write_str(";")
@@ -67,6 +60,6 @@ impl<U: DeleteQueryBuilder> DeleteQueryBuilder for Result<U, ErrorMessage> {
 
 impl UpdateQueryBuilder for TypeQLDelete {
     fn insert(self, vars: impl Writable) -> Result<TypeQLUpdate, ErrorMessage> {
-        Ok(TypeQLUpdate { delete_query: Some(self), insert_variables: vars.vars() })
+        Ok(TypeQLUpdate { delete_query: self, insert_variables: vars.vars() })
     }
 }

--- a/rust/query/typeql_delete.rs
+++ b/rust/query/typeql_delete.rs
@@ -21,7 +21,10 @@
  */
 
 use crate::common::token::Command::Delete;
-use crate::{write_joined, ErrorMessage, Query, ThingVariable, TypeQLMatch};
+use crate::{
+    write_joined, ErrorMessage, Insertable, Query, ThingVariable, TypeQLMatch, TypeQLUpdate,
+    UpdateQueryBuilder,
+};
 use std::fmt;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -93,5 +96,11 @@ pub trait DeleteQueryBuilder {
 impl<U: DeleteQueryBuilder> DeleteQueryBuilder for Result<U, ErrorMessage> {
     fn delete(self, vars: impl Deletable) -> Result<TypeQLDelete, ErrorMessage> {
         self?.delete(vars)
+    }
+}
+
+impl UpdateQueryBuilder for TypeQLDelete {
+    fn insert(self, vars: impl Insertable) -> Result<TypeQLUpdate, ErrorMessage> {
+        Ok(TypeQLUpdate { delete_query: Some(self), variables: vars.vars() })
     }
 }

--- a/rust/query/typeql_delete.rs
+++ b/rust/query/typeql_delete.rs
@@ -43,10 +43,10 @@ impl TypeQLDelete {
 impl fmt::Display for TypeQLDelete {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(match_query) = &self.match_query {
-            write!(f, "{}\n", match_query)?;
+            writeln!(f, "{}", match_query)?;
         }
 
-        write!(f, "{}\n", Delete)?;
+        writeln!(f, "{}", Delete)?;
         write_joined!(f, ";\n", self.variables)?;
         f.write_str(";")
     }

--- a/rust/query/typeql_delete.rs
+++ b/rust/query/typeql_delete.rs
@@ -101,6 +101,6 @@ impl<U: DeleteQueryBuilder> DeleteQueryBuilder for Result<U, ErrorMessage> {
 
 impl UpdateQueryBuilder for TypeQLDelete {
     fn insert(self, vars: impl Insertable) -> Result<TypeQLUpdate, ErrorMessage> {
-        Ok(TypeQLUpdate { delete_query: Some(self), variables: vars.vars() })
+        Ok(TypeQLUpdate { delete_query: Some(self), insert_variables: vars.vars() })
     }
 }

--- a/rust/query/typeql_delete.rs
+++ b/rust/query/typeql_delete.rs
@@ -22,7 +22,7 @@
 
 use crate::common::token::Command::Delete;
 use crate::{
-    write_joined, ErrorMessage, Insertable, Query, ThingVariable, TypeQLMatch, TypeQLUpdate,
+    write_joined, ErrorMessage, Writable, Query, ThingVariable, TypeQLMatch, TypeQLUpdate,
     UpdateQueryBuilder,
 };
 use std::fmt;
@@ -55,52 +55,18 @@ impl fmt::Display for TypeQLDelete {
     }
 }
 
-pub trait Deletable {
-    fn vars(self) -> Vec<ThingVariable>;
-}
-
-impl Deletable for ThingVariable {
-    fn vars(self) -> Vec<ThingVariable> {
-        vec![self]
-    }
-}
-
-impl<const N: usize> Deletable for [ThingVariable; N] {
-    fn vars(self) -> Vec<ThingVariable> {
-        self.to_vec()
-    }
-}
-
-impl<const N: usize> Deletable for [Result<ThingVariable, ErrorMessage>; N] {
-    fn vars(self) -> Vec<ThingVariable> {
-        self.into_iter().map(|x| x.unwrap()).collect()
-    }
-}
-
-impl Deletable for Vec<ThingVariable> {
-    fn vars(self) -> Vec<ThingVariable> {
-        self
-    }
-}
-
-impl<U: Deletable> Deletable for Result<U, ErrorMessage> {
-    fn vars(self) -> Vec<ThingVariable> {
-        self.unwrap().vars()
-    }
-}
-
 pub trait DeleteQueryBuilder {
-    fn delete(self, vars: impl Deletable) -> Result<TypeQLDelete, ErrorMessage>;
+    fn delete(self, vars: impl Writable) -> Result<TypeQLDelete, ErrorMessage>;
 }
 
 impl<U: DeleteQueryBuilder> DeleteQueryBuilder for Result<U, ErrorMessage> {
-    fn delete(self, vars: impl Deletable) -> Result<TypeQLDelete, ErrorMessage> {
+    fn delete(self, vars: impl Writable) -> Result<TypeQLDelete, ErrorMessage> {
         self?.delete(vars)
     }
 }
 
 impl UpdateQueryBuilder for TypeQLDelete {
-    fn insert(self, vars: impl Insertable) -> Result<TypeQLUpdate, ErrorMessage> {
+    fn insert(self, vars: impl Writable) -> Result<TypeQLUpdate, ErrorMessage> {
         Ok(TypeQLUpdate { delete_query: Some(self), insert_variables: vars.vars() })
     }
 }

--- a/rust/query/typeql_insert.rs
+++ b/rust/query/typeql_insert.rs
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+use std::fmt;
+use crate::common::token::Command::Insert;
+use crate::{ErrorMessage, Query, ThingVariable, TypeQLMatch, write_joined};
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct TypeQLInsert {
+    pub match_query: Option<TypeQLMatch>,
+    pub variables: Vec<ThingVariable>,
+}
+
+impl TypeQLInsert {
+    pub fn new(variables: Vec<ThingVariable>) -> Self {
+        TypeQLInsert {
+            match_query: None,
+            variables
+        }
+    }
+
+    pub fn into_query(self) -> Query {
+        Query::Insert(self)
+    }
+}
+
+impl fmt::Display for TypeQLInsert {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(match_query) = &self.match_query {
+            write!(f, "{}\n", match_query)?;
+        }
+
+        write!(f, "{}\n", Insert)?;
+        write_joined!(f, ";\n", self.variables)?;
+        f.write_str(";")
+    }
+}
+
+pub trait Insertable {
+    fn vars(self) -> Vec<ThingVariable>;
+}
+
+impl Insertable for ThingVariable {
+    fn vars(self) -> Vec<ThingVariable> { vec![self] }
+}
+
+impl<const N: usize> Insertable for [ThingVariable; N] {
+    fn vars(self) -> Vec<ThingVariable> { self.to_vec() }
+}
+
+impl Insertable for Vec<ThingVariable> {
+    fn vars(self) -> Vec<ThingVariable> { self }
+}
+
+impl<U: Insertable> Insertable for Result<U, ErrorMessage> {
+    fn vars(self) -> Vec<ThingVariable> {
+        self.unwrap().vars()
+    }
+}
+
+pub trait InsertQueryBuilder {
+    fn insert(self, vars: impl Insertable) -> Result<TypeQLInsert, ErrorMessage>;
+}
+
+impl<U: InsertQueryBuilder> InsertQueryBuilder for Result<U, ErrorMessage> {
+    fn insert(self, vars: impl Insertable) -> Result<TypeQLInsert, ErrorMessage> {
+        self?.insert(vars)
+    }
+}

--- a/rust/query/typeql_insert.rs
+++ b/rust/query/typeql_insert.rs
@@ -21,7 +21,7 @@
  */
 
 use crate::common::token::Command::Insert;
-use crate::{write_joined, ErrorMessage, Query, ThingVariable, TypeQLMatch};
+use crate::{write_joined, ErrorMessage, Query, ThingVariable, TypeQLMatch, Writable};
 use std::fmt;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -52,40 +52,12 @@ impl fmt::Display for TypeQLInsert {
     }
 }
 
-pub trait Insertable {
-    fn vars(self) -> Vec<ThingVariable>;
-}
-
-impl Insertable for ThingVariable {
-    fn vars(self) -> Vec<ThingVariable> {
-        vec![self]
-    }
-}
-
-impl<const N: usize> Insertable for [ThingVariable; N] {
-    fn vars(self) -> Vec<ThingVariable> {
-        self.to_vec()
-    }
-}
-
-impl Insertable for Vec<ThingVariable> {
-    fn vars(self) -> Vec<ThingVariable> {
-        self
-    }
-}
-
-impl<U: Insertable> Insertable for Result<U, ErrorMessage> {
-    fn vars(self) -> Vec<ThingVariable> {
-        self.unwrap().vars()
-    }
-}
-
 pub trait InsertQueryBuilder {
-    fn insert(self, vars: impl Insertable) -> Result<TypeQLInsert, ErrorMessage>;
+    fn insert(self, vars: impl Writable) -> Result<TypeQLInsert, ErrorMessage>;
 }
 
 impl<U: InsertQueryBuilder> InsertQueryBuilder for Result<U, ErrorMessage> {
-    fn insert(self, vars: impl Insertable) -> Result<TypeQLInsert, ErrorMessage> {
+    fn insert(self, vars: impl Writable) -> Result<TypeQLInsert, ErrorMessage> {
         self?.insert(vars)
     }
 }

--- a/rust/query/typeql_insert.rs
+++ b/rust/query/typeql_insert.rs
@@ -43,10 +43,10 @@ impl TypeQLInsert {
 impl fmt::Display for TypeQLInsert {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(match_query) = &self.match_query {
-            write!(f, "{}\n", match_query)?;
+            writeln!(f, "{}", match_query)?;
         }
 
-        write!(f, "{}\n", Insert)?;
+        writeln!(f, "{}", Insert)?;
         write_joined!(f, ";\n", self.variables)?;
         f.write_str(";")
     }

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -98,7 +98,7 @@ impl InsertQueryBuilder for TypeQLMatch {
 
 impl DeleteQueryBuilder for TypeQLMatch {
     fn delete(self, vars: impl Writable) -> Result<TypeQLDelete, ErrorMessage> {
-        Ok(TypeQLDelete { match_query: Some(self), variables: vars.vars() })
+        Ok(TypeQLDelete { match_query: self, variables: vars.vars() })
     }
 }
 

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -47,6 +47,31 @@ impl TypeQLMatch {
     }
 }
 
+pub trait MatchQueryBuilder {
+    fn get<T: Into<String>, const N: usize>(self, vars: [T; N]) -> Self;
+    fn sort(self, sorting: impl Into<Sorting>) -> Self;
+    fn limit(self, limit: usize) -> Self;
+    fn offset(self, offset: usize) -> Self;
+}
+
+impl<U: MatchQueryBuilder> MatchQueryBuilder for Result<U, ErrorMessage> {
+    fn get<T: Into<String>, const N: usize>(self, vars: [T; N]) -> Self {
+        Ok(self?.get(vars))
+    }
+
+    fn sort(self, sorting: impl Into<Sorting>) -> Self {
+        Ok(self?.sort(sorting))
+    }
+
+    fn limit(self, limit: usize) -> Self {
+        Ok(self?.limit(limit))
+    }
+
+    fn offset(self, offset: usize) -> Self {
+        Ok(self?.offset(offset))
+    }
+}
+
 impl MatchQueryBuilder for TypeQLMatch {
     fn get<T: Into<String>, const N: usize>(self, vars: [T; N]) -> Self {
         self.filter(vars.into_iter().map(|s| UnboundVariable::named(s.into())).collect())

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -65,6 +65,12 @@ impl MatchQueryBuilder for TypeQLMatch {
     }
 }
 
+impl InsertQueryBuilder for TypeQLMatch {
+    fn insert(self, vars: impl Insertable) -> Result<TypeQLInsert, ErrorMessage> {
+        Ok(TypeQLInsert { match_query: Some(self), variables: vars.vars() })
+    }
+}
+
 impl fmt::Display for TypeQLMatch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Match)?;

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -91,13 +91,13 @@ impl MatchQueryBuilder for TypeQLMatch {
 }
 
 impl InsertQueryBuilder for TypeQLMatch {
-    fn insert(self, vars: impl Insertable) -> Result<TypeQLInsert, ErrorMessage> {
+    fn insert(self, vars: impl Writable) -> Result<TypeQLInsert, ErrorMessage> {
         Ok(TypeQLInsert { match_query: Some(self), variables: vars.vars() })
     }
 }
 
 impl DeleteQueryBuilder for TypeQLMatch {
-    fn delete(self, vars: impl Deletable) -> Result<TypeQLDelete, ErrorMessage> {
+    fn delete(self, vars: impl Writable) -> Result<TypeQLDelete, ErrorMessage> {
         Ok(TypeQLDelete { match_query: Some(self), variables: vars.vars() })
     }
 }

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -96,6 +96,12 @@ impl InsertQueryBuilder for TypeQLMatch {
     }
 }
 
+impl DeleteQueryBuilder for TypeQLMatch {
+    fn delete(self, vars: impl Deletable) -> Result<TypeQLDelete, ErrorMessage> {
+        Ok(TypeQLDelete { match_query: Some(self), variables: vars.vars() })
+    }
+}
+
 impl fmt::Display for TypeQLMatch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Match)?;

--- a/rust/query/typeql_update.rs
+++ b/rust/query/typeql_update.rs
@@ -27,12 +27,12 @@ use std::fmt;
 #[derive(Debug, Eq, PartialEq)]
 pub struct TypeQLUpdate {
     pub delete_query: Option<TypeQLDelete>,
-    pub variables: Vec<ThingVariable>,
+    pub insert_variables: Vec<ThingVariable>,
 }
 
 impl TypeQLUpdate {
     pub fn new(variables: Vec<ThingVariable>) -> Self {
-        TypeQLUpdate { delete_query: None, variables }
+        TypeQLUpdate { delete_query: None, insert_variables: variables }
     }
 
     pub fn into_query(self) -> Query {
@@ -47,7 +47,7 @@ impl fmt::Display for TypeQLUpdate {
         }
 
         writeln!(f, "{}", Insert)?;
-        write_joined!(f, ";\n", self.variables)?;
+        write_joined!(f, ";\n", self.insert_variables)?;
         f.write_str(";")
     }
 }

--- a/rust/query/typeql_update.rs
+++ b/rust/query/typeql_update.rs
@@ -21,7 +21,7 @@
  */
 
 use crate::common::token::Command::Insert;
-use crate::{write_joined, ErrorMessage, Insertable, Query, ThingVariable, TypeQLDelete};
+use crate::{write_joined, ErrorMessage, Writable, Query, ThingVariable, TypeQLDelete};
 use std::fmt;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -53,11 +53,11 @@ impl fmt::Display for TypeQLUpdate {
 }
 
 pub trait UpdateQueryBuilder {
-    fn insert(self, vars: impl Insertable) -> Result<TypeQLUpdate, ErrorMessage>;
+    fn insert(self, vars: impl Writable) -> Result<TypeQLUpdate, ErrorMessage>;
 }
 
 impl<U: UpdateQueryBuilder> UpdateQueryBuilder for Result<U, ErrorMessage> {
-    fn insert(self, vars: impl Insertable) -> Result<TypeQLUpdate, ErrorMessage> {
+    fn insert(self, vars: impl Writable) -> Result<TypeQLUpdate, ErrorMessage> {
         self?.insert(vars)
     }
 }

--- a/rust/query/typeql_update.rs
+++ b/rust/query/typeql_update.rs
@@ -21,20 +21,16 @@
  */
 
 use crate::common::token::Command::Insert;
-use crate::{write_joined, ErrorMessage, Writable, Query, ThingVariable, TypeQLDelete};
+use crate::{write_joined, ErrorMessage, Query, ThingVariable, TypeQLDelete, Writable};
 use std::fmt;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct TypeQLUpdate {
-    pub delete_query: Option<TypeQLDelete>,
+    pub delete_query: TypeQLDelete,
     pub insert_variables: Vec<ThingVariable>,
 }
 
 impl TypeQLUpdate {
-    pub fn new(variables: Vec<ThingVariable>) -> Self {
-        TypeQLUpdate { delete_query: None, insert_variables: variables }
-    }
-
     pub fn into_query(self) -> Query {
         Query::Update(self)
     }
@@ -42,10 +38,7 @@ impl TypeQLUpdate {
 
 impl fmt::Display for TypeQLUpdate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(delete_query) = &self.delete_query {
-            writeln!(f, "{}", delete_query)?;
-        }
-
+        writeln!(f, "{}", self.delete_query)?;
         writeln!(f, "{}", Insert)?;
         write_joined!(f, ";\n", self.insert_variables)?;
         f.write_str(";")

--- a/rust/query/typeql_update.rs
+++ b/rust/query/typeql_update.rs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+use crate::common::token::Command::Insert;
+use crate::{write_joined, ErrorMessage, Insertable, Query, ThingVariable, TypeQLDelete};
+use std::fmt;
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct TypeQLUpdate {
+    pub delete_query: Option<TypeQLDelete>,
+    pub variables: Vec<ThingVariable>,
+}
+
+impl TypeQLUpdate {
+    pub fn new(variables: Vec<ThingVariable>) -> Self {
+        TypeQLUpdate { delete_query: None, variables }
+    }
+
+    pub fn into_query(self) -> Query {
+        Query::Update(self)
+    }
+}
+
+impl fmt::Display for TypeQLUpdate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(delete_query) = &self.delete_query {
+            writeln!(f, "{}", delete_query)?;
+        }
+
+        writeln!(f, "{}", Insert)?;
+        write_joined!(f, ";\n", self.variables)?;
+        f.write_str(";")
+    }
+}
+
+pub trait UpdateQueryBuilder {
+    fn insert(self, vars: impl Insertable) -> Result<TypeQLUpdate, ErrorMessage>;
+}
+
+impl<U: UpdateQueryBuilder> UpdateQueryBuilder for Result<U, ErrorMessage> {
+    fn insert(self, vars: impl Insertable) -> Result<TypeQLUpdate, ErrorMessage> {
+        self?.insert(vars)
+    }
+}

--- a/rust/query/writable.rs
+++ b/rust/query/writable.rs
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+use crate::{ErrorMessage, ThingVariable};
+
+pub trait Writable {
+    fn vars(self) -> Vec<ThingVariable>;
+}
+
+impl Writable for ThingVariable {
+    fn vars(self) -> Vec<ThingVariable> {
+        vec![self]
+    }
+}
+
+impl<const N: usize> Writable for [ThingVariable; N] {
+    fn vars(self) -> Vec<ThingVariable> {
+        self.to_vec()
+    }
+}
+
+impl<const N: usize> Writable for [Result<ThingVariable, ErrorMessage>; N] {
+    fn vars(self) -> Vec<ThingVariable> {
+        self.into_iter().map(|x| x.unwrap()).collect()
+    }
+}
+
+impl Writable for Vec<ThingVariable> {
+    fn vars(self) -> Vec<ThingVariable> {
+        self
+    }
+}
+
+impl<U: Writable> Writable for Result<U, ErrorMessage> {
+    fn vars(self) -> Vec<ThingVariable> {
+        self.unwrap().vars()
+    }
+}

--- a/rust/typeql_lang.rs
+++ b/rust/typeql_lang.rs
@@ -61,6 +61,17 @@ macro_rules! typeql_match {
 }
 
 #[macro_export]
+macro_rules! typeql_insert {
+    ($($thing_variable:expr),* $(,)?) => {{
+        let variables = [$($thing_variable),*].into_iter().collect::<Result<Vec<_>, ErrorMessage>>();
+        match variables {
+            Ok(variables) => Ok(TypeQLInsert::new(variables)),
+            Err(err) => Err(err),
+        }
+    }}
+}
+
+#[macro_export]
 macro_rules! and {
     ($($pattern:expr),* $(,)?) => {{
         let patterns = [$($pattern.map(|p| p.into_pattern())),*].into_iter().collect::<Result<Vec<_>, ErrorMessage>>();


### PR DESCRIPTION
## What is the goal of this PR?

We implement the data write queries, viz. `delete`, `insert`, and `delete`-`insert`, aka "update".

## What are the changes implemented in this PR?

Implement data structures, builder functions, and parser visitors for:
- insert query;
- delete query;
- update query (delete followed by insert).

Refactor:
- dedicated date_time module;
- simplified `has` building.