### PR TITLE
Bump dependencies and python version for GitHub deployment

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -114,6 +114,13 @@ release:
     deploy-github:
       image: vaticle-ubuntu-22.04
       command: |
+        export PYENV_ROOT="/opt/pyenv"
+        pyenv install 3.7.9
+        pyenv global 3.7.9
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
+        python3 -m pip install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "24fa2336004474fd993f35b743b7b342c2a5af1b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        tag = "2.12.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,12 +28,12 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "17c162fe7135db6988d7ac1ae5416568231c8789", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "24fa2336004474fd993f35b743b7b342c2a5af1b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "a503356d9d22e794393ced5b3d3f014db4189b60", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "17c3764aa3cce285523a566910fe716895f77c35", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )


### PR DESCRIPTION
## What is the goal of this PR?

We've fixed the Python version learned from the successful GitHub deployment of typedb-common a definite working version of Python for this job.

## What are the changes implemented in this PR?

We've bumped typedb-common and typedb-behaviour. We've also changed the used Python version to 3.7.9 from 3.7.12. This fixes a later bug where we attempt to link a library to a not-installed version of Python.