### PR TITLE
Add Rust IDE sync tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@
 # Bazel files #
 bazel-*
 
-# Maven files #
-target/
-
 # IDE files #
 .idea/
 *.iml
@@ -43,7 +40,12 @@ target/
 # Compiled files #
 dist/
 out/
+target/
 *.class
+
+# Cargo files #
+Cargo.toml
+Cargo.lock
 
 # Mobile Tools for Java (J2ME) files #
 .mtj.tmp/

--- a/BUILD
+++ b/BUILD
@@ -63,6 +63,7 @@ checkstyle_test(
 filegroup(
     name = "ci",
     data = [
+        "@vaticle_dependencies//ide/rust:sync",
         "@vaticle_dependencies//library/maven:update",
         "@vaticle_dependencies//tool/checkstyle:test-coverage",
         "@vaticle_dependencies//tool/release/notes:create",

--- a/BUILD
+++ b/BUILD
@@ -63,7 +63,6 @@ checkstyle_test(
 filegroup(
     name = "ci",
     data = [
-        "@vaticle_dependencies//ide/rust:sync",
         "@vaticle_dependencies//library/maven:update",
         "@vaticle_dependencies//tool/checkstyle:test-coverage",
         "@vaticle_dependencies//tool/release/notes:create",

--- a/dependencies/ide/rust/BUILD
+++ b/dependencies/ide/rust/BUILD
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "agpl-header",
+)

--- a/dependencies/ide/rust/sync.sh
+++ b/dependencies/ide/rust/sync.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+bazel run @vaticle_dependencies//ide/rust:sync

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "4464b506ca469f37d3b696fb2f1eda34061cdaa1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "2ddbe731c1db5f71c5a52e2d53f3493c3132c2e4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "2ddbe731c1db5f71c5a52e2d53f3493c3132c2e4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "fc4d0b2383512c852e2997351ef2511597fcdfc7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():


### PR DESCRIPTION
## What is the goal of this PR?

We added the Rust IDE sync tool to enable Rust development in IDEs.

## What are the changes implemented in this PR?

- Bump dependencies
- Add `dependencies/ide/rust/sync.sh`
- Add Cargo files and build artifacts to `.gitignore`

### Usage

Run `./dependencies/ide/rust/sync.sh`, immediately after cloning/pulling this repo, or after loading it in an IDE.

This will generate `Cargo.toml` files in the project, allowing the Rust targets to be built, run and debugged using Cargo. The Vaticle fork of the IntelliJ Rust plugin is required: this modified plugin is able to run the `cargo` binary that is loaded into the Bazel sandbox on building the Bazel project.