### PR TITLE
Migrate to Factory

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -86,7 +86,7 @@ build:
       filter:
         owner: vaticle
         branch: master
-      image: vaticle-ubuntu-22.04
+      image: vaticle-ubuntu-20.04
       dependencies: [ build, build-dependency ]
       command: |
         export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
@@ -138,7 +138,7 @@ release:
         bazel run --define version=$(cat VERSION) //java/parser:deploy-maven -- release
         bazel run --define version=$(cat VERSION) //java:deploy-maven -- release
     deploy-pip-release:
-      image: vaticle-ubuntu-22.04
+      image: vaticle-ubuntu-20.04
       dependencies: [ deploy-github ]
       command: |
         export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -32,24 +32,24 @@ build:
       owner: vaticle
       branch: master
     dependency-analysis:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel build //... --test_output=errors
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)')
     build-dependency:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
     test-java:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel test //java/common/... --test_output=errors
         bazel test //java/parser/... --test_output=errors
@@ -57,12 +57,12 @@ build:
         bazel test //java/query/... --test_output=errors
         bazel test //java/test/... --test_output=errors
     test-rust:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel test //rust/... --test_output=errors
     #    TODO: enable this
     #    deploy-crate-snapshot:
-    #      image: vaticle-ubuntu-21.04
+    #      image: vaticle-ubuntu-22.04
     #      dependencies: [build, build-dependency]
     #      command: |
     #        export DEPLOY_CRATE_TOKEN=$REPO_CRATES_TOKEN
@@ -71,7 +71,7 @@ build:
       filter:
         owner: vaticle
         branch: master
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [build, build-dependency, test-java]
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
@@ -86,15 +86,9 @@ build:
       filter:
         owner: vaticle
         branch: master
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [ build, build-dependency ]
       command: |
-        pyenv install 3.7.12
-        pyenv global 3.7.12
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.12/lib/python3.7/site-packages/lsb_release.py
-
         export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_PIP_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grammar/python:deploy-pip -- snapshot
@@ -102,7 +96,7 @@ build:
       filter:
         owner: vaticle
         branch: master
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [deploy-maven-snapshot]
       command: |
         sed -i -e "s/TYPEQL_LANG_VERSION_MARKER/$FACTORY_COMMIT/g" java/test/deployment/pom.xml
@@ -114,29 +108,25 @@ release:
     branch: master
   validation:
     validate-dependencies:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: bazel test //:release-validate-deps --test_output=streamed
   deployment:
     deploy-github:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
-        pyenv install -s 3.7.12
-        pyenv global 3.7.12 system
-        pip3 install -U pip
-        pip3 install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
         bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     #    TODO: enable this
     #    deploy-create-release:
-    #      image: vaticle-ubuntu-21.04
+    #      image: vaticle-ubuntu-22.04
     #      dependencies: [ deploy-github ]
     #      command: |
     #        export DEPLOY_CRATE_TOKEN=$REPO_CRATES_TOKEN
     #        bazel run --define version=$(cat VERSION) //grammar/rust:deploy_crate -- release
     deploy-maven-release:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [deploy-github]
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
@@ -148,12 +138,9 @@ release:
         bazel run --define version=$(cat VERSION) //java/parser:deploy-maven -- release
         bazel run --define version=$(cat VERSION) //java:deploy-maven -- release
     deploy-pip-release:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [ deploy-github ]
       command: |
-        pyenv install -s 3.7.12
-        pyenv global 3.7.12 system
-        pip3 install -U pip
         export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
         export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
         bazel run --define version=$(cat VERSION) //grammar/python:deploy-pip -- release

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Grabl](https://grabl.io/api/status/vaticle/typeql/badge.svg)](https://grabl.io/vaticle/typeql)
+[![Factory](https://factory.vaticle.com/api/status/vaticle/typeql/badge.svg)](https://factory.vaticle.com/vaticle/typeql)
 [![GitHub release](https://img.shields.io/github/release/vaticle/typeql.svg)](https://github.com/vaticle/typeql/releases/latest)
 [![Discord](https://img.shields.io/discord/665254494820368395?color=7389D8&label=chat&logo=discord&logoColor=ffffff)](https://vaticle.com/discord)
 [![Discussion Forum](https://img.shields.io/discourse/https/forum.vaticle.com/topics.svg)](https://forum.vaticle.com)

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,19 +21,19 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "de3355aecc62ef65db6e168b5435b9ee390490e0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "4464b506ca469f37d3b696fb2f1eda34061cdaa1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "8400246456704657bfcaacbfac5ef2f6adbd8263", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "17c162fe7135db6988d7ac1ae5416568231c8789", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "69abaf023e1c5837eeeb92d7566e8245dff4bcac", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "a503356d9d22e794393ced5b3d3f014db4189b60", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )


### PR DESCRIPTION
## What is the goal of this PR?

We've migrated our continuous integration for this repo to Vaticle Factory from Grabl.

## What are the changes implemented in this PR?

We've updated:
- dependencies.
- uses of pyenv that are no longer in line with our approach.
- machine definitions from ubuntu 21.04 to 22.04.
