### PR TITLE
Introduce unformatted toString

### DIFF
--- a/java/pattern/Conjunction.java
+++ b/java/pattern/Conjunction.java
@@ -123,17 +123,25 @@ public class Conjunction<T extends Pattern> implements Pattern {
     @Override
     public Conjunction<?> asConjunction() { return this; }
 
-    public String toString(boolean isMultiline) {
-        TypeQLToken.Char whitespace = isMultiline ? NEW_LINE : SPACE;
-        String body = patterns.stream().map(Objects::toString).collect(SEMICOLON_NEW_LINE.joiner()) + SEMICOLON;
-        if (isMultiline) body = indent(body);
-        return CURLY_OPEN.toString() + whitespace + body + whitespace + CURLY_CLOSE;
-    }
-
     @Override
     public String toString() {
         return toString(patterns.size() > 1 || patterns.get(0).toString().lines().count() > 1);
     }
+
+    @Override
+    public String toString(boolean pretty) {
+        if (pretty) {
+            TypeQLToken.Char whitespace = NEW_LINE;
+            String body = patterns.stream().map(p -> p.toString(pretty)).collect(SEMICOLON_NEW_LINE.joiner()) + SEMICOLON;
+            body = indent(body);
+            return CURLY_OPEN.toString() + whitespace + body + whitespace + CURLY_CLOSE;
+        } else {
+            TypeQLToken.Char whitespace = SPACE;
+            String body = patterns.stream().map(p -> p.toString(pretty)).collect(SEMICOLON.joiner()) + SEMICOLON;
+            return CURLY_OPEN.toString() + whitespace + body + whitespace + CURLY_CLOSE;
+        }
+    }
+
 
     @Override
     public boolean equals(Object o) {

--- a/java/pattern/Definable.java
+++ b/java/pattern/Definable.java
@@ -46,4 +46,6 @@ public interface Definable {
     default TypeVariable asTypeVariable() {
         throw TypeQLException.of(INVALID_CASTING.message(className(this.getClass()), className(TypeVariable.class)));
     }
+
+    String toString(boolean pretty);
 }

--- a/java/pattern/Disjunction.java
+++ b/java/pattern/Disjunction.java
@@ -22,11 +22,13 @@
 package com.vaticle.typeql.lang.pattern;
 
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
+
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.CURLY_CLOSE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.CURLY_OPEN;
@@ -75,22 +77,37 @@ public class Disjunction<T extends Pattern> implements Pattern {
     }
 
     @Override
-    public boolean isDisjunction() { return true; }
+    public boolean isDisjunction() {
+        return true;
+    }
 
     @Override
-    public Disjunction<?> asDisjunction() { return this; }
+    public Disjunction<?> asDisjunction() {
+        return this;
+    }
 
     @Override
     public String toString() {
+        return toString(true);
+    }
+
+    @Override
+    public String toString(boolean pretty) {
         StringBuilder disjunction = new StringBuilder();
         Iterator<T> patternIter = patterns.iterator();
         while (patternIter.hasNext()) {
             Pattern pattern = patternIter.next();
-            if (pattern.isConjunction()) disjunction.append(pattern.asConjunction().toString(true));
+            if (pattern.isConjunction()) disjunction.append(pattern.asConjunction().toString(pretty));
             else {
-                disjunction.append(CURLY_OPEN).append(NEW_LINE);
-                disjunction.append(indent(pattern.toString() + SEMICOLON));
-                disjunction.append(NEW_LINE).append(CURLY_CLOSE);
+                disjunction.append(CURLY_OPEN);
+                if (pretty) {
+                    disjunction.append(NEW_LINE);
+                    disjunction.append(indent(pattern.toString(pretty) + SEMICOLON));
+                    disjunction.append(NEW_LINE);
+                } else {
+                    disjunction.append(pattern.toString(pretty)).append(SEMICOLON);
+                }
+                disjunction.append(CURLY_CLOSE);
             }
             if (patternIter.hasNext()) disjunction.append(SPACE).append(OR).append(SPACE);
         }

--- a/java/pattern/Negation.java
+++ b/java/pattern/Negation.java
@@ -54,7 +54,9 @@ public class Negation<T extends Pattern> implements Conjunctable {
         this.pattern = pattern;
     }
 
-    public T pattern() { return pattern; }
+    public T pattern() {
+        return pattern;
+    }
 
     @Override
     public List<? extends Pattern> patterns() {
@@ -86,22 +88,30 @@ public class Negation<T extends Pattern> implements Conjunctable {
     }
 
     @Override
-    public boolean isNegation() { return true; }
+    public boolean isNegation() {
+        return true;
+    }
 
     @Override
-    public Negation<?> asNegation() { return this; }
+    public Negation<?> asNegation() {
+        return this;
+    }
 
     @Override
-    public String toString() {
+    public String toString(boolean pretty) {
         StringBuilder negation = new StringBuilder();
         negation.append(TypeQLToken.Operator.NOT).append(SPACE);
 
         if (pattern.isConjunction()) {
-            negation.append(pattern);
-        } else if (pattern.toString().lines().count() > 1) {
-            negation.append(CURLY_OPEN).append(NEW_LINE);
-            negation.append(indent(pattern.toString() + SEMICOLON));
-            negation.append(NEW_LINE).append(CURLY_CLOSE);
+            negation.append(pattern.toString(pretty));
+        } else if (pattern.toString(pretty).lines().count() > 1) {
+            negation.append(CURLY_OPEN);
+            if (pretty) {
+                negation.append(NEW_LINE).append(indent(pattern.toString(pretty) + SEMICOLON)).append(NEW_LINE);
+            } else {
+                negation.append(pattern.toString(pretty)).append(SEMICOLON);
+            }
+            negation.append(CURLY_CLOSE);
         } else {
             negation.append(CURLY_OPEN).append(SPACE);
             negation.append(pattern).append(SEMICOLON);

--- a/java/pattern/Pattern.java
+++ b/java/pattern/Pattern.java
@@ -71,4 +71,6 @@ public interface Pattern {
 
     @Override
     String toString();
+
+    String toString(boolean pretty);
 }

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -171,15 +171,27 @@ public class Rule implements Definable {
 
     @Override
     public String toString() {
+        return toString(true);
+    }
+
+    @Override
+    public String toString(boolean pretty) {
         StringBuilder rule = new StringBuilder("" + RULE + SPACE + label);
         if (when != null) {
-            rule.append(COLON).append(NEW_LINE);
-            StringBuilder body = new StringBuilder();
-            body.append(WHEN).append(SPACE).append(when.toString(true)).append(NEW_LINE);
-            body.append(THEN).append(SPACE).append(CURLY_OPEN).append(NEW_LINE);
-            body.append(indent(then)).append(SEMICOLON);
-            body.append(NEW_LINE).append(CURLY_CLOSE);
-            rule.append(indent(body));
+            if (pretty) {
+                rule.append(COLON).append(NEW_LINE);
+                StringBuilder body = new StringBuilder();
+                body.append(WHEN).append(SPACE).append(when.toString(pretty)).append(NEW_LINE);
+                body.append(THEN).append(SPACE).append(CURLY_OPEN).append(NEW_LINE);
+                body.append(indent(then)).append(SEMICOLON);
+                body.append(NEW_LINE).append(CURLY_CLOSE);
+                rule.append(indent(body));
+            } else {
+                rule.append(COLON);
+                String content = String.valueOf(WHEN) + SPACE + when.toString(pretty) + THEN + SPACE + CURLY_OPEN +
+                        then.toString(true) + SEMICOLON + CURLY_CLOSE;
+                rule.append(content);
+            }
         }
         return rule.toString();
     }

--- a/java/pattern/variable/ConceptVariable.java
+++ b/java/pattern/variable/ConceptVariable.java
@@ -67,7 +67,7 @@ public class ConceptVariable extends BoundVariable {
     }
 
     @Override
-    public String toString() {
+    public String toString(boolean pretty) {
         if (isConstraint == null) return reference.toString();
         return reference.toString() + SPACE + isConstraint;
     }

--- a/java/pattern/variable/ThingVariable.java
+++ b/java/pattern/variable/ThingVariable.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COMMA;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COMMA_NEW_LINE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.SPACE;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.ILLEGAL_CONSTRAINT_REPETITION;
@@ -121,9 +122,6 @@ public abstract class ThingVariable<T extends ThingVariable<T>> extends BoundVar
     }
 
     @Override
-    public abstract String toString();
-
-    @Override
     public final boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || !ThingVariable.class.isAssignableFrom(o.getClass())) return false;
@@ -162,19 +160,23 @@ public abstract class ThingVariable<T extends ThingVariable<T>> extends BoundVar
         }
 
         @Override
-        public String toString() {
+        public String toString(boolean pretty) {
             StringBuilder thing = new StringBuilder();
             if (isVisible()) thing.append(reference.syntax());
-            String constraints = Stream.of(thingSyntax(), hasSyntax())
-                    .filter(s -> !s.isEmpty()).collect(COMMA_NEW_LINE.joiner());
-            constraints = indent(constraints).trim();
+            String constraints;
+            if (pretty) {
+                constraints = Stream.of(thingSyntax(), hasSyntax()).filter(s -> !s.isEmpty()).collect(COMMA_NEW_LINE.joiner());
+                constraints = indent(constraints).trim();
+            } else {
+                constraints = Stream.of(thingSyntax(), hasSyntax()).filter(s -> !s.isEmpty()).collect(COMMA.joiner());
+            }
             if (!constraints.isEmpty()) thing.append(SPACE).append(constraints);
             return thing.toString();
         }
     }
 
     public static class Relation extends ThingVariable<Relation> implements ThingVariableBuilder.Relation,
-                                                                            ThingVariableBuilder.Common<Relation> {
+            ThingVariableBuilder.Common<Relation> {
 
         Relation(Reference reference, ThingConstraint.Relation relationConstraint) {
             super(reference);
@@ -194,14 +196,19 @@ public abstract class ThingVariable<T extends ThingVariable<T>> extends BoundVar
         }
 
         @Override
-        public String toString() {
+        public String toString(boolean pretty) {
             assert relation().isPresent();
             StringBuilder relation = new StringBuilder();
             if (isVisible()) relation.append(reference.syntax()).append(SPACE);
             relation.append(relation().get());
-            String constraints = Stream.of(isaSyntax(), hasSyntax())
-                    .filter(s -> !s.isEmpty()).collect(COMMA_NEW_LINE.joiner());
-            constraints = indent(constraints).trim();
+            String constraints;
+            if (pretty) {
+                constraints = Stream.of(isaSyntax(), hasSyntax())
+                        .filter(s -> !s.isEmpty()).collect(COMMA_NEW_LINE.joiner());
+                constraints = indent(constraints).trim();
+            } else {
+                constraints = Stream.of(isaSyntax(), hasSyntax()).filter(s -> !s.isEmpty()).collect(COMMA.joiner());
+            }
             if (!constraints.isEmpty()) relation.append(SPACE).append(constraints);
             return relation.toString();
         }
@@ -221,14 +228,20 @@ public abstract class ThingVariable<T extends ThingVariable<T>> extends BoundVar
         }
 
         @Override
-        public String toString() {
+        public String toString(boolean pretty) {
             assert value().isPresent();
             StringBuilder attribute = new StringBuilder();
             if (isVisible()) attribute.append(reference.syntax()).append(SPACE);
             attribute.append(value().get());
-            String constraints = Stream.of(isaSyntax(), hasSyntax())
-                    .filter(s -> !s.isEmpty()).collect(COMMA_NEW_LINE.joiner());
-            constraints = indent(constraints).trim();
+            String constraints;
+            if (pretty) {
+                constraints = Stream.of(isaSyntax(), hasSyntax())
+                        .filter(s -> !s.isEmpty()).collect(COMMA_NEW_LINE.joiner());
+                constraints = indent(constraints).trim();
+            } else {
+                constraints = Stream.of(isaSyntax(), hasSyntax())
+                        .filter(s -> !s.isEmpty()).collect(COMMA.joiner());
+            }
             if (!constraints.isEmpty()) attribute.append(SPACE).append(constraints);
             return attribute.toString();
         }

--- a/java/pattern/variable/TypeVariable.java
+++ b/java/pattern/variable/TypeVariable.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.vaticle.typedb.common.collection.Collections.set;
+import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COMMA;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COMMA_NEW_LINE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.SPACE;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.ILLEGAL_CONSTRAINT_REPETITION;
@@ -185,12 +186,17 @@ public class TypeVariable extends BoundVariable implements TypeVariableBuilder, 
     }
 
     @Override
-    public String toString() {
+    public String toString(boolean pretty) {
         StringBuilder syntax = new StringBuilder();
         if (isVisible() || label().isPresent()) {
             syntax.append(isVisible() ? reference.syntax() : label().get().scopedLabel());
             Stream<TypeConstraint> consStream = isVisible() ? constraints.stream() : constraints.stream().skip(1);
-            String consStr = indent(consStream.map(Constraint::toString).collect(COMMA_NEW_LINE.joiner())).trim();
+            String consStr;
+            if (pretty) {
+                consStr = indent(consStream.map(Constraint::toString).collect(COMMA_NEW_LINE.joiner())).trim();
+            } else {
+                consStr = consStream.map(Constraint::toString).collect(COMMA.joiner());
+            }
             if (!consStr.isEmpty()) syntax.append(SPACE).append(consStr);
         } else {
             // This should only be called by debuggers trying to print nested variables
@@ -219,5 +225,7 @@ public class TypeVariable extends BoundVariable implements TypeVariableBuilder, 
     }
 
     @Override
-    public TypeVariable asTypeVariable() { return this; }
+    public TypeVariable asTypeVariable() {
+        return this;
+    }
 }

--- a/java/pattern/variable/UnboundVariable.java
+++ b/java/pattern/variable/UnboundVariable.java
@@ -159,7 +159,7 @@ public class UnboundVariable extends Variable implements ConceptVariableBuilder,
     }
 
     @Override
-    public String toString() {
+    public String toString(boolean pretty) {
         return reference.syntax();
     }
 

--- a/java/pattern/variable/Variable.java
+++ b/java/pattern/variable/Variable.java
@@ -110,7 +110,11 @@ public abstract class Variable {
     }
 
     @Override
-    public abstract String toString();
+    public String toString() {
+        return toString(true);
+    }
+
+    public abstract String toString(boolean pretty);
 
     @Override
     public abstract boolean equals(Object o);

--- a/java/query/TypeQLDefinable.java
+++ b/java/query/TypeQLDefinable.java
@@ -79,9 +79,9 @@ abstract class TypeQLDefinable extends TypeQLQuery {
     }
 
     @Override
-    public final String toString() {
+    public String toString(boolean pretty) {
         StringBuilder query = new StringBuilder();
-        appendSubQuery(query, command, definables);
+        appendSubQuery(query, command, definables.stream().map(d -> d.toString(pretty)), pretty);
         return query.toString();
     }
 

--- a/java/query/TypeQLMatch.java
+++ b/java/query/TypeQLMatch.java
@@ -252,11 +252,11 @@ public class TypeQLMatch extends TypeQLQuery implements Aggregatable<TypeQLMatch
     }
 
     @Override
-    public String toString() {
+    public String toString(boolean pretty) {
         StringBuilder query = new StringBuilder();
-        appendSubQuery(query, MATCH, conjunction.patterns());
+        appendSubQuery(query, MATCH, conjunction.patterns().stream().map(p -> p.toString(pretty)), pretty);
         if (!modifiers.isEmpty()) {
-            query.append(NEW_LINE);
+            if (pretty) query.append(NEW_LINE);
             query.append(modifiers);
         }
         return query.toString();
@@ -435,10 +435,12 @@ public class TypeQLMatch extends TypeQLQuery implements Aggregatable<TypeQLMatch
         }
 
         @Override
-        public final String toString() {
+        public final String toString(boolean pretty) {
             StringBuilder query = new StringBuilder();
-            query.append(match()).append(NEW_LINE).append(method);
-            if (var != null) query.append(SPACE).append(var);
+            query.append(match());
+            if (pretty) query.append(NEW_LINE);
+            query.append(method);
+            if (var != null) query.append(SPACE).append(var.toString(pretty));
             query.append(SEMICOLON);
             return query.toString();
         }
@@ -495,8 +497,9 @@ public class TypeQLMatch extends TypeQLQuery implements Aggregatable<TypeQLMatch
         }
 
         @Override
-        public String toString() {
-            return match().toString() + NEW_LINE + GROUP + SPACE + var + SEMICOLON;
+        public String toString(boolean pretty) {
+            if (pretty) return match().toString(pretty) + NEW_LINE + GROUP + SPACE + var + SEMICOLON;
+            else return match().toString(pretty) + GROUP + SPACE + var + SEMICOLON;
         }
 
         @Override
@@ -555,11 +558,13 @@ public class TypeQLMatch extends TypeQLQuery implements Aggregatable<TypeQLMatch
             }
 
             @Override
-            public final String toString() {
+            public final String toString(boolean pretty) {
                 StringBuilder query = new StringBuilder();
-                query.append(group().match()).append(NEW_LINE);
-                query.append(GROUP).append(SPACE).append(group().var()).append(SEMICOLON).append(SPACE).append(method);
-                if (var != null) query.append(SPACE).append(var);
+                query.append(group().match().toString(pretty));
+                if (pretty) query.append(NEW_LINE);
+                query.append(GROUP).append(SPACE).append(group().var().toString(pretty))
+                        .append(SEMICOLON).append(SPACE).append(method);
+                if (var != null) query.append(SPACE).append(var.toString(pretty));
                 query.append(SEMICOLON);
                 return query.toString();
             }

--- a/java/query/TypeQLQuery.java
+++ b/java/query/TypeQLQuery.java
@@ -26,6 +26,7 @@ import com.vaticle.typeql.lang.common.TypeQLToken;
 import com.vaticle.typeql.lang.common.exception.TypeQLException;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.NEW_LINE;
@@ -109,12 +110,17 @@ public abstract class TypeQLQuery {
         }
     }
 
-    protected void appendSubQuery(StringBuilder query, TypeQLToken.Command command, List<?> elements) {
+    protected void appendSubQuery(StringBuilder query, TypeQLToken.Command command, Stream<String> elements, boolean pretty) {
         query.append(command).append(NEW_LINE);
-        query.append(elements.stream().map(Object::toString).collect(SEMICOLON_NEW_LINE.joiner()));
+        if (pretty) query.append(elements.collect(SEMICOLON_NEW_LINE.joiner()));
+        else query.append(elements.collect(SEMICOLON.joiner()));
         query.append(SEMICOLON);
     }
 
     @Override
-    public abstract String toString();
+    public String toString() {
+        return toString(true);
+    }
+
+    public abstract String toString(boolean pretty);
 }

--- a/java/query/TypeQLUpdate.java
+++ b/java/query/TypeQLUpdate.java
@@ -86,12 +86,12 @@ public class TypeQLUpdate extends TypeQLWritable {
     }
 
     @Override
-    public String toString() {
+    public String toString(boolean pretty) {
         StringBuilder query = new StringBuilder();
-        query.append(match).append(NEW_LINE);
-        appendSubQuery(query, DELETE, deleteVariables);
+        query.append(match.toString(pretty)).append(NEW_LINE);
+        appendSubQuery(query, DELETE, deleteVariables.stream().map(v -> v.toString(pretty)), pretty);
         query.append(NEW_LINE);
-        appendSubQuery(query, INSERT, insertVariables);
+        appendSubQuery(query, INSERT, insertVariables.stream().map(v -> v.toString(pretty)), pretty);
         return query.toString();
     }
 

--- a/java/query/TypeQLWritable.java
+++ b/java/query/TypeQLWritable.java
@@ -79,10 +79,10 @@ public abstract class TypeQLWritable extends TypeQLQuery {
         }
 
         @Override
-        public String toString() {
+        public String toString(boolean pretty) {
             StringBuilder query = new StringBuilder();
-            if (match != null) query.append(match).append(NEW_LINE);
-            appendSubQuery(query, command, variables);
+            if (match != null) query.append(match.toString(pretty)).append(NEW_LINE);
+            appendSubQuery(query, command, variables.stream().map(v -> v.toString(pretty)), pretty);
             return query.toString();
         }
 


### PR DESCRIPTION
## What is the goal of this PR?

We introduce an unformatted `toString` method which will not introduce any indentation or newlines.

This fixes a bug where a user's strings with newlines in them receive indentation in the middle of the attribute. Now, to avoid this visual or downstream effect the API exists to disable newlines and indentation.

## What are the changes implemented in this PR?

* introduce `toString(boolean pretty)` which allows enabling or disabling pretty-printing. This API is available on `Defineable`, `TypeQLQuery`, and `Pattern`, but not `Constraint` since these are very short and don't do any pretty printing themselves.
* the default `toString()` on all objects does do pretty printing when the option is available
