### PR TITLE
Pattern normalisation

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/dmitrii-ubskii/dependencies",
-        commit = "b50e4a19a0d93e829d878519e6f466974555b140", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "96acc1b80fc5e663e116a73d155d1373720dcaed", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "5fd89e4c6587edc6a2d6d80a84d8c6515c5bc44b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/dmitrii-ubskii/dependencies",
+        commit = "b50e4a19a0d93e829d878519e6f466974555b140", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -43,6 +43,7 @@ rust_library(
     ],
     deps = [
         "@vaticle_dependencies//library/crates:chrono",
+        "@vaticle_dependencies//library/crates:itertools",
         "@vaticle_dependencies//library/crates:pest",
         "@vaticle_dependencies//library/crates:regex",
     ],

--- a/rust/common/error.rs
+++ b/rust/common/error.rs
@@ -146,7 +146,7 @@ macro_rules! error_messages {
     };
     ($code_pfx:literal, $code_len:expr, $message_pfx:literal, $(($error_name:ident, $code:literal, $body:literal)),* $(,)?) => {
         $(
-        pub const $error_name: ErrorTemplate = ErrorTemplate {
+        pub(crate) const $error_name: ErrorTemplate = ErrorTemplate {
             template: concat!($message_pfx, ": ", $body),
             prefix: $code_pfx,
             code: $code,
@@ -158,16 +158,13 @@ macro_rules! error_messages {
 
 error_messages! {
    code: "TQL", type: "TypeQL Error",
-   SYNTAX_ERROR_NO_DETAILS = 2: "There is a syntax error at line {}:\n{}",
    SYNTAX_ERROR_DETAILED = 3: "There is a syntax error at line {}:\n{}\n{}\n{}",
-   INVALID_CASTING = 4: "The class '{}' cannot be casted to '{}'.",
+   INVALID_CASTING = 4: "The enum does not match '{}', and cannot be unwrapped into '{}'.",
    MISSING_PATTERNS = 5: "The query has not been provided with any patterns.",
    MISSING_DEFINABLES = 6: "The query has not been provided with any definables.",
    MATCH_HAS_NO_BOUNDING_NAMED_VARIABLE = 7: "The match query does not have named variables to bound the nested disjunction/negation pattern(s).",
-   MATCH_HAS_NO_NAMED_VARIABLE = 8: "The match query has no named variables to retrieve.",
    MATCH_PATTERN_VARIABLE_HAS_NO_NAMED_VARIABLE = 9: "The pattern '{}' has no named variable.",
    MATCH_HAS_UNBOUNDED_NESTED_PATTERN = 10: "The match query contains a nested pattern is not bounded: '{}'.",
-   MISSING_MATCH_FILTER = 11: "The match query cannot be constructed with NULL filter variable collection.",
    EMPTY_MATCH_FILTER = 12: "The match query cannot be filtered with an empty list of variables.",
    INVALID_IID_STRING = 13: "Invalid IID: '{}'. IIDs must follow the regular expression: '0x[0-9a-f]+'.",
    INVALID_ATTRIBUTE_TYPE_REGEX = 14: "Invalid regular expression '{}'.",
@@ -177,10 +174,7 @@ error_messages! {
    NO_VARIABLE_IN_SCOPE_INSERT = 18: "None of the variables in 'insert' ('{}') is within scope of 'match' ('{}')",
    VARIABLE_NOT_NAMED = 19: "Anonymous variable encountered in a match query filter.",
    INVALID_VARIABLE_NAME = 20: "The variable name '{}' is invalid; variables must match the following regular expression: '^[a-zA-Z0-9][a-zA-Z0-9_-]+$'.",
-   ILLEGAL_CONSTRAINT_REPETITION = 21: "The variable '{}' contains illegally repeating constraints: '{}' and '{}'.",
    MISSING_CONSTRAINT_RELATION_PLAYER = 22: "A relation variable has not been provided with role players.",
-   MISSING_CONSTRAINT_VALUE = 23: "A value constraint has not been provided with a variable or literal value.",
-   MISSING_CONSTRAINT_PREDICATE = 24: "A value constraint has not been provided with a predicate.",
    INVALID_CONSTRAINT_PREDICATE = 25: "The '{}' constraint may only accept a string value as its operand, got '{}' instead.",
    INVALID_CONSTRAINT_DATETIME_PRECISION = 26: "Attempted to assign DateTime value of '{}' which is more precise than 1 millisecond.",
    INVALID_DEFINE_QUERY_VARIABLE = 27: "Invalid define/undefine query. User defined variables are not accepted in define/undefine query.",
@@ -193,7 +187,6 @@ error_messages! {
    INVALID_RULE_THEN_ROLES = 34: "Rule '{}' 'then' '{}' must specify all role types explicitly or by using a variable.",
    REDUNDANT_NESTED_NEGATION = 35: "Invalid query containing redundant nested negations.",
    VARIABLE_NOT_SORTED = 36: "Variable '{}' does not exist in the sorting clause.",
-   INVALID_SORTING_ORDER = 37: "Invalid sorting order '{}'. Valid options: '{}' or '{}'.",
    INVALID_COUNT_VARIABLE_ARGUMENT = 38: "Aggregate COUNT does not accept a Variable.",
    ILLEGAL_GRAMMAR = 39: "Illegal grammar: '{}'",
    ILLEGAL_CHAR_IN_LABEL = 40: "'{}' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.",

--- a/rust/common/error.rs
+++ b/rust/common/error.rs
@@ -159,7 +159,7 @@ macro_rules! error_messages {
 error_messages! {
    code: "TQL", type: "TypeQL Error",
    SYNTAX_ERROR_DETAILED = 3: "There is a syntax error at line {}:\n{}\n{}\n{}",
-   INVALID_CASTING = 4: "The enum does not match '{}', and cannot be unwrapped into '{}'.",
+   INVALID_CASTING = 4: "Enum '{}::{}' does not match '{}', and cannot be unwrapped into '{}'.",
    MISSING_PATTERNS = 5: "The query has not been provided with any patterns.",
    MISSING_DEFINABLES = 6: "The query has not been provided with any definables.",
    MATCH_HAS_NO_BOUNDING_NAMED_VARIABLE = 7: "The match query does not have named variables to bound the nested disjunction/negation pattern(s).",

--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -34,7 +34,7 @@ macro_rules! string_enum {
                 use $name::*;
                 match string {
                     $($value => $item,)*
-                    _ => panic!(""),  // TODO TryFrom + ErrorMessage
+                    _ => panic!(""),
                 }
             }
         }

--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -34,7 +34,7 @@ macro_rules! string_enum {
                 use $name::*;
                 match string {
                     $($value => $item,)*
-                    _ => panic!(""),
+                    _ => panic!("Unexpected input while parsing {}: '{}'", stringify!($name), string),
                 }
             }
         }

--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -153,3 +153,8 @@ string_enum! { ValueType
     Long = "long",
     String = "string",
 }
+
+string_enum! { Order
+    Asc = "asc",
+    Desc = "desc",
+}

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -192,12 +192,12 @@ fn get_boolean(boolean: SyntaxTree) -> bool {
 }
 
 fn get_date(date: SyntaxTree) -> NaiveDate {
-    NaiveDate::parse_from_str(&date.as_str(), "%Y-%m-%d")
+    NaiveDate::parse_from_str(date.as_str(), "%Y-%m-%d")
         .expect(&ILLEGAL_GRAMMAR.format(&[date.as_str()]).message)
 }
 
 fn get_date_time(date_time: SyntaxTree) -> NaiveDateTime {
-    date_time::parse(&date_time.as_str())
+    date_time::parse(date_time.as_str())
         .expect(&ILLEGAL_GRAMMAR.format(&[date_time.as_str()]).message)
 }
 
@@ -251,7 +251,7 @@ fn visit_query(tree: SyntaxTree) -> Query {
         Rule::query_match_aggregate => visit_query_match_aggregate(child).into(),
         Rule::query_match_group => visit_query_match_group(child).into(),
         Rule::query_match_group_agg => visit_query_match_group_agg(child).into(),
-        _ => unreachable!("{:?}", ILLEGAL_GRAMMAR.format(&[&child.as_str()])),
+        _ => unreachable!("{:?}", ILLEGAL_GRAMMAR.format(&[child.as_str()])),
     }
 }
 
@@ -279,7 +279,7 @@ fn visit_query_insert(tree: SyntaxTree) -> TypeQLInsert {
         Rule::INSERT => TypeQLInsert::new(visit_variable_things(
             children.consume_expected(Rule::variable_things),
         )),
-        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&children.as_str()])),
+        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[children.as_str()])),
     }
 }
 
@@ -322,7 +322,7 @@ fn visit_query_match(tree: SyntaxTree) -> TypeQLMatch {
                         .skip_expected(Rule::LIMIT)
                         .consume_expected(Rule::LONG_),
                 ) as usize),
-                _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&modifier.as_str()])),
+                _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[modifier.as_str()])),
             };
         }
     }
@@ -396,7 +396,7 @@ fn visit_definable(tree: SyntaxTree) -> Definable {
         Rule::variable_type => visit_variable_type(child).into(),
         Rule::schema_rule => visit_schema_rule(child).into(),
         Rule::schema_rule_declaration => visit_schema_rule_declaration(child).into(),
-        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&child.as_str()])),
+        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[child.as_str()])),
     }
 }
 
@@ -411,7 +411,7 @@ fn visit_pattern(tree: SyntaxTree) -> Pattern {
         Rule::pattern_disjunction => visit_pattern_disjunction(child).into(),
         Rule::pattern_conjunction => visit_pattern_conjunction(child).into(),
         Rule::pattern_negation => visit_pattern_negation(child).into(),
-        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&child.as_str()])),
+        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[child.as_str()])),
     }
 }
 
@@ -448,7 +448,7 @@ fn visit_pattern_variable(tree: SyntaxTree) -> Variable {
         Rule::variable_thing_any => visit_variable_thing_any(child).into(),
         Rule::variable_type => visit_variable_type(child).into(),
         Rule::variable_concept => visit_variable_concept(child).into(),
-        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&child.as_str()])),
+        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[child.as_str()])),
     }
 }
 
@@ -501,7 +501,7 @@ fn visit_variable_type(tree: SyntaxTree) -> TypeVariable {
                 Rule::VALUE => var_type.value(token::ValueType::from(
                     constraint.consume_expected(Rule::value_type).as_str(),
                 )),
-                _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&constraint.as_str()])),
+                _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[constraint.as_str()])),
             }
         });
 
@@ -518,7 +518,7 @@ fn visit_variable_thing_any(tree: SyntaxTree) -> ThingVariable {
         Rule::variable_thing => visit_variable_thing(child),
         Rule::variable_relation => visit_variable_relation(child),
         Rule::variable_attribute => visit_variable_attribute(child),
-        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&child.as_str()])),
+        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[child.as_str()])),
     }
 }
 
@@ -531,7 +531,7 @@ fn visit_variable_thing(tree: SyntaxTree) -> ThingVariable {
             Rule::IID => var_thing.iid(children.consume_expected(Rule::IID_).as_str()),
             Rule::ISA_ => var_thing
                 .constrain_isa(get_isa_constraint(keyword, children.consume_expected(Rule::type_))),
-            _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&children.as_str()])),
+            _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[children.as_str()])),
         }
     }
     if let Some(attributes) = children.consume_if_matches(Rule::attributes) {
@@ -547,7 +547,7 @@ fn visit_variable_relation(tree: SyntaxTree) -> ThingVariable {
     let mut relation = children
         .consume_if_matches(Rule::VAR_)
         .map(get_var)
-        .unwrap_or_else(|| UnboundVariable::hidden())
+        .unwrap_or_else(UnboundVariable::hidden)
         .constrain_relation(visit_relation(children.consume_expected(Rule::relation)));
 
     if let Some(isa) = children.consume_if_matches(Rule::ISA_) {
@@ -568,7 +568,7 @@ fn visit_variable_attribute(tree: SyntaxTree) -> ThingVariable {
     let mut attribute = children
         .consume_if_matches(Rule::VAR_)
         .map(get_var)
-        .unwrap_or_else(|| UnboundVariable::hidden())
+        .unwrap_or_else(UnboundVariable::hidden)
         .constrain_value(visit_predicate(children.consume_expected(Rule::predicate)));
 
     if let Some(isa) = children.consume_if_matches(Rule::ISA_) {
@@ -606,11 +606,11 @@ fn visit_attribute(tree: SyntaxTree) -> HasConstraint {
                     label,
                     visit_predicate(children.consume_expected(Rule::predicate)),
                 )),
-                _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&children.as_str()])),
+                _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[children.as_str()])),
             }
         }
         Some(Rule::VAR_) => HasConstraint::from(get_var(children.consume_expected(Rule::VAR_))),
-        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&children.as_str()])),
+        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[children.as_str()])),
     }
 }
 
@@ -628,7 +628,7 @@ fn visit_predicate(tree: SyntaxTree) -> ValueConstraint {
                 match predicate_value.as_rule() {
                     Rule::value => visit_value(predicate_value),
                     Rule::VAR_ => Value::from(get_var(predicate_value)),
-                    _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&children.as_str()])),
+                    _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[children.as_str()])),
                 }
             },
         ),
@@ -646,13 +646,13 @@ fn visit_predicate(tree: SyntaxTree) -> ValueConstraint {
                         token::Predicate::Contains => {
                             get_string(children.consume_expected(Rule::STRING_))
                         }
-                        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&children.as_str()])),
+                        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[children.as_str()])),
                     }
                 }
                 .into(),
             )
         }
-        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&children.as_str()])),
+        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[children.as_str()])),
     }
 }
 
@@ -681,7 +681,7 @@ fn visit_type_any(tree: SyntaxTree) -> Type {
         Rule::VAR_ => Type::Variable(get_var(child)),
         Rule::type_ => visit_type(child),
         Rule::type_scoped => visit_type_scoped(child),
-        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&child.as_str()])),
+        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[child.as_str()])),
     }
 }
 
@@ -690,7 +690,7 @@ fn visit_type_scoped(tree: SyntaxTree) -> Type {
     match child.as_rule() {
         Rule::label_scoped => Type::Label(visit_label_scoped(child)),
         Rule::VAR_ => Type::Variable(get_var(child)),
-        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&child.as_str()])),
+        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[child.as_str()])),
     }
 }
 
@@ -699,7 +699,7 @@ fn visit_type(tree: SyntaxTree) -> Type {
     match child.as_rule() {
         Rule::label => Type::Label(child.as_str().into()),
         Rule::VAR_ => Type::Variable(get_var(child)),
-        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&child.as_str()])),
+        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[child.as_str()])),
     }
 }
 
@@ -708,7 +708,7 @@ fn visit_label_any(tree: SyntaxTree) -> Label {
     match child.as_rule() {
         Rule::label => Label::from(child.as_str()),
         Rule::label_scoped => visit_label_scoped(child),
-        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&child.as_str()])),
+        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[child.as_str()])),
     }
 }
 
@@ -727,6 +727,6 @@ fn visit_value(tree: SyntaxTree) -> Value {
         Rule::BOOLEAN_ => Value::from(get_boolean(child)),
         Rule::DATE_ => Value::from(get_date(child).and_hms_opt(0, 0, 0).unwrap()),
         Rule::DATETIME_ => Value::from(get_date_time(child)),
-        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[&child.as_str()])),
+        _ => unreachable!("{}", ILLEGAL_GRAMMAR.format(&[child.as_str()])),
     }
 }

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -26,7 +26,7 @@ mod test;
 use crate::{
     common::{
         date_time,
-        error::ILLEGAL_GRAMMAR,
+        error::{ILLEGAL_CHAR_IN_LABEL, ILLEGAL_GRAMMAR},
         string::{unescape_regex, unquote},
         token,
         validatable::Validatable,
@@ -163,8 +163,11 @@ pub(crate) fn visit_eof_variable(variable: &str) -> Result<Variable> {
 }
 
 pub(crate) fn visit_eof_label(label: &str) -> Result<Label> {
-    // TODO validation
-    Ok(parse_single(Rule::label, label)?.as_str().into())
+    let parsed = parse_single(Rule::eof_label, label)?.into_child().as_str();
+    if parsed != label {
+        Err(ILLEGAL_CHAR_IN_LABEL.format(&[label]))?;
+    }
+    Ok(parsed.into())
 }
 
 pub(crate) fn visit_eof_schema_rule(rule: &str) -> Result<RuleDefinition> {

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -382,7 +382,9 @@ fn visit_var_order(tree: SyntaxTree) -> sorting::OrderedVariable {
     let mut children = tree.into_children();
     sorting::OrderedVariable {
         var: get_var(children.consume_expected(Rule::VAR_)),
-        order: children.consume_if_matches(Rule::ORDER_).map(|child| token::Order::from(child.as_str())),
+        order: children
+            .consume_if_matches(Rule::ORDER_)
+            .map(|child| token::Order::from(child.as_str())),
     }
 }
 

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -382,7 +382,7 @@ fn visit_var_order(tree: SyntaxTree) -> sorting::OrderedVariable {
     let mut children = tree.into_children();
     sorting::OrderedVariable {
         var: get_var(children.consume_expected(Rule::VAR_)),
-        order: children.consume_if_matches(Rule::ORDER_).map(|child| child.as_str().to_owned()),
+        order: children.consume_if_matches(Rule::ORDER_).map(|child| token::Order::from(child.as_str())),
     }
 }
 

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -1106,7 +1106,7 @@ fn when_parse_incorrect_syntax_throw_typeql_syntax_exception_with_helpful_error(
     assert!(report.contains("syntax error"));
     assert!(report.contains("line 2"));
     assert!(report.contains("\n$x isa"));
-    assert!(report.contains("\n   ^"));
+    assert!(report.contains("\n      ^"));
 }
 
 #[test]
@@ -1117,7 +1117,7 @@ fn when_parse_incorrect_syntax_trailing_query_whitespace_is_ignored() {
     assert!(report.contains("syntax error"));
     assert!(report.contains("line 2"));
     assert!(report.contains("\n$x isa"));
-    assert!(report.contains("\n   ^"));
+    assert!(report.contains("\n      ^"));
 }
 
 #[test]

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -32,6 +32,7 @@ use crate::{
     rel, rule, type_, typeql_insert, typeql_match, var, Query,
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+use crate::common::token::Order::{Asc, Desc};
 
 macro_rules! assert_valid_eq_repr {
     ($expected:ident, $parsed:ident, $query:ident) => {
@@ -407,7 +408,7 @@ $x plays starring:actor;
 sort $x asc;"#;
 
     let parsed = parse_query(query).unwrap().into_match();
-    let expected = typeql_match!(var("x").plays(("starring", "actor"))).sort([("x", "asc")]);
+    let expected = typeql_match!(var("x").plays(("starring", "actor"))).sort([("x", Asc)]);
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -421,7 +422,7 @@ sort $r desc;"#;
 
     let parsed = parse_query(query).unwrap().into_match();
     let expected =
-        typeql_match!(var("x").isa("movie").has(("rating", var("r")))).sort([("r", "desc")]);
+        typeql_match!(var("x").isa("movie").has(("rating", var("r")))).sort([("r", Desc)]);
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -449,7 +450,7 @@ sort $r desc; offset 10; limit 10;"#;
 
     let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").isa("movie").has(("rating", var("r"))))
-        .sort([("r", "desc")])
+        .sort([("r", Desc)])
         .offset(10)
         .limit(10);
 

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -22,7 +22,13 @@
 
 use crate::{
     and,
-    common::{token::ValueType, validatable::Validatable},
+    common::{
+        token::{
+            Order::{Asc, Desc},
+            ValueType,
+        },
+        validatable::Validatable,
+    },
     gte, lt, lte, not, or, parse_pattern, parse_queries, parse_query,
     pattern::{
         ConceptVariableBuilder, Conjunction, Disjunction, RelationVariableBuilder,
@@ -32,7 +38,6 @@ use crate::{
     rel, rule, type_, typeql_insert, typeql_match, var, Query,
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
-use crate::common::token::Order::{Asc, Desc};
 
 macro_rules! assert_valid_eq_repr {
     ($expected:ident, $parsed:ident, $query:ident) => {

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -216,7 +216,7 @@ DESC = @{ "desc" ~ WB }
 
 TYPE = @{ "type" ~ WB }
 ABSTRACT = @{ "abstract" ~ WB }
-SUB_ = @{ SUBX | SUB }
+SUB_ = ${ SUBX | SUB }
 SUB = @{ "sub" ~ WB }
 SUBX = @{ "sub!" ~ WB }
 OWNS = @{ "owns" ~ WB }
@@ -231,7 +231,7 @@ THEN = @{ "then" ~ WB }
 // THING VARIABLE CONSTRAINT KEYWORDS
 
 IID = @{ "iid" ~ WB }
-ISA_ = @{ ISAX | ISA }
+ISA_ = ${ ISAX | ISA }
 ISA = @{ "isa" ~ WB }
 ISAX = @{ "isa!" ~ WB }
 HAS = @{ "has" ~ WB }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -328,7 +328,7 @@ SECOND_ = @{ ('0'..'6') ~ ASCII_DIGIT }
 SECOND_FRACTION_ = @{ ASCII_DIGIT{1,3} } // between 1 and 3 digits
 ESCAPE_SEQ_ = @{ "\\" ~ ANY }
 
-WB = _{ &(PUNCTUATION | WHITESPACE | COMMENT) } // Word boundary
+WB = _{ &(PUNCTUATION | WHITESPACE | COMMENT | EOI) } // Word boundary
 
 COMMENT = _{ "#" ~ (!NEWLINE ~ ANY)* ~ (NEWLINE | EOI) }
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/rust/pattern/conjunction.rs
+++ b/rust/pattern/conjunction.rs
@@ -70,7 +70,7 @@ impl Conjunction {
         let names = self.named_references();
         let combined_bounds = bounds.union(&names).cloned().collect();
         collect_err(
-            &mut iter::once(expect_bounded(&names, &bounds, &self))
+            &mut iter::once(expect_bounded(&names, bounds, self))
                 .chain(self.patterns.iter().map(|p| p.expect_is_bounded_by(&combined_bounds))),
         )
     }

--- a/rust/pattern/constraint/mod.rs
+++ b/rust/pattern/constraint/mod.rs
@@ -40,3 +40,12 @@ pub enum IsExplicit {
     Yes,
     No,
 }
+
+impl From<bool> for IsExplicit {
+    fn from(is_explicit: bool) -> Self {
+        match is_explicit {
+            true => IsExplicit::Yes,
+            false => IsExplicit::No,
+        }
+    }
+}

--- a/rust/pattern/disjunction.rs
+++ b/rust/pattern/disjunction.rs
@@ -68,8 +68,7 @@ impl Normalisable for Disjunction {
                             disjunction.normalise().into_disjunction().patterns.into_iter()
                         }
                         Pattern::Negation(negation) => {
-                            vec![Conjunction::new(vec![negation.normalise()]).into()]
-                                .into_iter()
+                            vec![Conjunction::new(vec![negation.normalise()]).into()].into_iter()
                         }
                         Pattern::Variable(variable) => {
                             vec![Conjunction::new(vec![variable.clone().into()]).into()].into_iter()

--- a/rust/pattern/disjunction.rs
+++ b/rust/pattern/disjunction.rs
@@ -57,27 +57,33 @@ impl Validatable for Disjunction {
 impl Normalisable for Disjunction {
     fn normalise(&mut self) -> Pattern {
         if self.normalised.is_none() {
-            self.normalised = Some(Box::new(Disjunction::new(
-                self.patterns
-                    .iter_mut()
-                    .flat_map(|pattern| match pattern {
-                        Pattern::Conjunction(conjunction) => {
-                            conjunction.normalise().into_disjunction().patterns.into_iter()
-                        }
-                        Pattern::Disjunction(disjunction) => {
-                            disjunction.normalise().into_disjunction().patterns.into_iter()
-                        }
-                        Pattern::Negation(negation) => {
-                            vec![Conjunction::new(vec![negation.normalise()]).into()].into_iter()
-                        }
-                        Pattern::Variable(variable) => {
-                            vec![Conjunction::new(vec![variable.clone().into()]).into()].into_iter()
-                        }
-                    })
-                    .collect(),
-            )));
+            self.normalised = Some(Box::new(self.compute_normalised().into_disjunction()));
         }
         self.normalised.as_ref().unwrap().as_ref().clone().into()
+    }
+
+    fn compute_normalised(&self) -> Pattern {
+        Disjunction::new(
+            self.patterns
+                .iter()
+                .flat_map(|pattern| match pattern {
+                    Pattern::Conjunction(conjunction) => {
+                        conjunction.compute_normalised().into_disjunction().patterns.into_iter()
+                    }
+                    Pattern::Disjunction(disjunction) => {
+                        disjunction.compute_normalised().into_disjunction().patterns.into_iter()
+                    }
+                    Pattern::Negation(negation) => {
+                        vec![Conjunction::new(vec![negation.compute_normalised()]).into()]
+                            .into_iter()
+                    }
+                    Pattern::Variable(variable) => {
+                        vec![Conjunction::new(vec![variable.clone().into()]).into()].into_iter()
+                    }
+                })
+                .collect(),
+        )
+        .into()
     }
 }
 

--- a/rust/pattern/disjunction.rs
+++ b/rust/pattern/disjunction.rs
@@ -68,7 +68,7 @@ impl Normalisable for Disjunction {
                             disjunction.normalise().into_disjunction().patterns.into_iter()
                         }
                         Pattern::Negation(negation) => {
-                            vec![Conjunction::new(vec![negation.normalise().into()]).into()]
+                            vec![Conjunction::new(vec![negation.normalise()]).into()]
                                 .into_iter()
                         }
                         Pattern::Variable(variable) => {

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -58,7 +58,7 @@ pub use variable::{
 mod test;
 
 use crate::{
-    common::{validatable::Validatable, Result},
+    common::{error::INVALID_CASTING, validatable::Validatable, Result},
     enum_getter, enum_wrapper,
 };
 use std::{collections::HashSet, fmt};

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -111,6 +111,7 @@ impl Validatable for Pattern {
 
 pub trait Normalisable {
     fn normalise(&mut self) -> Pattern;
+    fn compute_normalised(&self) -> Pattern;
 }
 
 impl Normalisable for Pattern {
@@ -121,6 +122,16 @@ impl Normalisable for Pattern {
             Disjunction(disjunction) => disjunction.normalise(),
             Negation(negation) => negation.normalise(),
             Variable(variable) => variable.normalise(),
+        }
+    }
+
+    fn compute_normalised(&self) -> Pattern {
+        use Pattern::*;
+        match self {
+            Conjunction(conjunction) => conjunction.compute_normalised(),
+            Disjunction(disjunction) => disjunction.compute_normalised(),
+            Negation(negation) => negation.compute_normalised(),
+            Variable(variable) => variable.compute_normalised(),
         }
     }
 }

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -88,6 +88,13 @@ impl Pattern {
     }
 }
 
+enum_wrapper! { Pattern
+    Conjunction => Conjunction,
+    Disjunction => Disjunction,
+    Negation => Negation,
+    Variable => Variable,
+}
+
 impl Validatable for Pattern {
     fn validate(&self) -> Result<()> {
         use Pattern::*;
@@ -100,11 +107,20 @@ impl Validatable for Pattern {
     }
 }
 
-enum_wrapper! { Pattern
-    Conjunction => Conjunction,
-    Disjunction => Disjunction,
-    Negation => Negation,
-    Variable => Variable,
+pub trait Normalisable {
+    fn normalise(&mut self) -> Pattern;
+}
+
+impl Normalisable for Pattern {
+    fn normalise(&mut self) -> Pattern {
+        use Pattern::*;
+        match self {
+            Conjunction(conjunction) => conjunction.normalise(),
+            Disjunction(disjunction) => disjunction.normalise(),
+            Negation(negation) => negation.normalise(),
+            Variable(variable) => variable.normalise(),
+        }
+    }
 }
 
 impl From<ConceptVariable> for Pattern {

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -72,11 +72,6 @@ pub enum Pattern {
 }
 
 impl Pattern {
-    enum_getter!(into_conjunction, Conjunction, Conjunction);
-    enum_getter!(into_disjunction, Disjunction, Disjunction);
-    enum_getter!(into_negation, Negation, Negation);
-    enum_getter!(into_variable, Variable, Variable);
-
     pub fn expect_is_bounded_by(&self, bounds: &HashSet<Reference>) -> Result<()> {
         use Pattern::*;
         match self {
@@ -86,6 +81,13 @@ impl Pattern {
             Variable(variable) => variable.expect_is_bounded_by(bounds),
         }
     }
+}
+
+enum_getter! { Pattern
+    into_conjunction(Conjunction) => Conjunction,
+    into_disjunction(Disjunction) => Disjunction,
+    into_negation(Negation) => Negation,
+    into_variable(Variable) => Variable,
 }
 
 enum_wrapper! { Pattern
@@ -166,10 +168,16 @@ pub enum Definable {
     TypeVariable(TypeVariable),
 }
 
-impl Definable {
-    enum_getter!(into_rule_declaration, RuleDeclaration, RuleDeclaration);
-    enum_getter!(into_rule, RuleDefinition, RuleDefinition);
-    enum_getter!(into_type_variable, TypeVariable, TypeVariable);
+enum_getter! { Definable
+    into_rule_declaration(RuleDeclaration) => RuleDeclaration,
+    into_rule(RuleDefinition) => RuleDefinition,
+    into_type_variable(TypeVariable) => TypeVariable,
+}
+
+enum_wrapper! { Definable
+    RuleDeclaration => RuleDeclaration,
+    RuleDefinition => RuleDefinition,
+    TypeVariable => TypeVariable,
 }
 
 impl Validatable for Definable {
@@ -181,12 +189,6 @@ impl Validatable for Definable {
             TypeVariable(variable) => variable.validate(),
         }
     }
-}
-
-enum_wrapper! { Definable
-    RuleDeclaration => RuleDeclaration,
-    RuleDefinition => RuleDefinition,
-    TypeVariable => TypeVariable,
 }
 
 impl fmt::Display for Definable {

--- a/rust/pattern/negation.rs
+++ b/rust/pattern/negation.rs
@@ -22,19 +22,26 @@
 
 use crate::{
     common::{error::REDUNDANT_NESTED_NEGATION, token, validatable::Validatable, Result},
-    pattern::{Pattern, Reference},
+    pattern::{Conjunction, Disjunction, Normalisable, Pattern, Reference},
 };
 use core::fmt;
 use std::collections::HashSet;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq)]
 pub struct Negation {
     pub pattern: Box<Pattern>,
+    normalised: Option<Box<Negation>>,
+}
+
+impl PartialEq for Negation {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern
+    }
 }
 
 impl Negation {
     pub fn new(pattern: Pattern) -> Self {
-        Self { pattern: Box::new(pattern) }
+        Self { pattern: Box::new(pattern), normalised: None }
     }
 
     pub fn expect_is_bounded_by(&self, bounds: &HashSet<Reference>) -> Result<()> {
@@ -48,6 +55,23 @@ impl Validatable for Negation {
             Pattern::Negation(_) => Err(REDUNDANT_NESTED_NEGATION.format(&[]))?,
             _ => Ok(()),
         }
+    }
+}
+
+impl Normalisable for Negation {
+    fn normalise(&mut self) -> Pattern {
+        if self.normalised.is_none() {
+            self.normalised = Some(Box::new(Negation::new(match self.pattern.as_mut() {
+                Pattern::Conjunction(conjunction) => conjunction.normalise(),
+                Pattern::Disjunction(disjunction) => disjunction.normalise(),
+                Pattern::Negation(_) => panic!("{}", REDUNDANT_NESTED_NEGATION.format(&[])),
+                Pattern::Variable(variable) => {
+                    Disjunction::new(vec![Conjunction::new(vec![variable.clone().into()]).into()])
+                        .into()
+                }
+            })));
+        }
+        self.normalised.as_ref().unwrap().as_ref().clone().into()
     }
 }
 

--- a/rust/pattern/negation.rs
+++ b/rust/pattern/negation.rs
@@ -61,17 +61,22 @@ impl Validatable for Negation {
 impl Normalisable for Negation {
     fn normalise(&mut self) -> Pattern {
         if self.normalised.is_none() {
-            self.normalised = Some(Box::new(Negation::new(match self.pattern.as_mut() {
-                Pattern::Conjunction(conjunction) => conjunction.normalise(),
-                Pattern::Disjunction(disjunction) => disjunction.normalise(),
-                Pattern::Negation(_) => panic!("{}", REDUNDANT_NESTED_NEGATION.format(&[])),
-                Pattern::Variable(variable) => {
-                    Disjunction::new(vec![Conjunction::new(vec![variable.clone().into()]).into()])
-                        .into()
-                }
-            })));
+            self.normalised = Some(Box::new(self.compute_normalised().into_negation()));
         }
         self.normalised.as_ref().unwrap().as_ref().clone().into()
+    }
+
+    fn compute_normalised(&self) -> Pattern {
+        Negation::new(match self.pattern.as_ref() {
+            Pattern::Conjunction(conjunction) => conjunction.compute_normalised(),
+            Pattern::Disjunction(disjunction) => disjunction.compute_normalised(),
+            Pattern::Negation(_) => panic!("{}", REDUNDANT_NESTED_NEGATION.format(&[])),
+            Pattern::Variable(variable) => {
+                Disjunction::new(vec![Conjunction::new(vec![variable.clone().into()]).into()])
+                    .into()
+            }
+        })
+        .into()
     }
 }
 

--- a/rust/pattern/test/mod.rs
+++ b/rust/pattern/test/mod.rs
@@ -19,3 +19,71 @@
  * under the License.
  *
  */
+
+use crate::{
+    and, not, or, parse_query,
+    pattern::{Conjunction, Disjunction, Normalisable, Pattern, ThingVariableBuilder},
+    var,
+};
+
+#[test]
+fn disjunction() {
+    let query = r#"match
+$com isa company;
+{
+    $com has name $n1;
+    $n1 "the-company";
+} or {
+    $com has name $n2;
+    $n2 "another-company";
+};"#;
+
+    let mut parsed = parse_query(query).unwrap().into_match();
+    let normalised = parsed.conjunction.normalise().into_disjunction();
+
+    assert_eq!(
+        normalised,
+        or!(
+            and!(
+                var("com").has(("name", var("n1"))),
+                var("n1").eq("the-company"),
+                var("com").isa("company"),
+            ),
+            and!(
+                var("com").has(("name", var("n2"))),
+                var("n2").eq("another-company"),
+                var("com").isa("company"),
+            )
+        )
+        .into_disjunction()
+    );
+}
+
+#[test]
+fn negated_disjunction() {
+    let query = r#"match
+$com isa company;
+not {
+    $com has name $n1;
+    {
+        $n1 "the-company";
+    } or {
+        $n1 "another-company";
+    };
+};"#;
+
+    let mut parsed = parse_query(query).unwrap().into_match();
+    let normalised = parsed.conjunction.normalise().into_disjunction();
+
+    assert_eq!(
+        normalised,
+        Disjunction::new(vec![and!(
+            var("com").isa("company"),
+            not(or!(
+                and!(var("n1").eq("the-company"), var("com").has(("name", var("n1")))),
+                and!(var("n1").eq("another-company"), var("com").has(("name", var("n1")))),
+            ))
+        )
+        .into()])
+    );
+}

--- a/rust/pattern/test/mod.rs
+++ b/rust/pattern/test/mod.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     and, not, or, parse_query,
-    pattern::{Conjunction, Disjunction, Normalisable, Pattern, ThingVariableBuilder},
+    pattern::{Conjunction, Disjunction, Normalisable, ThingVariableBuilder},
     var,
 };
 

--- a/rust/pattern/variable/mod.rs
+++ b/rust/pattern/variable/mod.rs
@@ -104,6 +104,10 @@ impl Validatable for Variable {
 
 impl Normalisable for Variable {
     fn normalise(&mut self) -> Pattern {
+        self.compute_normalised()
+    }
+
+    fn compute_normalised(&self) -> Pattern {
         self.clone().into()
     }
 }

--- a/rust/pattern/variable/mod.rs
+++ b/rust/pattern/variable/mod.rs
@@ -46,6 +46,7 @@ pub use builder::{
 use crate::{
     common::{error::MATCH_HAS_UNBOUNDED_NESTED_PATTERN, validatable::Validatable, Result},
     enum_wrapper,
+    pattern::{Normalisable, Pattern},
 };
 use std::fmt;
 
@@ -82,6 +83,13 @@ impl Variable {
     }
 }
 
+enum_wrapper! { Variable
+    ConceptVariable => Concept,
+    ThingVariable => Thing,
+    TypeVariable => Type,
+    UnboundVariable => Unbound,
+}
+
 impl Validatable for Variable {
     fn validate(&self) -> Result<()> {
         use Variable::*;
@@ -94,11 +102,10 @@ impl Validatable for Variable {
     }
 }
 
-enum_wrapper! { Variable
-    ConceptVariable => Concept,
-    ThingVariable => Thing,
-    TypeVariable => Type,
-    UnboundVariable => Unbound,
+impl Normalisable for Variable {
+    fn normalise(&mut self) -> Pattern {
+        self.clone().into()
+    }
 }
 
 impl fmt::Display for Variable {

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -78,6 +78,18 @@ enum_getter! { Query
     into_group_aggregate(GroupAggregate) => TypeQLMatchGroupAggregate,
 }
 
+enum_wrapper! { Query
+    TypeQLMatch => Match,
+    TypeQLInsert => Insert,
+    TypeQLDelete => Delete,
+    TypeQLUpdate => Update,
+    TypeQLDefine => Define,
+    TypeQLUndefine => Undefine,
+    TypeQLMatchAggregate => Aggregate,
+    TypeQLMatchGroup => Group,
+    TypeQLMatchGroupAggregate => GroupAggregate,
+}
+
 impl Validatable for Query {
     fn validate(&self) -> Result<()> {
         use Query::*;
@@ -108,18 +120,6 @@ impl Validatable for Query {
             GroupAggregate(query) => query.validated().map(TypeQLMatchGroupAggregate::into),
         }
     }
-}
-
-enum_wrapper! { Query
-    TypeQLMatch => Match,
-    TypeQLInsert => Insert,
-    TypeQLDelete => Delete,
-    TypeQLUpdate => Update,
-    TypeQLDefine => Define,
-    TypeQLUndefine => Undefine,
-    TypeQLMatchAggregate => Aggregate,
-    TypeQLMatchGroup => Group,
-    TypeQLMatchGroupAggregate => GroupAggregate,
 }
 
 impl fmt::Display for Query {

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -66,16 +66,16 @@ pub enum Query {
     GroupAggregate(TypeQLMatchGroupAggregate),
 }
 
-impl Query {
-    enum_getter!(into_match, Match, TypeQLMatch);
-    enum_getter!(into_insert, Insert, TypeQLInsert);
-    enum_getter!(into_delete, Delete, TypeQLDelete);
-    enum_getter!(into_update, Update, TypeQLUpdate);
-    enum_getter!(into_define, Define, TypeQLDefine);
-    enum_getter!(into_undefine, Undefine, TypeQLUndefine);
-    enum_getter!(into_aggregate, Aggregate, TypeQLMatchAggregate);
-    enum_getter!(into_group, Group, TypeQLMatchGroup);
-    enum_getter!(into_group_aggregate, GroupAggregate, TypeQLMatchGroupAggregate);
+enum_getter! { Query
+    into_match(Match) => TypeQLMatch,
+    into_insert(Insert) => TypeQLInsert,
+    into_delete(Delete) => TypeQLDelete,
+    into_update(Update) => TypeQLUpdate,
+    into_define(Define) => TypeQLDefine,
+    into_undefine(Undefine) => TypeQLUndefine,
+    into_aggregate(Aggregate) => TypeQLMatchAggregate,
+    into_group(Group) => TypeQLMatchGroup,
+    into_group_aggregate(GroupAggregate) => TypeQLMatchGroupAggregate,
 }
 
 impl Validatable for Query {

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -20,10 +20,6 @@
  *
  */
 
-use std::fmt;
-
-use crate::{enum_getter, enum_wrapper};
-
 mod aggregate;
 pub use aggregate::{AggregateQueryBuilder, TypeQLMatchAggregate, TypeQLMatchGroupAggregate};
 
@@ -51,7 +47,11 @@ pub use typeql_update::TypeQLUpdate;
 mod writable;
 pub use writable::Writable;
 
-use crate::common::{validatable::Validatable, Result};
+use crate::{
+    common::{error::INVALID_CASTING, validatable::Validatable, Result},
+    enum_getter, enum_wrapper,
+};
+use std::fmt;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Query {

--- a/rust/query/typeql_define.rs
+++ b/rust/query/typeql_define.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     common::{
-        error::{collect_err, INVALID_RULE_WHEN_MISSING_PATTERNS},
+        error::{collect_err, INVALID_RULE_WHEN_MISSING_PATTERNS, MISSING_DEFINABLES},
         token,
         validatable::Validatable,
         Result,
@@ -30,7 +30,7 @@ use crate::{
     pattern::{Definable, RuleDefinition, TypeVariable},
     write_joined,
 };
-use std::fmt;
+use std::{fmt, iter};
 
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct TypeQLDefine {
@@ -63,11 +63,19 @@ impl TypeQLDefine {
 impl Validatable for TypeQLDefine {
     fn validate(&self) -> Result<()> {
         collect_err(
-            &mut (self.variables.iter().map(Validatable::validate))
+            &mut iter::once(expect_non_empty(&self.variables, &self.rules))
+                .chain(self.variables.iter().map(Validatable::validate))
                 .chain(self.variables.iter().map(TypeVariable::validate_definable))
                 .chain(self.rules.iter().map(Validatable::validate)),
         )
     }
+}
+
+fn expect_non_empty(variables: &[TypeVariable], rules: &[RuleDefinition]) -> Result<()> {
+    if variables.is_empty() && rules.is_empty() {
+        Err(MISSING_DEFINABLES.format(&[]))?
+    }
+    Ok(())
 }
 
 impl fmt::Display for TypeQLDefine {

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -258,22 +258,17 @@ impl fmt::Display for Filter {
 pub mod sorting {
     use crate::pattern::UnboundVariable;
     use std::fmt;
+    use crate::common::token;
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct OrderedVariable {
         pub var: UnboundVariable,
-        pub order: Option<String>, // FIXME
+        pub order: Option<token::Order>,
     }
 
     impl OrderedVariable {
-        pub fn new(var: UnboundVariable, order: &str) -> Self {
-            OrderedVariable {
-                var,
-                order: match order {
-                    "" => None,
-                    order => Some(order.to_string()),
-                },
-            }
+        pub fn new(var: UnboundVariable, order: Option<token::Order>) -> Self {
+            OrderedVariable { var, order }
         }
     }
 
@@ -301,15 +296,15 @@ impl Sorting {
 
 impl From<&str> for Sorting {
     fn from(var_name: &str) -> Self {
-        Self::from([(var_name, "")])
+        Self::from(vec![var(var_name)])
     }
 }
 
-impl<const N: usize> From<([(&str, &str); N])> for Sorting {
-    fn from(ordered_vars: [(&str, &str); N]) -> Self {
+impl<const N: usize> From<([(&str, token::Order); N])> for Sorting {
+    fn from(ordered_vars: [(&str, token::Order); N]) -> Self {
         Self::new(
             ordered_vars
-                .map(|(name, order)| sorting::OrderedVariable::new(var(name), order))
+                .map(|(name, order)| sorting::OrderedVariable::new(var(name), Some(order)))
                 .to_vec(),
         )
     }
@@ -318,7 +313,7 @@ impl<const N: usize> From<([(&str, &str); N])> for Sorting {
 impl From<Vec<UnboundVariable>> for Sorting {
     fn from(vars: Vec<UnboundVariable>) -> Self {
         Self::new(
-            vars.into_iter().map(|name| sorting::OrderedVariable::new(var(name), "")).collect(),
+            vars.into_iter().map(|name| sorting::OrderedVariable::new(var(name), None)).collect(),
         )
     }
 }

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -36,6 +36,7 @@ use crate::{
     var, write_joined,
 };
 use std::{collections::HashSet, fmt, iter};
+use crate::common::error::EMPTY_MATCH_FILTER;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TypeQLMatch {
@@ -150,6 +151,9 @@ fn expect_each_variable_is_bounded_by_named<'a>(
 fn expect_filters_are_in_scope(conjunction: &Conjunction, filter: &Option<Filter>) -> Result<()> {
     let names_in_scope = conjunction.named_references();
     let mut seen = HashSet::new();
+    if filter.as_ref().map_or(false, |f| f.vars.is_empty()) {
+        Err(EMPTY_MATCH_FILTER.format(&[]))?;
+    }
     collect_err(&mut filter.iter().flat_map(|f| &f.vars).map(|v| &v.reference).map(|r| {
         if !r.is_name() {
             Err(Error::from(VARIABLE_NOT_NAMED.format(&[])))

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -24,7 +24,7 @@
 macro_rules! enum_getter {
     {$enum_name:ident $($fn_name:ident ( $enum_variant:ident ) => $classname:ty),* $(,)?} => {
         impl $enum_name {
-            fn get_name(&self) -> &'static str {
+            fn __enum_getter__get_name(&self) -> &'static str {
                 match self {
                     $(
                     Self::$enum_variant(_) => stringify!($enum_variant),
@@ -37,7 +37,10 @@ macro_rules! enum_getter {
                 match self {
                     Self::$enum_variant(x) => x,
                     _ => panic!("{}", INVALID_CASTING.format(&[
-                        stringify!($enum_name), self.get_name(), stringify!($enum_variant), stringify!($classname)
+                        stringify!($enum_name),
+                        self.__enum_getter__get_name(),
+                        stringify!($enum_variant),
+                        stringify!($classname)
                     ])),
                 }
             }

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -22,22 +22,32 @@
 
 #[macro_export]
 macro_rules! enum_getter {
-    ($fn_name:ident, $enum_value:ident, $classname:ty) => {
-        pub fn $fn_name(self) -> $classname {
-            match self {
-                Self::$enum_value(x) => x,
-                _ => panic!(
-                    "{}",
-                    INVALID_CASTING.format(&[stringify!($enum_value), stringify!($classname)])
-                ),
+    {$enum_name:ident $($fn_name:ident ( $enum_variant:ident ) => $classname:ty),* $(,)?} => {
+        impl $enum_name {
+            fn get_name(&self) -> &'static str {
+                match self {
+                    $(
+                    Self::$enum_variant(_) => stringify!($enum_variant),
+                    )*
+                }
             }
         }
+        $(impl $enum_name {
+            pub fn $fn_name(self) -> $classname {
+                match self {
+                    Self::$enum_variant(x) => x,
+                    _ => panic!("{}", INVALID_CASTING.format(&[
+                        stringify!($enum_name), self.get_name(), stringify!($enum_variant), stringify!($classname)
+                    ])),
+                }
+            }
+        })*
     };
 }
 
 #[macro_export]
 macro_rules! enum_wrapper {
-    {$enum_name:ident $($classname:ty => $enum_value:ident),* $(,)*} => {
+    {$enum_name:ident $($classname:ty => $enum_value:ident),* $(,)?} => {
         $(impl From<$classname> for $enum_name {
             fn from(x: $classname) -> Self {
                 Self::$enum_value(x)
@@ -48,7 +58,7 @@ macro_rules! enum_wrapper {
 
 #[macro_export]
 macro_rules! write_joined {
-    ($f:ident, $joiner:expr, $($iterable:expr),* $(,)*) => {{
+    ($f:ident, $joiner:expr, $($iterable:expr),* $(,)?) => {{
         let mut result: std::fmt::Result = Ok(());
         let mut _is_first = true;
         $(

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -26,7 +26,10 @@ macro_rules! enum_getter {
         pub fn $fn_name(self) -> $classname {
             match self {
                 Self::$enum_value(x) => x,
-                _ => panic!(""),
+                _ => panic!(
+                    "{}",
+                    INVALID_CASTING.format(&[stringify!($enum_value), stringify!($classname)])
+                ),
             }
         }
     };

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -24,7 +24,7 @@
 macro_rules! enum_getter {
     {$enum_name:ident $($fn_name:ident ( $enum_variant:ident ) => $classname:ty),* $(,)?} => {
         impl $enum_name {
-            fn __enum_getter__get_name(&self) -> &'static str {
+            fn __enum_getter_get_name(&self) -> &'static str {
                 match self {
                     $(
                     Self::$enum_variant(_) => stringify!($enum_variant),
@@ -38,7 +38,7 @@ macro_rules! enum_getter {
                     Self::$enum_variant(x) => x,
                     _ => panic!("{}", INVALID_CASTING.format(&[
                         stringify!($enum_name),
-                        self.__enum_getter__get_name(),
+                        self.__enum_getter_get_name(),
                         stringify!($enum_variant),
                         stringify!($classname)
                     ])),


### PR DESCRIPTION
## What is the goal of this PR?

We implement pattern normalisation: a conjunction or a disjunction becomes a flat disjunction of conjunctions. Negations are not expanded.

## What are the changes implemented in this PR?

Main change:
- implement normalisation routines.

Misc. drive-by improvements:
- implement missing validation checks;
- implement missing functionality: `sub!`, `isa!`;
- improve error reporting;
- refactoring:
    - use enums for sort ordering;
    - hide error templates from library users;
    - clean up dodgy code (double references, redundant closures, etc.)