### PR TITLE
Delete Rust dependencies that were added to patch issue building on M1 Macs

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "9cb57b3d5eb5c836b904380d53c2ae9613b88ae9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "3a355418fad6b632ab6cd809945296b6756ea076", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -41,8 +41,6 @@ rust_library(
     deps = [
         "@vaticle_dependencies//library/crates:antlr_rust",
         "@vaticle_dependencies//library/crates:chrono",
-        "@vaticle_dependencies//library/crates:core_foundation_sys", # transitive dependency of 'chrono', included to patch cfg('unix') issue (dependencies#385)
-        "@vaticle_dependencies//library/crates:libc", # transitive dependency of 'antlr_rust', included to patch cfg('unix') issue (dependencies#385)
 
         # External Vaticle Dependencies
         "//grammar/rust:typeql_grammar",


### PR DESCRIPTION
## What is the goal of this PR?

We deleted some unnecessary Rust dependencies that were added to patch an issue building on M1 Macs in https://github.com/vaticle/typeql/pull/250.

## What are the changes implemented in this PR?

We've fixed the `dependencies` repo so it correctly generates `BUILD` targets compatible with Apple Silicon, so now we can clean up our superfluous dependencies.