### PR TITLE
Add transitive Rust deps that aren't included by default on M1 Macs

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "fc4d0b2383512c852e2997351ef2511597fcdfc7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/alexjpwalker/dependencies",
+        commit = "0d9746004376c1a83918688df2e301baa7c106d7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/alexjpwalker/dependencies",
-        commit = "0d9746004376c1a83918688df2e301baa7c106d7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "9cb57b3d5eb5c836b904380d53c2ae9613b88ae9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -41,6 +41,9 @@ rust_library(
     deps = [
         "@vaticle_dependencies//library/crates:antlr_rust",
         "@vaticle_dependencies//library/crates:chrono",
+        "@vaticle_dependencies//library/crates:core_foundation_sys", # transitive dependency of 'chrono', included to patch cfg('unix') issue (dependencies#385)
+        "@vaticle_dependencies//library/crates:libc", # transitive dependency of 'antlr_rust', included to patch cfg('unix') issue (dependencies#385)
+
         # External Vaticle Dependencies
         "//grammar/rust:typeql_grammar",
     ],


### PR DESCRIPTION
## What is the goal of this PR?

We added `core-foundation-sys` and `libc` explicitly as Rust dependencies. They are conditional transitive dependencies of `antlr-rust` and `chrono` respectively. Due to https://github.com/vaticle/dependencies/issues/385 they are not included by default.

## What are the changes implemented in this PR?

`core-foundation-sys` and `libc` are conditional dependencies of the `antlr-rust` and `chrono` crates. The condition is the Cargo condition `cfg('unix')`, which is supposed to represent any Unix system. Due to https://github.com/vaticle/dependencies/issues/385, they are not correctly pulled in when the machine has `aarch64` architecture. For now, we work around the issue by declaring them as explicit dependencies.