### PR TITLE
Enable disjunctions in rules

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,5 +35,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "17c3764aa3cce285523a566910fe716895f77c35", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "9ce29c4e2ccf0d34186dbd9c9708153490732d76", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -80,25 +80,25 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
     public static final ErrorMessage INVALID_RULE_WHEN_NESTED_NEGATION =
             new ErrorMessage(29, "Rule '%s' 'when' contains a nested negation.");
     public static final ErrorMessage INVALID_RULE_THEN =
-            new ErrorMessage(31, "Rule '%s' 'then' '%s': must be exactly one attribute ownership, or exactly one relation.");
+            new ErrorMessage(30, "Rule '%s' 'then' '%s': must be exactly one attribute ownership, or exactly one relation.");
     public static final ErrorMessage INVALID_RULE_THEN_HAS =
-            new ErrorMessage(32, "Rule '%s' 'then' '%s' tries to assign type '%s' to variable '%s', but this variable already had a type assigned by the rule 'when'. Try omitting this type assignment.");
+            new ErrorMessage(31, "Rule '%s' 'then' '%s' tries to assign type '%s' to variable '%s', but this variable already had a type assigned by the rule 'when'. Try omitting this type assignment.");
     public static final ErrorMessage INVALID_RULE_THEN_VARIABLES =
-            new ErrorMessage(33, "Rule '%s' 'then' variables must be present in the 'when', outside of nested patterns.");
+            new ErrorMessage(32, "Rule '%s' 'then' variables must be present in the 'when', outside of nested patterns.");
     public static final ErrorMessage INVALID_RULE_THEN_ROLES =
-            new ErrorMessage(34, "Rule '%s' 'then' '%s' must specify all role types explicitly or by using a variable.");
+            new ErrorMessage(33, "Rule '%s' 'then' '%s' must specify all role types explicitly or by using a variable.");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =
-            new ErrorMessage(35, "Invalid query containing redundant nested negations.");
+            new ErrorMessage(34, "Invalid query containing redundant nested negations.");
     public static final ErrorMessage VARIABLE_NOT_SORTED =
-            new ErrorMessage(36, "Variable '%s' does not exist in the sorting clause.");
+            new ErrorMessage(35, "Variable '%s' does not exist in the sorting clause.");
     public static final ErrorMessage INVALID_SORTING_ORDER =
-            new ErrorMessage(37, "Invalid sorting order '%s'. Valid options: '%s' or '%s'.");
+            new ErrorMessage(36, "Invalid sorting order '%s'. Valid options: '%s' or '%s'.");
     public static final ErrorMessage INVALID_COUNT_VARIABLE_ARGUMENT =
-            new ErrorMessage(38, "Aggregate COUNT does not accept a Variable.");
+            new ErrorMessage(37, "Aggregate COUNT does not accept a Variable.");
     public static final ErrorMessage ILLEGAL_GRAMMAR =
-            new ErrorMessage(39, "Illegal grammar!");
+            new ErrorMessage(38, "Illegal grammar!");
     public static final ErrorMessage ILLEGAL_CHAR_IN_LABEL =
-            new ErrorMessage(40, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
+            new ErrorMessage(39, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
 
 
     private static final String codePrefix = "TQL";

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -79,14 +79,12 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
             new ErrorMessage(28, "Rule '%s' 'when' has not been provided with any patterns.");
     public static final ErrorMessage INVALID_RULE_WHEN_NESTED_NEGATION =
             new ErrorMessage(29, "Rule '%s' 'when' contains a nested negation.");
-    public static final ErrorMessage INVALID_RULE_WHEN_CONTAINS_DISJUNCTION =
-            new ErrorMessage(30, "Rule '%s' 'when' contains a disjunction.");
     public static final ErrorMessage INVALID_RULE_THEN =
             new ErrorMessage(31, "Rule '%s' 'then' '%s': must be exactly one attribute ownership, or exactly one relation.");
     public static final ErrorMessage INVALID_RULE_THEN_HAS =
             new ErrorMessage(32, "Rule '%s' 'then' '%s' tries to assign type '%s' to variable '%s', but this variable already had a type assigned by the rule 'when'. Try omitting this type assignment.");
     public static final ErrorMessage INVALID_RULE_THEN_VARIABLES =
-            new ErrorMessage(33, "Rule '%s' 'then' variables must be present in rule 'when'.");
+            new ErrorMessage(33, "Rule '%s' 'then' variables must be present in every branch of rule 'when'.");
     public static final ErrorMessage INVALID_RULE_THEN_ROLES =
             new ErrorMessage(34, "Rule '%s' 'then' '%s' must specify all role types explicitly or by using a variable.");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -84,7 +84,7 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
     public static final ErrorMessage INVALID_RULE_THEN_HAS =
             new ErrorMessage(32, "Rule '%s' 'then' '%s' tries to assign type '%s' to variable '%s', but this variable already had a type assigned by the rule 'when'. Try omitting this type assignment.");
     public static final ErrorMessage INVALID_RULE_THEN_VARIABLES =
-            new ErrorMessage(33, "Rule '%s' 'then' variables must be present in every branch of rule 'when'.");
+            new ErrorMessage(33, "Rule '%s' 'then' variables must be present in the 'when', outside of nested patterns.");
     public static final ErrorMessage INVALID_RULE_THEN_ROLES =
             new ErrorMessage(34, "Rule '%s' 'then' '%s' must specify all role types explicitly or by using a variable.");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -50,7 +50,6 @@ import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_HAS;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_ROLES;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_VARIABLES;
-import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_CONTAINS_DISJUNCTION;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_MISSING_PATTERNS;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_NESTED_NEGATION;
 import static com.vaticle.typeql.lang.common.util.Strings.indent;

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -149,14 +149,12 @@ public class Rule implements Definable {
             Set<Reference> thenReferences = Stream.concat(Stream.of(then), then.variables())
                     .filter(Variable::isNamed).map(Variable::reference).collect(Collectors.toSet());
 
-            when.normalise().patterns().forEach(conjunction -> {
-                Set<Reference> whenReferences = conjunction.variables()
-                        .filter(Variable::isNamed).map(Variable::reference).collect(Collectors.toSet());
+            Set<Reference> whenReferences = when.variables()
+                    .filter(Variable::isNamed).map(Variable::reference).collect(Collectors.toSet());
 
-                if (!whenReferences.containsAll(thenReferences)) {
-                    throw TypeQLException.of(INVALID_RULE_THEN_VARIABLES.message(label));
-                }
-            });
+            if (!whenReferences.containsAll(thenReferences)) {
+                throw TypeQLException.of(INVALID_RULE_THEN_VARIABLES.message(label));
+            }
         }
 
         // Roles must be explicit


### PR DESCRIPTION
## What is the goal of this PR?
Enables disjunctions in rules, and updates rule-validation accordingly.

## What are the changes implemented in this PR?
* Updates rule-validation to allow disjunctions in rule-conditions. 
* updates other validation steps to reflect disjunctions being allowed
  - Every variable in the rule-then must be present in the trunk of the rule-when (i.e., outside negations and nested disjunctions).
