### PR TITLE
Remove error propagation and force error handling as early as possible

### DIFF
--- a/rust/builder/mod.rs
+++ b/rust/builder/mod.rs
@@ -25,44 +25,28 @@ use crate::{common::token::Predicate, *};
 #[macro_export]
 macro_rules! typeql_match {
     ($($pattern:expr),* $(,)?) => {{
-        let patterns = [$($pattern.map(|p| p.into_pattern())),*].into_iter().collect::<Result<Vec<_>, ErrorMessage>>();
-        match patterns {
-            Ok(patterns) => Ok(TypeQLMatch::new(Conjunction::from(patterns))),
-            Err(err) => Err(err),
-        }
+        TypeQLMatch::new(Conjunction::from(vec![$($pattern.into_pattern()),*]))
     }}
 }
 
 #[macro_export]
 macro_rules! typeql_insert {
     ($($thing_variable:expr),* $(,)?) => {{
-        let variables = [$($thing_variable),*].into_iter().collect::<Result<Vec<_>, ErrorMessage>>();
-        match variables {
-            Ok(variables) => Ok(TypeQLInsert::new(variables)),
-            Err(err) => Err(err),
-        }
+        TypeQLInsert::new(vec![$($thing_variable),*])
     }}
 }
 
 #[macro_export]
 macro_rules! and {
     ($($pattern:expr),* $(,)?) => {{
-        let patterns = [$($pattern.map(|p| p.into_pattern())),*].into_iter().collect::<Result<Vec<_>, ErrorMessage>>();
-        match patterns {
-            Ok(patterns) => Ok(Conjunction::from(patterns)),
-            Err(err) => Err(err),
-        }
+        Conjunction::from(vec![$($pattern.into_pattern()),*])
     }}
 }
 
 #[macro_export]
 macro_rules! or {
     ($($pattern:expr),* $(,)?) => {{
-        let patterns = [$($pattern.map(|p| p.into_pattern())),*].into_iter().collect::<Result<Vec<_>, ErrorMessage>>();
-        match patterns {
-            Ok(patterns) => Ok(Disjunction::from(patterns)),
-            Err(err) => Err(err),
-        }
+        Disjunction::from(vec![$($pattern.into_pattern()),*])
     }}
 }
 
@@ -70,19 +54,16 @@ pub fn var(var: impl Into<UnboundVariable>) -> UnboundVariable {
     var.into()
 }
 
-pub fn type_(name: impl Into<String>) -> Result<TypeVariable, ErrorMessage> {
+pub fn type_(name: impl Into<String>) -> TypeVariable {
     UnboundVariable::hidden().type_(name.into())
 }
 
-pub fn rel<T: Into<RolePlayerConstraint>>(value: T) -> Result<ThingVariable, ErrorMessage> {
+pub fn rel<T: Into<RolePlayerConstraint>>(value: T) -> ThingVariable {
     UnboundVariable::hidden().rel(value)
 }
 
-pub fn not<T: TryInto<Negation>>(pattern: T) -> Result<Negation, ErrorMessage>
-where
-    ErrorMessage: From<<T as TryInto<Negation>>::Error>,
-{
-    Ok(pattern.try_into()?)
+pub fn not<T: Into<Negation>>(pattern: T) -> Negation {
+    pattern.into()
 }
 
 pub fn eq<T: TryInto<Value>>(value: T) -> Result<ValueConstraint, ErrorMessage>

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -21,7 +21,7 @@
  */
 
 use crate::{
-    and, gte, lt, lte, not, or, parse_query, rel, type_, typeql_insert, typeql_match, var,
+    and, gte, lt, lte, not, or, parse_query, rel, try_, type_, typeql_insert, typeql_match, var,
     ConceptVariableBuilder, Conjunction, DeleteQueryBuilder, Disjunction, ErrorMessage,
     InsertQueryBuilder, MatchQueryBuilder, Query, RelationVariableBuilder, ThingVariableBuilder,
     TypeQLInsert, TypeQLMatch, TypeVariableBuilder, UpdateQueryBuilder, KEY,
@@ -30,9 +30,9 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
 macro_rules! assert_query_eq {
     ($expected:ident, $parsed:ident, $query:ident) => {
-        assert_eq!($expected.as_ref().unwrap(), $parsed.as_ref().unwrap()); // TODO remove unwraps when `typeql_match` returns ErrorMessage
-        assert_eq!($expected.as_ref().unwrap().to_string(), $query);
-        assert_eq!($parsed.as_ref().unwrap().to_string(), $query);
+        assert_eq!($expected, $parsed);
+        assert_eq!($expected.to_string(), $query);
+        assert_eq!($parsed.to_string(), $query);
     };
 }
 
@@ -41,7 +41,7 @@ fn test_simple_query() {
     let query = r#"match
 $x isa movie;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").isa("movie"));
     assert_query_eq!(expected, parsed, query);
 }
@@ -52,7 +52,7 @@ fn test_named_type_variable() {
 $a type attribute_label;
 get $a;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("a").type_("attribute_label")).get(["a"]);
     assert_query_eq!(expected, parsed, query);
 }
@@ -63,8 +63,12 @@ fn test_parse_string_with_slash() {
 $x isa person,
     has name "alice/bob";"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").isa("person").has(("name", "alice/bob")));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("x").isa("person").has(("name", "alice/bob"))?)
+    }
+    .unwrap();
+
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -75,7 +79,7 @@ $brando "Marl B" isa name;
 (actor: $brando, $char, production-with-cast: $prod);
 get $char, $prod;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(
         var("brando").eq("Marl B").isa("name"),
         rel(("actor", "brando")).rel("char").rel(("production-with-cast", "prod")),
@@ -90,7 +94,7 @@ fn test_role_type_scoped_globally() {
     let query = r#"match
 $m relates spouse;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("m").relates("spouse"));
     assert_query_eq!(expected, parsed, query);
 }
@@ -100,7 +104,7 @@ fn test_role_type_not_scoped() {
     let query = r#"match
 marriage relates $s;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(type_("marriage").relates(var("s")));
     assert_query_eq!(expected, parsed, query);
 }
@@ -120,16 +124,20 @@ $x isa movie,
 };
 $t != "Apocalypse Now";"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(
-        var("x").isa("movie").has(("title", var("t"))),
-        or!(
-            var("t").eq("Apocalypse Now"),
-            and!(var("t").lt("Juno"), var("t").gt("Godfather")),
-            var("t").eq("Spy"),
-        ),
-        var("t").neq("Apocalypse Now"),
-    );
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(
+            var("x").isa("movie").has(("title", var("t")))?,
+            or!(
+                var("t").eq("Apocalypse Now"),
+                and!(var("t").lt("Juno"), var("t").gt("Godfather")),
+                var("t").eq("Spy"),
+            ),
+            var("t").neq("Apocalypse Now"),
+        )
+    }
+    .unwrap();
+
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -146,14 +154,18 @@ $x isa movie,
     $t "The Muppets";
 };"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(
-        var("x").isa("movie").has(("title", var("t"))),
-        or!(
-            and!(var("t").lte("Juno"), var("t").gte("Godfather"), var("t").neq("Heat"),),
-            var("t").eq("The Muppets"),
-        ),
-    );
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(
+            var("x").isa("movie").has(("title", var("t")))?,
+            or!(
+                and!(var("t").lte("Juno"), var("t").gte("Godfather"), var("t").neq("Heat"),),
+                var("t").eq("The Muppets"),
+            ),
+        )
+    }
+    .unwrap();
+
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -169,12 +181,16 @@ $y isa person,
     $n like "^M.*$";
 };"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(
-        rel("x").rel("y"),
-        var("y").isa("person").has(("name", var("n"))),
-        or!(var("n").contains("ar"), var("n").like("^M.*$")),
-    );
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(
+            rel("x").rel("y"),
+            var("y").isa("person").has(("name", var("n")))?,
+            or!(var("n").contains("ar")?, var("n").like("^M.*$")?),
+        )
+    }
+    .unwrap();
+
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -185,12 +201,16 @@ $x has age $y;
 $y >= $z;
 $z 18 isa age;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(
-        var("x").has(("age", var("y"))),
-        var("y").gte(var("z")),
-        var("z").eq(18).isa("age"),
-    );
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(
+            var("x").has(("age", var("y")))?,
+            var("y").gte(var("z")),
+            var("z").eq(18).isa("age"),
+        )
+    }
+    .unwrap();
+
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -204,6 +224,7 @@ $b isa $y;
 not { $x is $y; };
 not { $a is $b; };"#;
 
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(
         var("x").sub(var("z")),
         var("y").sub(var("z")),
@@ -212,7 +233,7 @@ not { $a is $b; };"#;
         not(var("x").is(var("y"))),
         not(var("a").is(var("b"))),
     );
-    let parsed = parse_query(query).map(Query::into_match);
+
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -221,7 +242,7 @@ fn test_value_equals_variable_query() {
     let query = r#"match
 $s1 = $s2;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("s1").eq(var("s2")));
     assert_query_eq!(expected, parsed, query);
 }
@@ -233,11 +254,14 @@ $x has release-date >= $r;
 $_ has title "Spy",
     has release-date $r;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(
-        var("x").has(("release-date", gte(var("r")))),
-        var(()).has(("title", "Spy")).has(("release-date", var("r"))),
-    );
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(
+            var("x").has(("release-date", gte(var("r"))))?,
+            var(()).has(("title", "Spy"))?.has(("release-date", var("r")))?,
+        )
+    }
+    .unwrap();
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -248,14 +272,17 @@ $x has release-date < 1986-03-03T00:00,
     has tmdb-vote-count 100,
     has tmdb-vote-average <= 9.0;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x")
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("x")
         .has((
             "release-date",
-            lt(NaiveDateTime::new(NaiveDate::from_ymd(1986, 3, 3), NaiveTime::from_hms(0, 0, 0)))
-        ))
-        .has(("tmdb-vote-count", 100))
-        .has(("tmdb-vote-average", lte(9.0))));
+            lt(NaiveDateTime::new(NaiveDate::from_ymd(1986, 3, 3), NaiveTime::from_hms(0, 0, 0)))?
+        ))?
+        .has(("tmdb-vote-count", 100))?
+        .has(("tmdb-vote-average", lte(9.0)))?)
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -265,11 +292,14 @@ fn when_parsing_date_handle_time() {
     let query = r#"match
 $x has release-date 1000-11-12T13:14:15;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").has((
-        "release-date",
-        NaiveDateTime::new(NaiveDate::from_ymd(1000, 11, 12), NaiveTime::from_hms(13, 14, 15)),
-    )));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("x").has((
+            "release-date",
+            NaiveDateTime::new(NaiveDate::from_ymd(1000, 11, 12), NaiveTime::from_hms(13, 14, 15)),
+        ))?)
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -279,11 +309,14 @@ fn when_parsing_date_handle_big_years() {
     let query = r#"match
 $x has release-date +12345-12-25T00:00;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").has((
-        "release-date",
-        NaiveDateTime::new(NaiveDate::from_ymd(12345, 12, 25), NaiveTime::from_hms(0, 0, 0)),
-    )));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("x").has((
+            "release-date",
+            NaiveDateTime::new(NaiveDate::from_ymd(12345, 12, 25), NaiveTime::from_hms(0, 0, 0)),
+        ))?)
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -293,11 +326,14 @@ fn when_parsing_date_handle_small_years() {
     let query = r#"match
 $x has release-date 0867-01-01T00:00;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").has((
-        "release-date",
-        NaiveDateTime::new(NaiveDate::from_ymd(867, 1, 1), NaiveTime::from_hms(0, 0, 0)),
-    )));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("x").has((
+            "release-date",
+            NaiveDateTime::new(NaiveDate::from_ymd(867, 1, 1), NaiveTime::from_hms(0, 0, 0)),
+        ))?)
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -307,11 +343,14 @@ fn when_parsing_date_handle_negative_years() {
     let query = r#"match
 $x has release-date -3200-01-01T00:00;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").has((
-        "release-date",
-        NaiveDateTime::new(NaiveDate::from_ymd(-3200, 1, 1), NaiveTime::from_hms(0, 0, 0)),
-    )));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("x").has((
+            "release-date",
+            NaiveDateTime::new(NaiveDate::from_ymd(-3200, 1, 1), NaiveTime::from_hms(0, 0, 0)),
+        ))?)
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -321,14 +360,17 @@ fn when_parsing_date_handle_millis() {
     let query = r#"match
 $x has release-date 1000-11-12T13:14:15.123;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").has((
-        "release-date",
-        NaiveDateTime::new(
-            NaiveDate::from_ymd(1000, 11, 12),
-            NaiveTime::from_hms_milli(13, 14, 15, 123),
-        ),
-    )));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("x").has((
+            "release-date",
+            NaiveDateTime::new(
+                NaiveDate::from_ymd(1000, 11, 12),
+                NaiveTime::from_hms_milli(13, 14, 15, 123),
+            ),
+        ))?)
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -338,14 +380,17 @@ fn when_parsing_date_handle_millis_shorthand() {
     let query = r#"match
 $x has release-date 1000-11-12T13:14:15.1;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").has((
-        "release-date",
-        NaiveDateTime::new(
-            NaiveDate::from_ymd(1000, 11, 12),
-            NaiveTime::from_hms_milli(13, 14, 15, 100),
-        ),
-    )));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("x").has((
+            "release-date",
+            NaiveDateTime::new(
+                NaiveDate::from_ymd(1000, 11, 12),
+                NaiveTime::from_hms_milli(13, 14, 15, 100),
+            ),
+        ))?)
+    }
+    .unwrap();
 
     let parsed_query = r#"match
 $x has release-date 1000-11-12T13:14:15.100;"#;
@@ -357,20 +402,22 @@ fn when_parsing_date_error_when_parsing_overly_precise_decimal_seconds() {
     let query = r#"match
 $x has release-date 1000-11-12T13:14:15.000123456;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query);
     assert!(parsed.is_err());
     assert!(parsed.err().unwrap().contains("no viable alternative"));
 }
 
 #[test]
 fn when_parsing_date_error_when_handling_overly_precise_nanos() {
-    let expected = typeql_match!(var("x").has((
-        "release-date",
-        NaiveDateTime::new(
-            NaiveDate::from_ymd(1000, 11, 12),
-            NaiveTime::from_hms_nano(13, 14, 15, 123450000),
-        ),
-    )));
+    let expected = try_! {
+        typeql_match!(var("x").has((
+            "release-date",
+            NaiveDateTime::new(
+                NaiveDate::from_ymd(1000, 11, 12),
+                NaiveTime::from_hms_nano(13, 14, 15, 123450000),
+            ),
+        ))?)
+    };
     assert!(expected.is_err());
     assert!(expected.err().unwrap().message.contains("more precise than 1 millisecond"));
 }
@@ -381,8 +428,11 @@ fn test_long_predicate_query() {
 $x isa movie,
     has tmdb-vote-count <= 400;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").isa("movie").has(("tmdb-vote-count", lte(400))));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("x").isa("movie").has(("tmdb-vote-count", lte(400)))?)
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -393,7 +443,7 @@ fn test_schema_query() {
 $x plays starring:actor;
 sort $x asc;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").plays(("starring", "actor"))).sort([("x", "asc")]);
 
     assert_query_eq!(expected, parsed, query);
@@ -406,9 +456,11 @@ $x isa movie,
     has rating $r;
 sort $r desc;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected =
-        typeql_match!(var("x").isa("movie").has(("rating", var("r")))).sort([("r", "desc")]);
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("x").isa("movie").has(("rating", var("r")))?).sort([("r", "desc")])
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -420,9 +472,11 @@ $x isa movie,
     has rating $r;
 sort $r; limit 10;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected =
-        typeql_match!(var("x").isa("movie").has(("rating", var("r")))).sort("r").limit(10);
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("x").isa("movie").has(("rating", var("r")))?).sort("r").limit(10)
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -434,11 +488,14 @@ $x isa movie,
     has rating $r;
 sort $r desc; offset 10; limit 10;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").isa("movie").has(("rating", var("r"))))
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("x").isa("movie").has(("rating", var("r")))?)
         .sort([("r", "desc")])
         .offset(10)
-        .limit(10);
+        .limit(10)
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -450,8 +507,11 @@ $y isa movie,
     has title $n;
 offset 2; limit 4;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("y").isa("movie").has(("title", var("n")))).offset(2).limit(4);
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var("y").isa("movie").has(("title", var("n")))?).offset(2).limit(4)
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -465,7 +525,7 @@ $y "crime";
 $z sub production;
 has-genre relates $p;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(
         rel((var("p"), var("x"))).rel("y"),
         var("x").isa(var("z")),
@@ -483,7 +543,7 @@ fn test_parse_relates_type_variable() {
 $x isa $type;
 $type relates someRole;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").isa(var("type")), var("type").relates("someRole"));
 
     assert_query_eq!(expected, parsed, query);
@@ -500,7 +560,7 @@ $x isa movie;
     $x "The Muppets";
 };"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(
         var("x").isa("movie"),
         or!(and!(var("y").eq("drama").isa("genre"), rel("x").rel("y")), var("x").eq("The Muppets"))
@@ -536,17 +596,19 @@ $y isa $p;
     };
 };"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(
-        var("y").isa(var("p")),
-        or!(
-            rel("y").rel("q"),
-            and!(
-                var("x").isa(var("p")),
-                or!(var("x").has(("first-name", var("y"))), var("x").has(("last-name", var("z"))))
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(
+            var("y").isa(var("p")),
+            or!(
+                rel("y").rel("q"),
+                and!(
+                    var("x").isa(var("p")),
+                    or!(var("x").has(("first-name", var("y")))?, var("x").has(("last-name", var("z")))?)
+                )
             )
         )
-    );
+    }.unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -567,7 +629,9 @@ fn test_aggregate_count_query() {
             "get $x, $y;\n" +
             "count;";
     let parsed = parse_query(query).unwrapAggregate();
-    let expected = typeql_match!(rel("x").rel("y").isa("friendship")).get("x", "y").count();
+    let expected = try_! {
+    typeql_match!(rel("x").rel("y").isa("friendship")).get("x", "y").count()
+};
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -579,7 +643,9 @@ fn test_aggregate_group_count_query() {
             "get $x, $y;\n" +
             "group $x; count;";
     let parsed = parse_query(query).unwrapGroupAggregate();
-    let expected = typeql_match!(rel("x").rel("y").isa("friendship")).get("x", "y").group("x").count();
+    let expected = try_! {
+    typeql_match!(rel("x").rel("y").isa("friendship")).get("x", "y").group("x").count()
+};
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -590,7 +656,9 @@ fn test_single_line_group_aggregate_max_query() {
             "$x has age $a;\n" +
             "group $x; max $a;";
     let parsed = parse_query(query).unwrapGroupAggregate();
-    let expected = typeql_match!(var("x").has(("age", var("a")))).group("x").max("a");
+    let expected = try_! {
+    typeql_match!(var("x").has(("age", var("a")))).group("x").max("a")
+};
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -602,10 +670,12 @@ fn test_multi_line_group_aggregate_max_query() {
             "$y has age $z;\n" +
             "group $x; max $z;";
     let parsed = parse_query(query).unwrapGroupAggregate();
-    let expected = typeql_match!(
+    let expected = try_! {
+    typeql_match!(
             rel("x").rel("y").isa("friendship"),
             var("y").has(("age", var("z")))
-    ).group("x").max("z");
+    ).group("x").max("z")
+};
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -618,10 +688,12 @@ fn test_multi_line_filtered_group_aggregate_max_query() {
             "get $x, $y, $z;\n" +
             "group $x; max $z;";
     let parsed = parse_query(query).unwrapGroupAggregate();
-    let expected = typeql_match!(
+    let expected = try_! {
+    typeql_match!(
             rel("x").rel("y").isa("friendship"),
             var("y").has(("age", var("z")))
-    ).get("x", "y", "z").group("x").max("z");
+    ).get("x", "y", "z").group("x").max("z")
+};
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -633,20 +705,24 @@ fn when_comparing_count_query_using_typeql_and_java_typeql_they_are_equivalent()
             "    has title \"Godfather\";\n" +
             "count;";
     let parsed = parse_query(query).unwrapAggregate();
-    let expected = typeql_match!(var("x").isa("movie").has(("title", "Godfather"))).count();
+    let expected = try_! {
+    typeql_match!(var("x").isa("movie").has(("title", "Godfather"))).count()
+};
 
     assert_query_eq!(expected, parsed, query);
 }
 */
-
 #[test]
 fn test_insert_query() {
     let query = r#"insert
 $_ isa movie,
     has title "The Title";"#;
 
-    let parsed = parse_query(query).map(Query::into_insert);
-    let expected = typeql_insert!(var(()).isa("movie").has(("title", "The Title")));
+    let parsed = parse_query(query).unwrap().into_insert();
+    let expected = try_! {
+        typeql_insert!(var(()).isa("movie").has(("title", "The Title"))?)
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -661,10 +737,12 @@ delete
 $x isa movie;
 $y isa movie;"#;
 
-    let parsed = parse_query(query).map(Query::into_delete);
-    let expected =
-        typeql_match!(var("x").isa("movie").has(("title", "The Title")), var("y").isa("movie"))
-            .delete([var("x").isa("movie"), var("y").isa("movie")]);
+    let parsed = parse_query(query).unwrap().into_delete();
+    let expected = try_! {
+        typeql_match!(var("x").isa("movie").has(("title", "The Title"))?, var("y").isa("movie"))
+        .delete([var("x").isa("movie"), var("y").isa("movie")])
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -681,14 +759,17 @@ $z isa pokemon,
 (evolves-from: $x, evolves-to: $y) isa evolution;
 (evolves-from: $y, evolves-to: $z) isa evolution;"#;
 
-    let parsed = parse_query(query).map(Query::into_insert);
-    let expected = typeql_insert!(
-        var("x").isa("pokemon").has(("name", "Pichu")),
-        var("y").isa("pokemon").has(("name", "Pikachu")),
-        var("z").isa("pokemon").has(("name", "Raichu")),
-        rel(("evolves-from", "x")).rel(("evolves-to", "y")).isa("evolution"),
-        rel(("evolves-from", "y")).rel(("evolves-to", "z")).isa("evolution")
-    );
+    let parsed = parse_query(query).unwrap().into_insert();
+    let expected = try_! {
+        typeql_insert!(
+            var("x").isa("pokemon").has(("name", "Pichu"))?,
+            var("y").isa("pokemon").has(("name", "Pikachu"))?,
+            var("z").isa("pokemon").has(("name", "Raichu"))?,
+            rel(("evolves-from", "x")).rel(("evolves-to", "y")).isa("evolution"),
+            rel(("evolves-from", "y")).rel(("evolves-to", "z")).isa("evolution")
+        )
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -704,11 +785,14 @@ $x has $a;
 insert
 $x has age 25;"#;
 
-    let parsed = parse_query(query).map(Query::into_update);
-    let expected =
-        typeql_match!(var("x").isa("person").has(("name", "alice")).has(("age", var("a"))))
-            .delete(var("x").has(var("a")))
-            .insert(var("x").has(("age", 25)));
+    let parsed = parse_query(query).unwrap().into_update();
+    let expected = try_! {
+        typeql_match!(var("x").isa("person").has(("name", "alice"))?.has(("age", var("a")))?)
+            .delete(var("x").has(var("a"))?)
+            .insert(var("x").has(("age", 25))?)
+    }
+    .unwrap();
+
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -748,7 +832,7 @@ $f sub parenthood,
     relates father as parent,
     relates son as child;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("f")
         .sub("parenthood")
         .relates(("father", "parent"))
@@ -880,8 +964,11 @@ $x isa language;
 insert
 $x has name "HELLO";"#;
 
-    let parsed = parse_query(query).map(Query::into_insert);
-    let expected = typeql_match!(var("x").isa("language")).insert(var("x").has(("name", "HELLO")));
+    let parsed = parse_query(query).unwrap().into_insert();
+    let expected = try_! {
+        typeql_match!(var("x").isa("language")).insert(var("x").has(("name", "HELLO"))?)
+    }
+    .unwrap();
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -905,13 +992,14 @@ fn test_define_abstract_entity_query() {
 #[test]
 fn test_match_value_type_query() {
     let query = "match\n$x value double;";
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").value(TypeQLArg.ValueType.DOUBLE));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+    typeql_match!(var("x").value(TypeQLArg.ValueType.DOUBLE))
+};
 
     assert_query_eq!(expected, parsed, query);
 }
  */
-
 // #[test]
 fn test_parse_without_var() {
     let query = r#"match
@@ -919,7 +1007,7 @@ $_ isa person;"#;
 
     let parsed = parse_query(query); // todo error
     assert!(parsed.is_err());
-    let built = typeql_match!(var(()).isa("person")); // todo error
+    let built = try_! { typeql_match!(var(()).isa("person")) }; // todo error
     assert!(built.is_err());
 }
 
@@ -928,7 +1016,9 @@ $_ isa person;"#;
 fn when_parsing_date_keyword_parse_as_the_correct_value_type() {
     let query = "match\n$x value datetime;";
     let parsed = parse_query(query).asMatch();
-    let expected = typeql_match!(var("x").value(TypeQLArg.ValueType.DATETIME));
+    let expected = try_! {
+    typeql_match!(var("x").value(TypeQLArg.ValueType.DATETIME))
+};
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -944,7 +1034,6 @@ fn test_define_value_type_query() {
     assert_query_eq!(expected, parsed, query);
 }
 */
-
 #[test]
 fn test_escape_string() {
     // ANTLR will see this as a string that looks like:
@@ -958,9 +1047,8 @@ $_ isa movie,
         input
     );
 
-    let parsed = parse_query(&query).map(Query::into_insert);
-    let expected = typeql_insert!(var(()).isa("movie").has(("title", input)));
-
+    let parsed = parse_query(&query).unwrap().into_insert();
+    let expected = try_! { typeql_insert!(var(()).isa("movie").has(("title", input))?) }.unwrap();
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -972,7 +1060,9 @@ fn when_parsing_query_with_comments_they_are_ignored() {
     let uncommented = "match\n$x isa movie;\ncount;";
 
     let parsed = parse_query(query).asMatchAggregate();
-    let expected = typeql_match!(var("x").isa("movie")).count();
+    let expected = try_! {
+    typeql_match!(var("x").isa("movie")).count()
+};
 
     assert_query_eq!(expected, parsed, uncommented);
 }
@@ -1015,15 +1105,13 @@ fn test_define_rules() {
     assert_query_eq!(expected, parsed, query.replace("'", "\""));
 }
 */
-
 #[test]
 fn test_parse_boolean() {
     let query = r#"insert
 $_ has flag true;"#;
 
-    let parsed = parse_query(query).map(Query::into_insert);
-    let expected = typeql_insert!(var(()).has(("flag", true)));
-
+    let parsed = parse_query(query).unwrap().into_insert();
+    let expected = try_! { typeql_insert!(var(()).has(("flag", true))?) }.unwrap();
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -1034,7 +1122,9 @@ fn test_parse_aggregate_group() {
             "$x isa movie;\n" +
             "group $x;";
     let parsed = parse_query(query).asMatchGroup();
-    let expected = typeql_match!(var("x").isa("movie")).group("x");
+    let expected = try_! {
+    typeql_match!(var("x").isa("movie")).group("x")
+};
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -1045,7 +1135,9 @@ fn test_parse_aggregate_group_count() {
             "$x isa movie;\n" +
             "group $x; count;";
     let parsed = parse_query(query).asMatchGroupAggregate();
-    let expected = typeql_match!(var("x").isa("movie")).group("x").count();
+    let expected = try_! {
+    typeql_match!(var("x").isa("movie")).group("x").count()
+};
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -1056,7 +1148,9 @@ fn test_parse_aggregate_std() {
             "$x isa movie;\n" +
             "std $x;";
     let parsed = parse_query(query).asMatchAggregate();
-    let expected = typeql_match!(var("x").isa("movie")).std("x");
+    let expected = try_! {
+    typeql_match!(var("x").isa("movie")).std("x")
+};
 
     assert_query_eq!(expected, parsed, query);
 }
@@ -1070,10 +1164,9 @@ fn test_parse_aggregate_to_string() {
     assertEquals(query, parse_query(query).toString());
 }
 */
-
 #[test]
 fn when_parse_incorrect_syntax_throw_typeql_syntax_exception_with_helpful_error() {
-    let parsed = parse_query("match\n$x isa").map(Query::into_match);
+    let parsed = parse_query("match\n$x isa");
     assert!(parsed.is_err());
     let message = parsed.unwrap_err();
     assert!(message.contains("syntax error"));
@@ -1084,7 +1177,7 @@ fn when_parse_incorrect_syntax_throw_typeql_syntax_exception_with_helpful_error(
 
 #[test]
 fn when_parse_incorrect_syntax_trailing_query_whitespace_is_ignored() {
-    let parsed = parse_query("match\n$x isa \n").map(Query::into_match);
+    let parsed = parse_query("match\n$x isa \n");
     assert!(parsed.is_err());
     let message = parsed.unwrap_err();
     assert!(message.contains("syntax error"));
@@ -1095,7 +1188,7 @@ fn when_parse_incorrect_syntax_trailing_query_whitespace_is_ignored() {
 
 #[test]
 fn when_parse_incorrect_syntax_error_message_should_retain_whitespace() {
-    let parsed = parse_query("match\n$x isa ").map(Query::into_match);
+    let parsed = parse_query("match\n$x isa ");
     assert!(parsed.is_err());
     let message = parsed.unwrap_err();
     assert!(!message.contains("match$xisa")); // FIXME bizarre thing to test?
@@ -1103,7 +1196,7 @@ fn when_parse_incorrect_syntax_error_message_should_retain_whitespace() {
 
 #[test]
 fn test_syntax_error_pointer() {
-    let parsed = parse_query("match\n$x of").map(Query::into_match);
+    let parsed = parse_query("match\n$x of");
     assert!(parsed.is_err());
     let message = parsed.unwrap_err();
     assert!(message.contains("\n$x of"));
@@ -1116,10 +1209,11 @@ fn test_has_variable() {
 $_ has title "Godfather",
     has tmdb-vote-count $x;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected =
-        typeql_match!(var(()).has(("title", "Godfather")).has(("tmdb-vote-count", var("x"))));
-
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! {
+        typeql_match!(var(()).has(("title", "Godfather"))?.has(("tmdb-vote-count", var("x")))?)
+    }
+    .unwrap();
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -1128,9 +1222,8 @@ fn test_regex_attribute_type() {
     let query = r#"match
 $x regex "(fe)?male";"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").regex("(fe)?male"));
-
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -1145,9 +1238,8 @@ fn test_parse_key() {
 $x owns name @key;
 get $x;"#;
 
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").owns(("name", KEY))).get(["x"]);
-
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -1163,7 +1255,9 @@ fn test_parse_list_one_match() {
 $y isa movie;"#;
 
     let parsed = parse_queries(queries).collect();  // TODO parse_queries -> Iter
-    let expected = vec![typeql_match!(var("y").isa("movie"))];
+    let expected = vec![try_! {
+    typeql_match!(var("y").isa("movie"))]
+};
 
     assert_eq!(parsed, expected);
 }
@@ -1199,7 +1293,9 @@ fn test_parse_list() {
     let match_string = "match\n$y isa movie;";
     let queries = parse_queries(insert_string + match_string).collect();
 
-    assertEquals(list(insert(var("x").isa("movie")), typeql_match!(var("y").isa("movie"))), queries);
+    assertEquals(list(insert(var("x").isa("movie")), try_! {
+    typeql_match!(var("y").isa("movie"))), queries)
+};
 }
 
 #[test]
@@ -1212,7 +1308,9 @@ fn test_parse_many_match_insert_without_stack_overflow() {
     }
 
     let parsed = parse_queries(long_query).collect();
-    let expected = typeql_match!(var("x").isa("person")).insert(var("x").has(("name", "bob")));
+    let expected = try_! {
+    typeql_match!(var("x").isa("person")).insert(var("x").has(("name", "bob")))
+};
 
     assert_eq!(vec![expected; num_queries], parsed);
 }
@@ -1221,7 +1319,6 @@ fn test_parse_many_match_insert_without_stack_overflow() {
 #[test]
 fn when_parsing_list_of_queries_with_syntax_error_report_error() {
     let query_text = "define\nperson sub entity has name;"; // note no comma
-
     let parsed = parse_query(query_text);
     assert!(parsed.is_err());
     assert!(parsed.err().unwrap().contains("\nperson sub entity has name;"));
@@ -1274,18 +1371,17 @@ fn define_attribute_type_regex() {
 #[test]
 fn undefine_attribute_type_regex() {
     let query = "undefine\ndigit regex '\\d';";
-    let parsed = parse_query(query).map(Query::into_match);
+    let parsed = parse_query(query).unwrap().into_match();
     let expected = undefine(type_("digit").regex("\\d"));
     assert_query_eq!(expected, parsed, query.replace("'", "\""));
 }
 */
-
 #[test]
 fn regex_predicate_parses_character_classes_correctly() {
     let query = r#"match
 $x like "\d";"#;
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").like("\\d"));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! { typeql_match!(var("x").like("\\d")?) }.unwrap();
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -1293,8 +1389,8 @@ $x like "\d";"#;
 fn regex_predicate_parses_quotes_correctly() {
     let query = r#"match
 $x like "\"";"#;
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").like("\\\""));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! { typeql_match!(var("x").like("\\\"")?) }.unwrap();
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -1302,8 +1398,8 @@ $x like "\"";"#;
 fn regex_predicate_parses_backslashes_correctly() {
     let query = r#"match
 $x like "\\";"#;
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").like("\\\\"));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! { typeql_match!(var("x").like("\\\\")?) }.unwrap();
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -1311,8 +1407,8 @@ $x like "\\";"#;
 fn regex_predicate_parses_newline_correctly() {
     let query = r#"match
 $x like "\n";"#;
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").like("\\n"));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! { typeql_match!(var("x").like("\\n")?) }.unwrap();
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -1320,16 +1416,18 @@ $x like "\n";"#;
 fn regex_predicate_parses_forward_slashes_correctly() {
     let query = r#"match
 $x like "\/";"#;
-    let parsed = parse_query(query).map(Query::into_match);
-    let expected = typeql_match!(var("x").like("/"));
+    let parsed = parse_query(query).unwrap().into_match();
+    let expected = try_! { typeql_match!(var("x").like("/")?) }.unwrap();
     assert_query_eq!(expected, parsed, query);
 }
 
 #[test]
 fn when_value_equality_to_string_create_valid_query_string() {
-    // TODO no unwraps
-    let expected = typeql_match!(var("x").eq(var("y"))).unwrap();
-    let parsed = parse_query(&expected.to_string()).map(Query::into_match).unwrap();
+    let expected = try_! {
+        typeql_match!(var("x").eq(var("y")))
+    }
+    .unwrap();
+    let parsed = parse_query(&expected.to_string()).unwrap().into_match();
 
     assert_eq!(expected, parsed);
 }
@@ -1343,8 +1441,8 @@ $x iid {};"#,
         iid
     );
 
-    let parsed = parse_query(&query).map(Query::into_match);
-    let expected = typeql_match!(var("x").iid(iid));
+    let parsed = parse_query(&query).unwrap().into_match();
+    let expected = try_! { typeql_match!(var("x").iid(iid)?) }.unwrap();
     assert_query_eq!(expected, parsed, query);
 }
 
@@ -1357,13 +1455,13 @@ $x iid {};"#,
         iid
     );
 
-    let parsed = parse_query(&query).map(Query::into_match);
+    let parsed = parse_query(&query);
     assert!(parsed.is_err());
 }
 
 #[test]
 fn when_building_invalid_iid_throw() {
     let iid = "invalid";
-    let expected = typeql_match!(var("x").iid(iid));
+    let expected = try_! { typeql_match!(var("x").iid(iid)?) };
     assert!(expected.is_err());
 }

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -22,9 +22,8 @@
 
 use crate::{
     and, gte, lt, lte, not, or, parse_query, rel, try_, type_, typeql_insert, typeql_match, var,
-    ConceptVariableBuilder, Conjunction, DeleteQueryBuilder, Disjunction, ErrorMessage,
-    InsertQueryBuilder, MatchQueryBuilder, Query, RelationVariableBuilder, ThingVariableBuilder,
-    TypeQLInsert, TypeQLMatch, TypeVariableBuilder, UpdateQueryBuilder, KEY,
+    ConceptVariableBuilder, Conjunction, Disjunction, ErrorMessage, Query, RelationVariableBuilder,
+    ThingVariableBuilder, TypeQLInsert, TypeQLMatch, TypeVariableBuilder, KEY,
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 

--- a/rust/pattern/conjunction.rs
+++ b/rust/pattern/conjunction.rs
@@ -56,28 +56,6 @@ impl<T: Into<Pattern>> From<Vec<T>> for Conjunction {
     }
 }
 
-impl<T: Into<Pattern>, E> TryFrom<Result<T, E>> for Conjunction
-where
-    ErrorMessage: From<E>,
-{
-    type Error = ErrorMessage;
-
-    fn try_from(value: Result<T, E>) -> Result<Self, Self::Error> {
-        Ok(Self::from(value?))
-    }
-}
-
-impl<T: Into<Pattern>, const N: usize, E> TryFrom<[Result<T, E>; N]> for Conjunction
-where
-    ErrorMessage: From<E>,
-{
-    type Error = ErrorMessage;
-
-    fn try_from(patterns: [Result<T, E>; N]) -> Result<Self, Self::Error> {
-        Ok(Self::from(patterns.into_iter().collect::<Result<Vec<T>, E>>()?))
-    }
-}
-
 impl fmt::Display for Conjunction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("{\n")?;

--- a/rust/pattern/constraint/thing/has.rs
+++ b/rust/pattern/constraint/thing/has.rs
@@ -48,11 +48,11 @@ where
     fn try_from((type_name, value): (S, T)) -> Result<Self, Self::Error> {
         Ok(match value.try_into()? {
             Value::Variable(variable) => HasConstraint {
-                type_: Some(UnboundVariable::hidden().type_(type_name.into()).unwrap()),
+                type_: Some(UnboundVariable::hidden().type_(type_name.into())),
                 attribute: *variable,
             },
             value => HasConstraint {
-                type_: Some(UnboundVariable::hidden().type_(type_name.into()).unwrap()),
+                type_: Some(UnboundVariable::hidden().type_(type_name.into())),
                 attribute: UnboundVariable::hidden()
                     .constrain_value(ValueConstraint::new(Predicate::Eq, value)?),
             },
@@ -65,7 +65,7 @@ impl<S: Into<String>> TryFrom<(S, ValueConstraint)> for HasConstraint {
 
     fn try_from((type_name, value): (S, ValueConstraint)) -> Result<Self, Self::Error> {
         Ok(HasConstraint {
-            type_: Some(UnboundVariable::hidden().type_(type_name.into()).unwrap()),
+            type_: Some(UnboundVariable::hidden().type_(type_name.into())),
             attribute: UnboundVariable::hidden().constrain_value(value),
         })
     }
@@ -78,7 +78,7 @@ impl<S: Into<String>> TryFrom<(S, Result<ValueConstraint, ErrorMessage>)> for Ha
         (type_name, value): (S, Result<ValueConstraint, ErrorMessage>),
     ) -> Result<Self, Self::Error> {
         Ok(HasConstraint {
-            type_: Some(UnboundVariable::hidden().type_(type_name.into()).unwrap()),
+            type_: Some(UnboundVariable::hidden().type_(type_name.into())),
             attribute: UnboundVariable::hidden().constrain_value(value?),
         })
     }
@@ -87,7 +87,7 @@ impl<S: Into<String>> TryFrom<(S, Result<ValueConstraint, ErrorMessage>)> for Ha
 impl HasConstraint {
     pub fn new((type_name, value_constraint): (String, ValueConstraint)) -> Self {
         HasConstraint {
-            type_: Some(UnboundVariable::hidden().type_(type_name).unwrap()),
+            type_: Some(UnboundVariable::hidden().type_(type_name)),
             attribute: UnboundVariable::hidden().constrain_value(value_constraint),
         }
     }

--- a/rust/pattern/constraint/thing/isa.rs
+++ b/rust/pattern/constraint/thing/isa.rs
@@ -40,13 +40,13 @@ impl IsaConstraint {
 
 impl<T: Into<Label>> From<T> for IsaConstraint {
     fn from(type_name: T) -> Self {
-        IsaConstraint::new(UnboundVariable::hidden().type_(type_name).unwrap(), IsExplicit::No)
+        IsaConstraint::new(UnboundVariable::hidden().type_(type_name), IsExplicit::No)
     }
 }
 
 impl<T: Into<Label>> From<(T, IsExplicit)> for IsaConstraint {
     fn from((type_name, is_explicit): (T, IsExplicit)) -> Self {
-        IsaConstraint::new(UnboundVariable::hidden().type_(type_name).unwrap(), is_explicit)
+        IsaConstraint::new(UnboundVariable::hidden().type_(type_name), is_explicit)
     }
 }
 

--- a/rust/pattern/constraint/thing/relation.rs
+++ b/rust/pattern/constraint/thing/relation.rs
@@ -107,13 +107,13 @@ impl From<UnboundVariable> for RolePlayerConstraint {
 
 impl From<(String, UnboundVariable)> for RolePlayerConstraint {
     fn from((role_type, player_var): (String, UnboundVariable)) -> Self {
-        Self::from((UnboundVariable::hidden().type_(role_type).unwrap(), player_var))
+        Self::from((UnboundVariable::hidden().type_(role_type), player_var))
     }
 }
 
 impl From<(Label, UnboundVariable)> for RolePlayerConstraint {
     fn from((role_type, player_var): (Label, UnboundVariable)) -> Self {
-        Self::from((UnboundVariable::hidden().type_(role_type).unwrap(), player_var))
+        Self::from((UnboundVariable::hidden().type_(role_type), player_var))
     }
 }
 

--- a/rust/pattern/constraint/type_/owns.rs
+++ b/rust/pattern/constraint/type_/owns.rs
@@ -89,7 +89,7 @@ impl From<(String, IsKeyAttribute)> for OwnsConstraint {
 
 impl From<(Label, IsKeyAttribute)> for OwnsConstraint {
     fn from((attribute_type, is_key): (Label, IsKeyAttribute)) -> Self {
-        OwnsConstraint::from((UnboundVariable::hidden().type_(attribute_type).unwrap(), is_key))
+        OwnsConstraint::from((UnboundVariable::hidden().type_(attribute_type), is_key))
     }
 }
 

--- a/rust/pattern/constraint/type_/plays.rs
+++ b/rust/pattern/constraint/type_/plays.rs
@@ -37,9 +37,7 @@ impl PlaysConstraint {
     fn new(role_type: TypeVariable, overridden_role_type: Option<TypeVariable>) -> Self {
         PlaysConstraint {
             relation_type: role_type.label.as_ref().map(|label| {
-                UnboundVariable::hidden()
-                    .type_(label.label.scope.as_ref().cloned().unwrap())
-                    .unwrap()
+                UnboundVariable::hidden().type_(label.label.scope.as_ref().cloned().unwrap())
             }),
             role_type,
             overridden_role_type,
@@ -61,7 +59,7 @@ impl From<(String, String)> for PlaysConstraint {
 
 impl From<Label> for PlaysConstraint {
     fn from(scoped_type: Label) -> Self {
-        PlaysConstraint::new(UnboundVariable::hidden().type_(scoped_type).unwrap(), None)
+        PlaysConstraint::new(UnboundVariable::hidden().type_(scoped_type), None)
     }
 }
 

--- a/rust/pattern/constraint/type_/relates.rs
+++ b/rust/pattern/constraint/type_/relates.rs
@@ -47,10 +47,8 @@ impl From<String> for RelatesConstraint {
 impl From<(&str, &str)> for RelatesConstraint {
     fn from((role_type, overridden_role_type): (&str, &str)) -> Self {
         RelatesConstraint {
-            role_type: UnboundVariable::hidden().type_(role_type).unwrap(),
-            overridden_role_type: Some(
-                UnboundVariable::hidden().type_(overridden_role_type).unwrap(),
-            ),
+            role_type: UnboundVariable::hidden().type_(role_type),
+            overridden_role_type: Some(UnboundVariable::hidden().type_(overridden_role_type)),
         }
     }
 }
@@ -58,7 +56,7 @@ impl From<(&str, &str)> for RelatesConstraint {
 impl From<Label> for RelatesConstraint {
     fn from(type_: Label) -> Self {
         RelatesConstraint {
-            role_type: UnboundVariable::hidden().type_(type_).unwrap(),
+            role_type: UnboundVariable::hidden().type_(type_),
             overridden_role_type: None,
         }
     }

--- a/rust/pattern/constraint/type_/sub.rs
+++ b/rust/pattern/constraint/type_/sub.rs
@@ -32,7 +32,7 @@ pub struct SubConstraint {
 
 impl<T: Into<Label>> From<T> for SubConstraint {
     fn from(scoped_type: T) -> Self {
-        SubConstraint { type_: Box::new(UnboundVariable::hidden().type_(scoped_type).unwrap()) }
+        SubConstraint { type_: Box::new(UnboundVariable::hidden().type_(scoped_type)) }
     }
 }
 

--- a/rust/pattern/label.rs
+++ b/rust/pattern/label.rs
@@ -32,7 +32,7 @@ pub enum Type {
 impl Type {
     pub fn into_type_variable(self) -> TypeVariable {
         match self {
-            Self::Label(label) => UnboundVariable::hidden().type_(label).unwrap(),
+            Self::Label(label) => UnboundVariable::hidden().type_(label),
             Self::Variable(var) => var.into_type(),
         }
     }

--- a/rust/pattern/negation.rs
+++ b/rust/pattern/negation.rs
@@ -46,14 +46,6 @@ impl<T: Into<Variable>> From<T> for Negation {
     }
 }
 
-impl<T: Into<Variable>> TryFrom<Result<T, ErrorMessage>> for Negation {
-    type Error = ErrorMessage;
-
-    fn try_from(variable: Result<T, ErrorMessage>) -> Result<Self, Self::Error> {
-        Ok(Negation { pattern: Box::new(variable?.into().into_pattern()) })
-    }
-}
-
 impl fmt::Display for Negation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {{ {}; }}", Not, self.pattern)

--- a/rust/pattern/variable/builder/concept.rs
+++ b/rust/pattern/variable/builder/concept.rs
@@ -20,24 +20,18 @@
  *
  */
 
-use crate::{pattern::*, ErrorMessage};
+use crate::pattern::*;
 
 pub trait ConceptConstrainable {
     fn constrain_is(self, is: IsConstraint) -> ConceptVariable;
 }
 
 pub trait ConceptVariableBuilder: Sized {
-    fn is(self, is: impl Into<IsConstraint>) -> Result<ConceptVariable, ErrorMessage>;
+    fn is(self, is: impl Into<IsConstraint>) -> ConceptVariable;
 }
 
 impl<U: ConceptConstrainable> ConceptVariableBuilder for U {
-    fn is(self, is: impl Into<IsConstraint>) -> Result<ConceptVariable, ErrorMessage> {
-        Ok(self.constrain_is(is.into()))
-    }
-}
-
-impl<U: ConceptVariableBuilder> ConceptVariableBuilder for Result<U, ErrorMessage> {
-    fn is(self, is: impl Into<IsConstraint>) -> Result<ConceptVariable, ErrorMessage> {
-        self?.is(is)
+    fn is(self, is: impl Into<IsConstraint>) -> ConceptVariable {
+        self.constrain_is(is.into())
     }
 }

--- a/rust/pattern/variable/builder/thing.rs
+++ b/rust/pattern/variable/builder/thing.rs
@@ -42,14 +42,14 @@ pub trait ThingVariableBuilder {
     where
         ErrorMessage: From<<T as TryInto<IIDConstraint>>::Error>;
 
-    fn isa(self, isa: impl Into<IsaConstraint>) -> Result<ThingVariable, ErrorMessage>;
+    fn isa(self, isa: impl Into<IsaConstraint>) -> ThingVariable;
 
-    fn eq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
-    fn neq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
-    fn gt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
-    fn gte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
-    fn lt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
-    fn lte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage>;
+    fn eq(self, value: impl Into<Value>) -> ThingVariable;
+    fn neq(self, value: impl Into<Value>) -> ThingVariable;
+    fn gt(self, value: impl Into<Value>) -> ThingVariable;
+    fn gte(self, value: impl Into<Value>) -> ThingVariable;
+    fn lt(self, value: impl Into<Value>) -> ThingVariable;
+    fn lte(self, value: impl Into<Value>) -> ThingVariable;
     fn contains(self, string: impl Into<String>) -> Result<ThingVariable, ErrorMessage>;
     fn like(self, string: impl Into<String>) -> Result<ThingVariable, ErrorMessage>;
 }
@@ -69,32 +69,32 @@ impl<U: ThingConstrainable> ThingVariableBuilder for U {
         Ok(self.constrain_iid(iid.try_into()?))
     }
 
-    fn isa(self, isa: impl Into<IsaConstraint>) -> Result<ThingVariable, ErrorMessage> {
-        Ok(self.constrain_isa(isa.into()))
+    fn isa(self, isa: impl Into<IsaConstraint>) -> ThingVariable {
+        self.constrain_isa(isa.into())
     }
 
-    fn eq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
-        Ok(self.constrain_value(ValueConstraint::new(Predicate::Eq, value.into())?))
+    fn eq(self, value: impl Into<Value>) -> ThingVariable {
+        self.constrain_value(ValueConstraint::new(Predicate::Eq, value.into()).unwrap())
     }
 
-    fn neq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
-        Ok(self.constrain_value(ValueConstraint::new(Predicate::Neq, value.into())?))
+    fn neq(self, value: impl Into<Value>) -> ThingVariable {
+        self.constrain_value(ValueConstraint::new(Predicate::Neq, value.into()).unwrap())
     }
 
-    fn gt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
-        Ok(self.constrain_value(ValueConstraint::new(Predicate::Gt, value.into())?))
+    fn gt(self, value: impl Into<Value>) -> ThingVariable {
+        self.constrain_value(ValueConstraint::new(Predicate::Gt, value.into()).unwrap())
     }
 
-    fn gte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
-        Ok(self.constrain_value(ValueConstraint::new(Predicate::Gte, value.into())?))
+    fn gte(self, value: impl Into<Value>) -> ThingVariable {
+        self.constrain_value(ValueConstraint::new(Predicate::Gte, value.into()).unwrap())
     }
 
-    fn lt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
-        Ok(self.constrain_value(ValueConstraint::new(Predicate::Lt, value.into())?))
+    fn lt(self, value: impl Into<Value>) -> ThingVariable {
+        self.constrain_value(ValueConstraint::new(Predicate::Lt, value.into()).unwrap())
     }
 
-    fn lte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
-        Ok(self.constrain_value(ValueConstraint::new(Predicate::Lte, value.into())?))
+    fn lte(self, value: impl Into<Value>) -> ThingVariable {
+        self.constrain_value(ValueConstraint::new(Predicate::Lte, value.into()).unwrap())
     }
 
     fn contains(self, string: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
@@ -109,74 +109,16 @@ impl<U: ThingConstrainable> ThingVariableBuilder for U {
     }
 }
 
-impl<U: ThingVariableBuilder> ThingVariableBuilder for Result<U, ErrorMessage> {
-    fn has<T: TryInto<HasConstraint>>(self, has: T) -> Result<ThingVariable, ErrorMessage>
-    where
-        ErrorMessage: From<<T as TryInto<HasConstraint>>::Error>,
-    {
-        self?.has(has)
-    }
-
-    fn iid<T: TryInto<IIDConstraint>>(self, iid: T) -> Result<ThingVariable, ErrorMessage>
-    where
-        ErrorMessage: From<<T as TryInto<IIDConstraint>>::Error>,
-    {
-        self?.iid(iid)
-    }
-
-    fn isa(self, isa: impl Into<IsaConstraint>) -> Result<ThingVariable, ErrorMessage> {
-        self?.isa(isa)
-    }
-
-    fn eq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
-        self?.eq(value)
-    }
-
-    fn neq(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
-        self?.neq(value)
-    }
-
-    fn gt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
-        self?.gt(value)
-    }
-
-    fn gte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
-        self?.gte(value)
-    }
-
-    fn lt(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
-        self?.lt(value)
-    }
-
-    fn lte(self, value: impl Into<Value>) -> Result<ThingVariable, ErrorMessage> {
-        self?.lte(value)
-    }
-
-    fn contains(self, string: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
-        self?.contains(string)
-    }
-
-    fn like(self, string: impl Into<String>) -> Result<ThingVariable, ErrorMessage> {
-        self?.like(string)
-    }
-}
-
 pub trait RelationConstrainable {
     fn constrain_role_player(self, role_player: RolePlayerConstraint) -> ThingVariable;
 }
 
 pub trait RelationVariableBuilder {
-    fn rel(self, value: impl Into<RolePlayerConstraint>) -> Result<ThingVariable, ErrorMessage>;
+    fn rel(self, value: impl Into<RolePlayerConstraint>) -> ThingVariable;
 }
 
 impl<U: RelationConstrainable> RelationVariableBuilder for U {
-    fn rel(self, value: impl Into<RolePlayerConstraint>) -> Result<ThingVariable, ErrorMessage> {
-        Ok(self.constrain_role_player(value.into()))
-    }
-}
-
-impl<U: RelationVariableBuilder> RelationVariableBuilder for Result<U, ErrorMessage> {
-    fn rel(self, value: impl Into<RolePlayerConstraint>) -> Result<ThingVariable, ErrorMessage> {
-        self?.rel(value)
+    fn rel(self, value: impl Into<RolePlayerConstraint>) -> ThingVariable {
+        self.constrain_role_player(value.into())
     }
 }

--- a/rust/pattern/variable/builder/type_.rs
+++ b/rust/pattern/variable/builder/type_.rs
@@ -20,7 +20,7 @@
  *
  */
 
-use crate::{pattern::*, ErrorMessage};
+use crate::pattern::*;
 
 pub trait TypeConstrainable {
     fn constrain_label(self, label: LabelConstraint) -> TypeVariable;
@@ -32,62 +32,36 @@ pub trait TypeConstrainable {
 }
 
 pub trait TypeVariableBuilder: Sized {
-    fn owns(self, owns: impl Into<OwnsConstraint>) -> Result<TypeVariable, ErrorMessage>;
-    fn plays(self, plays: impl Into<PlaysConstraint>) -> Result<TypeVariable, ErrorMessage>;
-    fn regex(self, regex: impl Into<RegexConstraint>) -> Result<TypeVariable, ErrorMessage>;
-    fn relates(self, relates: impl Into<RelatesConstraint>) -> Result<TypeVariable, ErrorMessage>;
-    fn sub(self, sub: impl Into<SubConstraint>) -> Result<TypeVariable, ErrorMessage>;
-    fn type_(self, type_name: impl Into<Label>) -> Result<TypeVariable, ErrorMessage>;
+    fn owns(self, owns: impl Into<OwnsConstraint>) -> TypeVariable;
+    fn plays(self, plays: impl Into<PlaysConstraint>) -> TypeVariable;
+    fn regex(self, regex: impl Into<RegexConstraint>) -> TypeVariable;
+    fn relates(self, relates: impl Into<RelatesConstraint>) -> TypeVariable;
+    fn sub(self, sub: impl Into<SubConstraint>) -> TypeVariable;
+    fn type_(self, type_name: impl Into<Label>) -> TypeVariable;
 }
 
 impl<U: TypeConstrainable> TypeVariableBuilder for U {
-    fn owns(self, owns: impl Into<OwnsConstraint>) -> Result<TypeVariable, ErrorMessage> {
-        Ok(self.constrain_owns(owns.into()))
+    fn owns(self, owns: impl Into<OwnsConstraint>) -> TypeVariable {
+        self.constrain_owns(owns.into())
     }
 
-    fn plays(self, plays: impl Into<PlaysConstraint>) -> Result<TypeVariable, ErrorMessage> {
-        Ok(self.constrain_plays(plays.into()))
+    fn plays(self, plays: impl Into<PlaysConstraint>) -> TypeVariable {
+        self.constrain_plays(plays.into())
     }
 
-    fn regex(self, regex: impl Into<RegexConstraint>) -> Result<TypeVariable, ErrorMessage> {
-        Ok(self.constrain_regex(regex.into()))
+    fn regex(self, regex: impl Into<RegexConstraint>) -> TypeVariable {
+        self.constrain_regex(regex.into())
     }
 
-    fn relates(self, relates: impl Into<RelatesConstraint>) -> Result<TypeVariable, ErrorMessage> {
-        Ok(self.constrain_relates(relates.into()))
+    fn relates(self, relates: impl Into<RelatesConstraint>) -> TypeVariable {
+        self.constrain_relates(relates.into())
     }
 
-    fn sub(self, sub: impl Into<SubConstraint>) -> Result<TypeVariable, ErrorMessage> {
-        Ok(self.constrain_sub(sub.into()))
+    fn sub(self, sub: impl Into<SubConstraint>) -> TypeVariable {
+        self.constrain_sub(sub.into())
     }
 
-    fn type_(self, type_name: impl Into<Label>) -> Result<TypeVariable, ErrorMessage> {
-        Ok(self.constrain_label(LabelConstraint { label: type_name.into() }))
-    }
-}
-
-impl<U: TypeVariableBuilder> TypeVariableBuilder for Result<U, ErrorMessage> {
-    fn owns(self, owns: impl Into<OwnsConstraint>) -> Result<TypeVariable, ErrorMessage> {
-        self?.owns(owns)
-    }
-
-    fn plays(self, plays: impl Into<PlaysConstraint>) -> Result<TypeVariable, ErrorMessage> {
-        self?.plays(plays)
-    }
-
-    fn regex(self, regex: impl Into<RegexConstraint>) -> Result<TypeVariable, ErrorMessage> {
-        self?.regex(regex)
-    }
-
-    fn relates(self, relates: impl Into<RelatesConstraint>) -> Result<TypeVariable, ErrorMessage> {
-        self?.relates(relates)
-    }
-
-    fn sub(self, sub: impl Into<SubConstraint>) -> Result<TypeVariable, ErrorMessage> {
-        self?.sub(sub)
-    }
-
-    fn type_(self, type_name: impl Into<Label>) -> Result<TypeVariable, ErrorMessage> {
-        self?.type_(type_name)
+    fn type_(self, type_name: impl Into<Label>) -> TypeVariable {
+        self.constrain_label(LabelConstraint { label: type_name.into() })
     }
 }

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -22,7 +22,7 @@
 
 use std::fmt;
 
-use crate::{enum_getter, pattern::*, var, ErrorMessage};
+use crate::{enum_getter, pattern::*, var};
 
 mod typeql_delete;
 pub use typeql_delete::*;

--- a/rust/query/typeql_delete.rs
+++ b/rust/query/typeql_delete.rs
@@ -21,8 +21,8 @@
  */
 
 use crate::{
-    common::token::Command::Delete, write_joined, ErrorMessage, Query, ThingVariable, TypeQLMatch,
-    TypeQLUpdate, UpdateQueryBuilder, Writable,
+    common::token::Command::Delete, write_joined, Query, ThingVariable, TypeQLMatch, TypeQLUpdate,
+    UpdateQueryBuilder, Writable,
 };
 use std::fmt;
 
@@ -48,17 +48,11 @@ impl fmt::Display for TypeQLDelete {
 }
 
 pub trait DeleteQueryBuilder {
-    fn delete(self, vars: impl Writable) -> Result<TypeQLDelete, ErrorMessage>;
-}
-
-impl<U: DeleteQueryBuilder> DeleteQueryBuilder for Result<U, ErrorMessage> {
-    fn delete(self, vars: impl Writable) -> Result<TypeQLDelete, ErrorMessage> {
-        self?.delete(vars)
-    }
+    fn delete(self, vars: impl Writable) -> TypeQLDelete;
 }
 
 impl UpdateQueryBuilder for TypeQLDelete {
-    fn insert(self, vars: impl Writable) -> Result<TypeQLUpdate, ErrorMessage> {
-        Ok(TypeQLUpdate { delete_query: self, insert_variables: vars.vars() })
+    fn insert(self, vars: impl Writable) -> TypeQLUpdate {
+        TypeQLUpdate { delete_query: self, insert_variables: vars.vars() }
     }
 }

--- a/rust/query/typeql_delete.rs
+++ b/rust/query/typeql_delete.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     common::token::Command::Delete, write_joined, Query, ThingVariable, TypeQLMatch, TypeQLUpdate,
-    UpdateQueryBuilder, Writable,
+    Writable,
 };
 use std::fmt;
 
@@ -36,6 +36,10 @@ impl TypeQLDelete {
     pub fn into_query(self) -> Query {
         Query::Delete(self)
     }
+
+    pub fn insert(self, vars: impl Writable) -> TypeQLUpdate {
+        TypeQLUpdate { delete_query: self, insert_variables: vars.vars() }
+    }
 }
 
 impl fmt::Display for TypeQLDelete {
@@ -44,15 +48,5 @@ impl fmt::Display for TypeQLDelete {
         writeln!(f, "{}", Delete)?;
         write_joined!(f, ";\n", self.variables)?;
         f.write_str(";")
-    }
-}
-
-pub trait DeleteQueryBuilder {
-    fn delete(self, vars: impl Writable) -> TypeQLDelete;
-}
-
-impl UpdateQueryBuilder for TypeQLDelete {
-    fn insert(self, vars: impl Writable) -> TypeQLUpdate {
-        TypeQLUpdate { delete_query: self, insert_variables: vars.vars() }
     }
 }

--- a/rust/query/typeql_insert.rs
+++ b/rust/query/typeql_insert.rs
@@ -21,8 +21,7 @@
  */
 
 use crate::{
-    common::token::Command::Insert, write_joined, ErrorMessage, Query, ThingVariable, TypeQLMatch,
-    Writable,
+    common::token::Command::Insert, write_joined, Query, ThingVariable, TypeQLMatch, Writable,
 };
 use std::fmt;
 
@@ -55,11 +54,5 @@ impl fmt::Display for TypeQLInsert {
 }
 
 pub trait InsertQueryBuilder {
-    fn insert(self, vars: impl Writable) -> Result<TypeQLInsert, ErrorMessage>;
-}
-
-impl<U: InsertQueryBuilder> InsertQueryBuilder for Result<U, ErrorMessage> {
-    fn insert(self, vars: impl Writable) -> Result<TypeQLInsert, ErrorMessage> {
-        self?.insert(vars)
-    }
+    fn insert(self, vars: impl Writable) -> TypeQLInsert;
 }

--- a/rust/query/typeql_insert.rs
+++ b/rust/query/typeql_insert.rs
@@ -20,9 +20,7 @@
  *
  */
 
-use crate::{
-    common::token::Command::Insert, write_joined, Query, ThingVariable, TypeQLMatch, Writable,
-};
+use crate::{common::token::Command::Insert, write_joined, Query, ThingVariable, TypeQLMatch};
 use std::fmt;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -51,8 +49,4 @@ impl fmt::Display for TypeQLInsert {
         write_joined!(f, ";\n", self.variables)?;
         f.write_str(";")
     }
-}
-
-pub trait InsertQueryBuilder {
-    fn insert(self, vars: impl Writable) -> TypeQLInsert;
 }

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -52,24 +52,6 @@ pub trait MatchQueryBuilder {
     fn offset(self, offset: usize) -> Self;
 }
 
-impl<U: MatchQueryBuilder> MatchQueryBuilder for Result<U, ErrorMessage> {
-    fn get<T: Into<String>, const N: usize>(self, vars: [T; N]) -> Self {
-        Ok(self?.get(vars))
-    }
-
-    fn sort(self, sorting: impl Into<Sorting>) -> Self {
-        Ok(self?.sort(sorting))
-    }
-
-    fn limit(self, limit: usize) -> Self {
-        Ok(self?.limit(limit))
-    }
-
-    fn offset(self, offset: usize) -> Self {
-        Ok(self?.offset(offset))
-    }
-}
-
 impl MatchQueryBuilder for TypeQLMatch {
     fn get<T: Into<String>, const N: usize>(self, vars: [T; N]) -> Self {
         self.filter(vars.into_iter().map(|s| UnboundVariable::named(s.into())).collect())
@@ -89,14 +71,14 @@ impl MatchQueryBuilder for TypeQLMatch {
 }
 
 impl InsertQueryBuilder for TypeQLMatch {
-    fn insert(self, vars: impl Writable) -> Result<TypeQLInsert, ErrorMessage> {
-        Ok(TypeQLInsert { match_query: Some(self), variables: vars.vars() })
+    fn insert(self, vars: impl Writable) -> TypeQLInsert {
+        TypeQLInsert { match_query: Some(self), variables: vars.vars() }
     }
 }
 
 impl DeleteQueryBuilder for TypeQLMatch {
-    fn delete(self, vars: impl Writable) -> Result<TypeQLDelete, ErrorMessage> {
-        Ok(TypeQLDelete { match_query: self, variables: vars.vars() })
+    fn delete(self, vars: impl Writable) -> TypeQLDelete {
+        TypeQLDelete { match_query: self, variables: vars.vars() }
     }
 }
 

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -43,41 +43,28 @@ impl TypeQLMatch {
     pub fn filter(self, vars: Vec<UnboundVariable>) -> Self {
         TypeQLMatch { modifiers: self.modifiers.filter(vars), ..self }
     }
-}
 
-pub trait MatchQueryBuilder {
-    fn get<T: Into<String>, const N: usize>(self, vars: [T; N]) -> Self;
-    fn sort(self, sorting: impl Into<Sorting>) -> Self;
-    fn limit(self, limit: usize) -> Self;
-    fn offset(self, offset: usize) -> Self;
-}
-
-impl MatchQueryBuilder for TypeQLMatch {
-    fn get<T: Into<String>, const N: usize>(self, vars: [T; N]) -> Self {
+    pub fn get<T: Into<String>, const N: usize>(self, vars: [T; N]) -> Self {
         self.filter(vars.into_iter().map(|s| UnboundVariable::named(s.into())).collect())
     }
 
-    fn sort(self, sorting: impl Into<Sorting>) -> Self {
+    pub fn sort(self, sorting: impl Into<Sorting>) -> Self {
         TypeQLMatch { modifiers: self.modifiers.sort(sorting), ..self }
     }
 
-    fn limit(self, limit: usize) -> Self {
+    pub fn limit(self, limit: usize) -> Self {
         TypeQLMatch { modifiers: self.modifiers.limit(limit), ..self }
     }
 
-    fn offset(self, offset: usize) -> Self {
+    pub fn offset(self, offset: usize) -> Self {
         TypeQLMatch { modifiers: self.modifiers.offset(offset), ..self }
     }
-}
 
-impl InsertQueryBuilder for TypeQLMatch {
-    fn insert(self, vars: impl Writable) -> TypeQLInsert {
+    pub fn insert(self, vars: impl Writable) -> TypeQLInsert {
         TypeQLInsert { match_query: Some(self), variables: vars.vars() }
     }
-}
 
-impl DeleteQueryBuilder for TypeQLMatch {
-    fn delete(self, vars: impl Writable) -> TypeQLDelete {
+    pub fn delete(self, vars: impl Writable) -> TypeQLDelete {
         TypeQLDelete { match_query: self, variables: vars.vars() }
     }
 }

--- a/rust/query/typeql_update.rs
+++ b/rust/query/typeql_update.rs
@@ -21,8 +21,7 @@
  */
 
 use crate::{
-    common::token::Command::Insert, write_joined, ErrorMessage, Query, ThingVariable, TypeQLDelete,
-    Writable,
+    common::token::Command::Insert, write_joined, Query, ThingVariable, TypeQLDelete, Writable,
 };
 use std::fmt;
 
@@ -48,11 +47,5 @@ impl fmt::Display for TypeQLUpdate {
 }
 
 pub trait UpdateQueryBuilder {
-    fn insert(self, vars: impl Writable) -> Result<TypeQLUpdate, ErrorMessage>;
-}
-
-impl<U: UpdateQueryBuilder> UpdateQueryBuilder for Result<U, ErrorMessage> {
-    fn insert(self, vars: impl Writable) -> Result<TypeQLUpdate, ErrorMessage> {
-        self?.insert(vars)
-    }
+    fn insert(self, vars: impl Writable) -> TypeQLUpdate;
 }

--- a/rust/query/typeql_update.rs
+++ b/rust/query/typeql_update.rs
@@ -45,7 +45,3 @@ impl fmt::Display for TypeQLUpdate {
         f.write_str(";")
     }
 }
-
-pub trait UpdateQueryBuilder {
-    fn insert(self, vars: impl Writable) -> TypeQLUpdate;
-}

--- a/rust/query/writable.rs
+++ b/rust/query/writable.rs
@@ -20,7 +20,7 @@
  *
  */
 
-use crate::{ErrorMessage, ThingVariable};
+use crate::ThingVariable;
 
 pub trait Writable {
     fn vars(self) -> Vec<ThingVariable>;
@@ -38,20 +38,8 @@ impl<const N: usize> Writable for [ThingVariable; N] {
     }
 }
 
-impl<const N: usize> Writable for [Result<ThingVariable, ErrorMessage>; N] {
-    fn vars(self) -> Vec<ThingVariable> {
-        self.into_iter().map(|x| x.unwrap()).collect()
-    }
-}
-
 impl Writable for Vec<ThingVariable> {
     fn vars(self) -> Vec<ThingVariable> {
         self
-    }
-}
-
-impl<U: Writable> Writable for Result<U, ErrorMessage> {
-    fn vars(self) -> Vec<ThingVariable> {
-        self.unwrap().vars()
     }
 }

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -52,3 +52,12 @@ macro_rules! write_joined {
         result
     }};
 }
+
+#[macro_export]
+macro_rules! try_ {
+    {$($stmt:tt)*} => {
+        || -> Result<_, ErrorMessage> {
+            Ok({$($stmt)*})
+        }()
+    };
+}


### PR DESCRIPTION
## What is the goal of this PR?

We create a macro emulating an unstable [try-blocks feature](https://doc.rust-lang.org/beta/unstable-book/language-features/try-blocks.html) that enables us to restrict the `Result<...>` return type to fallible function calls only. We also remove error propagation through builder functions.

## What are the changes implemented in this PR?

Previously, in order to enable the unit tests, we returned Result from all builder functions and extended the builder functions to `Result<T, E>` as well as `T`. The new `try_!` macro allows us to use the `?` operator directly by wrapping the contents of the macro in an immediately evaluated lambda expression.