### PR TITLE
Idiomatic Rust error message enum

### DIFF
--- a/rust/BUILD
+++ b/rust/BUILD
@@ -50,7 +50,7 @@ rust_library(
     proc_macro_deps = [
         "@vaticle_dependencies//library/crates:pest_derive",
     ],
-    visibility = ["//rust:__subpackages__"]
+    visibility = ["//visibility:public"]
 )
 
 rust_test(

--- a/rust/common/error.rs
+++ b/rust/common/error.rs
@@ -20,14 +20,16 @@
  *
  */
 
+use std::fmt;
+
+use chrono::NaiveDateTime;
+use pest::error::{Error as PestError, LineColLocation};
+
 use crate::{
     common::token,
     pattern::{Label, Pattern, Reference, ThingVariable, TypeVariable, UnboundVariable, Value},
     write_joined,
 };
-use chrono::NaiveDateTime;
-use pest::error::{Error as PestError, LineColLocation};
-use std::fmt;
 
 #[derive(Debug)]
 pub struct Error {

--- a/rust/common/error.rs
+++ b/rust/common/error.rs
@@ -136,10 +136,12 @@ macro_rules! format_message {
 
 #[macro_export]
 macro_rules! error_messages {
-    {$name:ident code: $code_pfx:literal, type: $message_pfx:literal,
-    $(
-        $error_name:ident( $($inner:ty),* $(,)? ) = $code:literal: $body:literal
-    ),* $(,)?} => {
+    {
+        $name:ident code: $code_pfx:literal, type: $message_pfx:literal,
+        $(
+            $error_name:ident( $($inner:ty),* $(,)? ) = $code:literal: $body:literal
+        ),* $(,)?
+    } => {
         error_messages!(
             $name, $code_pfx, num_digits(max!($($code),*)), $message_pfx,
             $(($error_name, $code, $body, ($($inner),*))),*

--- a/rust/common/error.rs
+++ b/rust/common/error.rs
@@ -134,6 +134,7 @@ macro_rules! format_message {
     };
 }
 
+#[macro_export]
 macro_rules! error_messages {
     {$name:ident code: $code_pfx:literal, type: $message_pfx:literal,
     $(

--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#[macro_export]
+macro_rules! error_messages {
+    {
+        $name:ident code: $code_pfx:literal, type: $message_pfx:literal,
+        $(
+            $error_name:ident( $($inner:ty),* $(,)? ) = $code:literal: $body:literal
+        ),* $(,)?
+    } => {
+        error_messages_impl!(
+            $name, $code_pfx, max!($($code),*), $message_pfx,
+            $(($error_name, $code, $body, ($($inner),*))),*
+        );
+    };
+}
+
+macro_rules! error_messages_impl {
+    (
+        $name:ident, $code_pfx:literal, $max_code:expr, $message_pfx:literal,
+        $(($error_name:ident, $code:literal, $body:literal, ($($inner:ty),*))),*
+    ) => {
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        pub enum $name {$(
+            $error_name($($inner),*),
+        )*}
+
+        impl $name {
+            pub fn code(&self) -> usize {
+                match self {$(
+                    Self::$error_name(..) => $code,
+                )*}
+            }
+
+            fn __padding_len(&self) -> usize {
+                let num_digits = |mut x: usize| -> usize {
+                    let mut len = 1;
+                    while x > 10 {
+                        len += 1;
+                        x /= 10;
+                    }
+                    len
+                };
+                match self {$(
+                    Self::$error_name(..) => num_digits($max_code) - num_digits($code),
+                )*}
+            }
+
+            pub fn message(&self) -> String {
+                match self {$(
+                    Self::$error_name(..) => format_message!(self, $error_name, $body, $($inner),*),
+                )*}
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, concat!("[", $code_pfx, "{}{}] ", $message_pfx, ": {}"), "0".repeat(self.__padding_len()), self.code(), self.message())
+            }
+        }
+    };
+}
+
+macro_rules! format_message {
+    ($self:ident, $error_name:ident, $body:literal, ) => {
+        format!($body)
+    };
+    ($self:ident, $error_name:ident, $body:literal, $t1:ty) => {
+        if let Self::$error_name(a) = &$self {
+            format!($body, a)
+        } else {
+            unreachable!()
+        }
+    };
+    ($self:ident, $error_name:ident, $body:literal, $t1:ty, $t2:ty) => {
+        if let Self::$error_name(a, b) = &$self {
+            format!($body, a, b)
+        } else {
+            unreachable!()
+        }
+    };
+    ($self:ident, $error_name:ident, $body:literal, $t1:ty, $t2:ty, $t3:ty) => {
+        if let Self::$error_name(a, b, c) = &$self {
+            format!($body, a, b, c)
+        } else {
+            unreachable!()
+        }
+    };
+    ($self:ident, $error_name:ident, $body:literal, $t1:ty, $t2:ty, $t3:ty, $t4:ty) => {
+        if let Self::$error_name(a, b, c, d) = &$self {
+            format!($body, a, b, c, d)
+        } else {
+            unreachable!()
+        }
+    };
+}
+
+macro_rules! max {
+    (
+        $x0:literal, $x1:literal, $x2:literal, $x3:literal, $x4:literal,
+        $x5:literal, $x6:literal, $x7:literal, $x8:literal, $x9:literal,
+        $($xs:literal),*
+    ) => {
+        max_branch!(max!($x0, $x1, $x2, $x3, $x4, $x5, $x6, $x7, $x8, $x9), max!($($xs),*))
+    };
+    ($x:literal, $($xs:literal),*) => { max_branch!($x, max!($($xs),*)) };
+    ($x:literal) => ($x);
+}
+
+macro_rules! max_branch {
+    ($lhs:expr, $rhs:expr) => {{
+        let lhs = $lhs;
+        let rhs = $rhs;
+        if lhs > rhs {
+            lhs
+        } else {
+            rhs
+        }
+    }};
+}

--- a/rust/common/mod.rs
+++ b/rust/common/mod.rs
@@ -26,4 +26,6 @@ pub mod string;
 pub mod token;
 pub mod validatable;
 
-pub type Result<T> = std::result::Result<T, error::Error>;
+pub use error::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -23,6 +23,10 @@
 #[cfg(test)]
 mod test;
 
+use chrono::{NaiveDate, NaiveDateTime};
+use pest::Parser;
+use pest_derive::Parser;
+
 use crate::{
     common::{
         date_time,
@@ -46,9 +50,6 @@ use crate::{
         TypeQLUndefine, TypeQLUpdate,
     },
 };
-use chrono::{NaiveDate, NaiveDateTime};
-use pest::Parser;
-use pest_derive::Parser;
 
 #[derive(Parser)]
 #[grammar = "parser/typeql.pest"]

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -184,25 +184,33 @@ fn get_regex(string: SyntaxTree) -> String {
 }
 
 fn get_long(long: SyntaxTree) -> i64 {
-    long.as_str().parse().expect(&TypeQLError::IllegalGrammar(long.to_string()).to_string())
+    long.as_str()
+        .parse()
+        .unwrap_or_else(|_| panic!("{}", TypeQLError::IllegalGrammar(long.to_string())))
 }
 
 fn get_double(double: SyntaxTree) -> f64 {
-    double.as_str().parse().expect(&TypeQLError::IllegalGrammar(double.to_string()).to_string())
+    double
+        .as_str()
+        .parse()
+        .unwrap_or_else(|_| panic!("{}", TypeQLError::IllegalGrammar(double.to_string())))
 }
 
 fn get_boolean(boolean: SyntaxTree) -> bool {
-    boolean.as_str().parse().expect(&TypeQLError::IllegalGrammar(boolean.to_string()).to_string())
+    boolean
+        .as_str()
+        .parse()
+        .unwrap_or_else(|_| panic!("{}", TypeQLError::IllegalGrammar(boolean.to_string())))
 }
 
 fn get_date(date: SyntaxTree) -> NaiveDate {
     NaiveDate::parse_from_str(date.as_str(), "%Y-%m-%d")
-        .expect(&TypeQLError::IllegalGrammar(date.to_string()).to_string())
+        .unwrap_or_else(|_| panic!("{}", TypeQLError::IllegalGrammar(date.to_string())))
 }
 
 fn get_date_time(date_time: SyntaxTree) -> NaiveDateTime {
     date_time::parse(date_time.as_str())
-        .expect(&TypeQLError::IllegalGrammar(date_time.to_string()).to_string())
+        .unwrap_or_else(|| panic!("{}", TypeQLError::IllegalGrammar(date_time.to_string())))
 }
 
 fn get_var(var: SyntaxTree) -> UnboundVariable {

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+
 use crate::{
     and,
     common::{
@@ -37,7 +39,6 @@ use crate::{
     query::{AggregateQueryBuilder, TypeQLDefine, TypeQLInsert, TypeQLMatch, TypeQLUndefine},
     rel, rule, type_, typeql_insert, typeql_match, var, Query,
 };
-use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
 macro_rules! assert_valid_eq_repr {
     ($expected:ident, $parsed:ident, $query:ident) => {

--- a/rust/pattern/conjunction.rs
+++ b/rust/pattern/conjunction.rs
@@ -26,7 +26,7 @@ use itertools::Itertools;
 
 use crate::{
     common::{
-        error::{collect_err, ErrorMessage},
+        error::{collect_err, TypeQLError},
         string::indent,
         validatable::Validatable,
         Result,
@@ -84,7 +84,7 @@ fn expect_bounded(
     conjunction: &Conjunction,
 ) -> Result<()> {
     if bounds.is_disjoint(names) {
-        Err(ErrorMessage::MatchHasUnboundedNestedPattern(conjunction.clone().into()))?;
+        Err(TypeQLError::MatchHasUnboundedNestedPattern(conjunction.clone().into()))?;
     }
     Ok(())
 }

--- a/rust/pattern/conjunction.rs
+++ b/rust/pattern/conjunction.rs
@@ -20,6 +20,10 @@
  *
  */
 
+use std::{collections::HashSet, fmt, iter};
+
+use itertools::Itertools;
+
 use crate::{
     common::{
         error::{collect_err, ErrorMessage},
@@ -29,8 +33,6 @@ use crate::{
     },
     pattern::{Disjunction, NamedReferences, Normalisable, Pattern, Reference},
 };
-use itertools::Itertools;
-use std::{collections::HashSet, fmt, iter};
 
 #[derive(Debug, Clone, Eq)]
 pub struct Conjunction {

--- a/rust/pattern/conjunction.rs
+++ b/rust/pattern/conjunction.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     common::{
-        error::{collect_err, MATCH_HAS_UNBOUNDED_NESTED_PATTERN},
+        error::{collect_err, ErrorMessage},
         string::indent,
         validatable::Validatable,
         Result,
@@ -82,8 +82,7 @@ fn expect_bounded(
     conjunction: &Conjunction,
 ) -> Result<()> {
     if bounds.is_disjoint(names) {
-        Err(MATCH_HAS_UNBOUNDED_NESTED_PATTERN
-            .format(&[&conjunction.to_string().replace('\n', " ")]))?;
+        Err(ErrorMessage::MatchHasUnboundedNestedPattern(conjunction.clone().into()))?;
     }
     Ok(())
 }

--- a/rust/pattern/constraint/concept.rs
+++ b/rust/pattern/constraint/concept.rs
@@ -20,12 +20,13 @@
  *
  */
 
+use std::fmt;
+
 use crate::{
     common::{token, validatable::Validatable, Result},
     pattern::{ConceptVariable, UnboundVariable},
     var,
 };
-use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct IsConstraint {

--- a/rust/pattern/constraint/mod.rs
+++ b/rust/pattern/constraint/mod.rs
@@ -21,18 +21,17 @@
  */
 
 mod concept;
-pub use concept::IsConstraint;
-
-mod type_;
-pub use type_::{
-    AbstractConstraint, IsKeyAttribute, LabelConstraint, OwnsConstraint, PlaysConstraint,
-    RegexConstraint, RelatesConstraint, SubConstraint, ValueTypeConstraint, KEY,
-};
-
 mod thing;
+mod type_;
+
+pub use concept::IsConstraint;
 pub use thing::{
     HasConstraint, IIDConstraint, IsaConstraint, RelationConstraint, RolePlayerConstraint, Value,
     ValueConstraint,
+};
+pub use type_::{
+    AbstractConstraint, IsKeyAttribute, LabelConstraint, OwnsConstraint, PlaysConstraint,
+    RegexConstraint, RelatesConstraint, SubConstraint, ValueTypeConstraint, KEY,
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/rust/pattern/constraint/thing/has.rs
+++ b/rust/pattern/constraint/thing/has.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{error::collect_err, token, validatable::Validatable, Result},
     pattern::{
@@ -27,7 +29,6 @@ use crate::{
         UnboundVariable, Value, ValueConstraint,
     },
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct HasConstraint {

--- a/rust/pattern/constraint/thing/iid.rs
+++ b/rust/pattern/constraint/thing/iid.rs
@@ -20,8 +20,9 @@
  *
  */
 
-use crate::common::{error::ErrorMessage, token, validatable::Validatable, Result};
 use std::fmt;
+
+use crate::common::{error::ErrorMessage, token, validatable::Validatable, Result};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct IIDConstraint {

--- a/rust/pattern/constraint/thing/iid.rs
+++ b/rust/pattern/constraint/thing/iid.rs
@@ -20,7 +20,7 @@
  *
  */
 
-use crate::common::{error::INVALID_IID_STRING, token, validatable::Validatable, Result};
+use crate::common::{error::ErrorMessage, token, validatable::Validatable, Result};
 use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -41,7 +41,7 @@ impl IIDConstraint {
 impl Validatable for IIDConstraint {
     fn validate(&self) -> Result<()> {
         if !is_valid_iid(&self.iid) {
-            Err(INVALID_IID_STRING.format(&[&self.iid]))?
+            Err(ErrorMessage::InvalidIIDString(self.iid.clone()))?
         }
         Ok(())
     }

--- a/rust/pattern/constraint/thing/iid.rs
+++ b/rust/pattern/constraint/thing/iid.rs
@@ -22,7 +22,7 @@
 
 use std::fmt;
 
-use crate::common::{error::ErrorMessage, token, validatable::Validatable, Result};
+use crate::common::{error::TypeQLError, token, validatable::Validatable, Result};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct IIDConstraint {
@@ -42,7 +42,7 @@ impl IIDConstraint {
 impl Validatable for IIDConstraint {
     fn validate(&self) -> Result<()> {
         if !is_valid_iid(&self.iid) {
-            Err(ErrorMessage::InvalidIIDString(self.iid.clone()))?
+            Err(TypeQLError::InvalidIIDString(self.iid.clone()))?
         }
         Ok(())
     }

--- a/rust/pattern/constraint/thing/isa.rs
+++ b/rust/pattern/constraint/thing/isa.rs
@@ -20,12 +20,13 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{token, validatable::Validatable, Result},
     pattern::{IsExplicit, Reference, TypeVariable, TypeVariableBuilder, UnboundVariable},
     Label,
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct IsaConstraint {

--- a/rust/pattern/constraint/thing/mod.rs
+++ b/rust/pattern/constraint/thing/mod.rs
@@ -21,16 +21,13 @@
  */
 
 mod has;
-pub use has::HasConstraint;
-
 mod iid;
-pub use iid::IIDConstraint;
-
 mod isa;
-pub use isa::IsaConstraint;
-
 mod relation;
-pub use relation::{RelationConstraint, RolePlayerConstraint};
-
 mod value;
+
+pub use has::HasConstraint;
+pub use iid::IIDConstraint;
+pub use isa::IsaConstraint;
+pub use relation::{RelationConstraint, RolePlayerConstraint};
 pub use value::{Value, ValueConstraint};

--- a/rust/pattern/constraint/thing/relation.rs
+++ b/rust/pattern/constraint/thing/relation.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{
         error::{collect_err, ErrorMessage},
@@ -30,7 +32,6 @@ use crate::{
     pattern::{Reference, ThingVariable, TypeVariable, TypeVariableBuilder, UnboundVariable},
     write_joined, Label,
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RelationConstraint {

--- a/rust/pattern/constraint/thing/relation.rs
+++ b/rust/pattern/constraint/thing/relation.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     common::{
-        error::{collect_err, MISSING_CONSTRAINT_RELATION_PLAYER},
+        error::{collect_err, ErrorMessage},
         token,
         validatable::Validatable,
         Result,
@@ -63,7 +63,7 @@ impl Validatable for RelationConstraint {
 
 fn expect_role_players_present(role_players: &[RolePlayerConstraint]) -> Result<()> {
     if role_players.is_empty() {
-        Err(MISSING_CONSTRAINT_RELATION_PLAYER.format(&[]))?
+        Err(ErrorMessage::MissingConstraintRelationPlayer())?
     }
     Ok(())
 }

--- a/rust/pattern/constraint/thing/relation.rs
+++ b/rust/pattern/constraint/thing/relation.rs
@@ -24,7 +24,7 @@ use std::{fmt, iter};
 
 use crate::{
     common::{
-        error::{collect_err, ErrorMessage},
+        error::{collect_err, TypeQLError},
         token,
         validatable::Validatable,
         Result,
@@ -64,7 +64,7 @@ impl Validatable for RelationConstraint {
 
 fn expect_role_players_present(role_players: &[RolePlayerConstraint]) -> Result<()> {
     if role_players.is_empty() {
-        Err(ErrorMessage::MissingConstraintRelationPlayer())?
+        Err(TypeQLError::MissingConstraintRelationPlayer())?
     }
     Ok(())
 }

--- a/rust/pattern/constraint/thing/value.rs
+++ b/rust/pattern/constraint/thing/value.rs
@@ -20,6 +20,10 @@
  *
  */
 
+use std::{fmt, iter};
+
+use chrono::{NaiveDateTime, Timelike};
+
 use crate::{
     common::{
         date_time,
@@ -31,8 +35,6 @@ use crate::{
     },
     pattern::{Reference, ThingVariable, UnboundVariable},
 };
-use chrono::{NaiveDateTime, Timelike};
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ValueConstraint {

--- a/rust/pattern/constraint/thing/value.rs
+++ b/rust/pattern/constraint/thing/value.rs
@@ -23,7 +23,7 @@
 use crate::{
     common::{
         date_time,
-        error::{collect_err, INVALID_CONSTRAINT_DATETIME_PRECISION, INVALID_CONSTRAINT_PREDICATE},
+        error::{collect_err, ErrorMessage},
         string::{escape_regex, format_double, quote},
         token,
         validatable::Validatable,
@@ -70,7 +70,7 @@ fn expect_string_value_with_substring_predicate(
     value: &Value,
 ) -> Result<()> {
     if predicate.is_substring() && !matches!(value, Value::String(_)) {
-        Err(INVALID_CONSTRAINT_PREDICATE.format(&[&predicate.to_string(), &value.to_string()]))?
+        Err(ErrorMessage::InvalidConstraintPredicate(predicate, value.clone()))?
     }
     Ok(())
 }
@@ -106,8 +106,7 @@ impl Validatable for Value {
         match &self {
             Self::DateTime(date_time) => {
                 if date_time.nanosecond() % 1000000 > 0 {
-                    Err(INVALID_CONSTRAINT_DATETIME_PRECISION
-                        .format(&[date_time.to_string().as_str()]))?
+                    Err(ErrorMessage::InvalidConstraintDatetimePrecision(date_time.clone()))?
                 }
                 Ok(())
             }

--- a/rust/pattern/constraint/thing/value.rs
+++ b/rust/pattern/constraint/thing/value.rs
@@ -27,7 +27,7 @@ use chrono::{NaiveDateTime, Timelike};
 use crate::{
     common::{
         date_time,
-        error::{collect_err, ErrorMessage},
+        error::{collect_err, TypeQLError},
         string::{escape_regex, format_double, quote},
         token,
         validatable::Validatable,
@@ -72,7 +72,7 @@ fn expect_string_value_with_substring_predicate(
     value: &Value,
 ) -> Result<()> {
     if predicate.is_substring() && !matches!(value, Value::String(_)) {
-        Err(ErrorMessage::InvalidConstraintPredicate(predicate, value.clone()))?
+        Err(TypeQLError::InvalidConstraintPredicate(predicate, value.clone()))?
     }
     Ok(())
 }
@@ -108,7 +108,7 @@ impl Validatable for Value {
         match &self {
             Self::DateTime(date_time) => {
                 if date_time.nanosecond() % 1000000 > 0 {
-                    Err(ErrorMessage::InvalidConstraintDatetimePrecision(date_time.clone()))?
+                    Err(TypeQLError::InvalidConstraintDatetimePrecision(date_time.clone()))?
                 }
                 Ok(())
             }

--- a/rust/pattern/constraint/type_/abstract_.rs
+++ b/rust/pattern/constraint/type_/abstract_.rs
@@ -20,8 +20,9 @@
  *
  */
 
-use crate::common::{token, validatable::Validatable, Result};
 use std::fmt;
+
+use crate::common::{token, validatable::Validatable, Result};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct AbstractConstraint;

--- a/rust/pattern/constraint/type_/label.rs
+++ b/rust/pattern/constraint/type_/label.rs
@@ -20,11 +20,12 @@
  *
  */
 
+use std::fmt;
+
 use crate::{
     common::{token, validatable::Validatable, Result},
     Label,
 };
-use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct LabelConstraint {

--- a/rust/pattern/constraint/type_/mod.rs
+++ b/rust/pattern/constraint/type_/mod.rs
@@ -21,25 +21,20 @@
  */
 
 mod abstract_;
-pub use abstract_::AbstractConstraint;
-
 mod label;
-pub use label::LabelConstraint;
-
 mod owns;
-pub use owns::{IsKeyAttribute, OwnsConstraint, KEY};
-
 mod plays;
-pub use plays::PlaysConstraint;
-
 mod regex;
-pub use self::regex::RegexConstraint;
-
 mod relates;
-pub use relates::RelatesConstraint;
-
 mod sub;
-pub use sub::SubConstraint;
-
 mod value_type;
+
+pub use abstract_::AbstractConstraint;
+pub use label::LabelConstraint;
+pub use owns::{IsKeyAttribute, OwnsConstraint, KEY};
+pub use plays::PlaysConstraint;
+pub use relates::RelatesConstraint;
+pub use sub::SubConstraint;
 pub use value_type::ValueTypeConstraint;
+
+pub use self::regex::RegexConstraint;

--- a/rust/pattern/constraint/type_/owns.rs
+++ b/rust/pattern/constraint/type_/owns.rs
@@ -20,12 +20,13 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{error::collect_err, token, validatable::Validatable, Result},
     pattern::{variable::Reference, Type, TypeVariable, TypeVariableBuilder, UnboundVariable},
     Label,
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum IsKeyAttribute {

--- a/rust/pattern/constraint/type_/plays.rs
+++ b/rust/pattern/constraint/type_/plays.rs
@@ -20,12 +20,13 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{error::collect_err, token, validatable::Validatable, Result},
     pattern::{variable::Reference, Type, TypeVariable, TypeVariableBuilder, UnboundVariable},
     Label,
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PlaysConstraint {

--- a/rust/pattern/constraint/type_/regex.rs
+++ b/rust/pattern/constraint/type_/regex.rs
@@ -21,8 +21,7 @@
  */
 
 use crate::common::{
-    error::INVALID_ATTRIBUTE_TYPE_REGEX, string::escape_regex, token, validatable::Validatable,
-    Result,
+    error::ErrorMessage, string::escape_regex, token, validatable::Validatable, Result,
 };
 use regex::Regex;
 use std::fmt;
@@ -35,7 +34,7 @@ pub struct RegexConstraint {
 impl Validatable for RegexConstraint {
     fn validate(&self) -> Result<()> {
         if Regex::new(&self.regex).is_err() {
-            Err(INVALID_ATTRIBUTE_TYPE_REGEX.format(&[&self.regex]))?;
+            Err(ErrorMessage::InvalidAttributeTypeRegex(self.regex.clone()))?;
         }
         Ok(())
     }

--- a/rust/pattern/constraint/type_/regex.rs
+++ b/rust/pattern/constraint/type_/regex.rs
@@ -20,11 +20,13 @@
  *
  */
 
+use std::fmt;
+
+use regex::Regex;
+
 use crate::common::{
     error::ErrorMessage, string::escape_regex, token, validatable::Validatable, Result,
 };
-use regex::Regex;
-use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RegexConstraint {

--- a/rust/pattern/constraint/type_/regex.rs
+++ b/rust/pattern/constraint/type_/regex.rs
@@ -25,7 +25,7 @@ use std::fmt;
 use regex::Regex;
 
 use crate::common::{
-    error::ErrorMessage, string::escape_regex, token, validatable::Validatable, Result,
+    error::TypeQLError, string::escape_regex, token, validatable::Validatable, Result,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -36,7 +36,7 @@ pub struct RegexConstraint {
 impl Validatable for RegexConstraint {
     fn validate(&self) -> Result<()> {
         if Regex::new(&self.regex).is_err() {
-            Err(ErrorMessage::InvalidAttributeTypeRegex(self.regex.clone()))?;
+            Err(TypeQLError::InvalidAttributeTypeRegex(self.regex.clone()))?;
         }
         Ok(())
     }

--- a/rust/pattern/constraint/type_/relates.rs
+++ b/rust/pattern/constraint/type_/relates.rs
@@ -20,12 +20,13 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{error::collect_err, token, validatable::Validatable, Result},
     pattern::{variable::Reference, Type, TypeVariable, TypeVariableBuilder, UnboundVariable},
     Label,
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RelatesConstraint {

--- a/rust/pattern/constraint/type_/sub.rs
+++ b/rust/pattern/constraint/type_/sub.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{token, validatable::Validatable, Result},
     pattern::{
@@ -27,7 +29,6 @@ use crate::{
     },
     Label,
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SubConstraint {

--- a/rust/pattern/constraint/type_/value_type.rs
+++ b/rust/pattern/constraint/type_/value_type.rs
@@ -20,8 +20,9 @@
  *
  */
 
-use crate::common::{token, validatable::Validatable, Result};
 use std::fmt;
+
+use crate::common::{token, validatable::Validatable, Result};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ValueTypeConstraint {

--- a/rust/pattern/disjunction.rs
+++ b/rust/pattern/disjunction.rs
@@ -20,11 +20,12 @@
  *
  */
 
+use std::{collections::HashSet, fmt};
+
 use crate::{
     common::{error::collect_err, string::indent, token, validatable::Validatable, Result},
     pattern::{Conjunction, Normalisable, Pattern, Reference},
 };
-use std::{collections::HashSet, fmt};
 
 #[derive(Debug, Clone, Eq)]
 pub struct Disjunction {

--- a/rust/pattern/label.rs
+++ b/rust/pattern/label.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::fmt;
+
 use crate::{
     common::token,
     pattern::{
@@ -27,7 +29,6 @@ use crate::{
         TypeVariableBuilder,
     },
 };
-use std::fmt;
 
 #[derive(Debug)]
 pub enum Type {

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -21,32 +21,30 @@
  */
 
 mod conjunction;
-pub use conjunction::Conjunction;
-
 mod constraint;
+mod disjunction;
+mod label;
+mod named_references;
+mod negation;
+mod schema;
+#[cfg(test)]
+mod test;
+mod variable;
+
+use std::{collections::HashSet, fmt};
+
+pub use conjunction::Conjunction;
 pub use constraint::{
     AbstractConstraint, HasConstraint, IIDConstraint, IsConstraint, IsExplicit, IsKeyAttribute,
     IsaConstraint, LabelConstraint, OwnsConstraint, PlaysConstraint, RegexConstraint,
     RelatesConstraint, RelationConstraint, RolePlayerConstraint, SubConstraint, Value,
     ValueConstraint, ValueTypeConstraint, KEY,
 };
-
-mod disjunction;
 pub use disjunction::Disjunction;
-
-mod label;
 pub use label::{Label, Type};
-
-mod negation;
-pub use negation::Negation;
-
-mod schema;
-pub use schema::{RuleDeclaration, RuleDefinition};
-
-mod named_references;
 pub use named_references::NamedReferences;
-
-mod variable;
+pub use negation::Negation;
+pub use schema::{RuleDeclaration, RuleDefinition};
 pub use variable::{
     ConceptConstrainable, ConceptVariable, ConceptVariableBuilder, Reference,
     RelationConstrainable, RelationVariableBuilder, ThingConstrainable, ThingVariable,
@@ -54,14 +52,10 @@ pub use variable::{
     Variable, Visibility,
 };
 
-#[cfg(test)]
-mod test;
-
 use crate::{
     common::{error::ErrorMessage, validatable::Validatable, Result},
     enum_getter, enum_wrapper,
 };
-use std::{collections::HashSet, fmt};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Pattern {

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -58,7 +58,7 @@ pub use variable::{
 mod test;
 
 use crate::{
-    common::{error::INVALID_CASTING, validatable::Validatable, Result},
+    common::{error::ErrorMessage, validatable::Validatable, Result},
     enum_getter, enum_wrapper,
 };
 use std::{collections::HashSet, fmt};

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -53,7 +53,7 @@ pub use variable::{
 };
 
 use crate::{
-    common::{error::ErrorMessage, validatable::Validatable, Result},
+    common::{error::TypeQLError, validatable::Validatable, Result},
     enum_getter, enum_wrapper,
 };
 

--- a/rust/pattern/named_references.rs
+++ b/rust/pattern/named_references.rs
@@ -20,8 +20,9 @@
  *
  */
 
-use crate::pattern::Reference;
 use std::collections::HashSet;
+
+use crate::pattern::Reference;
 
 pub trait NamedReferences {
     fn named_references(&self) -> HashSet<Reference>;

--- a/rust/pattern/negation.rs
+++ b/rust/pattern/negation.rs
@@ -20,12 +20,13 @@
  *
  */
 
+use core::fmt;
+use std::collections::HashSet;
+
 use crate::{
     common::{error::ErrorMessage, token, validatable::Validatable, Result},
     pattern::{Conjunction, Disjunction, Normalisable, Pattern, Reference},
 };
-use core::fmt;
-use std::collections::HashSet;
 
 #[derive(Debug, Clone, Eq)]
 pub struct Negation {

--- a/rust/pattern/negation.rs
+++ b/rust/pattern/negation.rs
@@ -24,7 +24,7 @@ use core::fmt;
 use std::collections::HashSet;
 
 use crate::{
-    common::{error::ErrorMessage, token, validatable::Validatable, Result},
+    common::{error::TypeQLError, token, validatable::Validatable, Result},
     pattern::{Conjunction, Disjunction, Normalisable, Pattern, Reference},
 };
 
@@ -53,7 +53,7 @@ impl Negation {
 impl Validatable for Negation {
     fn validate(&self) -> Result<()> {
         match self.pattern.as_ref() {
-            Pattern::Negation(_) => Err(ErrorMessage::RedundantNestedNegation())?,
+            Pattern::Negation(_) => Err(TypeQLError::RedundantNestedNegation())?,
             _ => Ok(()),
         }
     }
@@ -71,7 +71,7 @@ impl Normalisable for Negation {
         Negation::new(match self.pattern.as_ref() {
             Pattern::Conjunction(conjunction) => conjunction.compute_normalised(),
             Pattern::Disjunction(disjunction) => disjunction.compute_normalised(),
-            Pattern::Negation(_) => panic!("{}", ErrorMessage::RedundantNestedNegation()),
+            Pattern::Negation(_) => panic!("{}", TypeQLError::RedundantNestedNegation()),
             Pattern::Variable(variable) => {
                 Disjunction::new(vec![Conjunction::new(vec![variable.clone().into()]).into()])
                     .into()

--- a/rust/pattern/negation.rs
+++ b/rust/pattern/negation.rs
@@ -21,7 +21,7 @@
  */
 
 use crate::{
-    common::{error::REDUNDANT_NESTED_NEGATION, token, validatable::Validatable, Result},
+    common::{error::ErrorMessage, token, validatable::Validatable, Result},
     pattern::{Conjunction, Disjunction, Normalisable, Pattern, Reference},
 };
 use core::fmt;
@@ -52,7 +52,7 @@ impl Negation {
 impl Validatable for Negation {
     fn validate(&self) -> Result<()> {
         match self.pattern.as_ref() {
-            Pattern::Negation(_) => Err(REDUNDANT_NESTED_NEGATION.format(&[]))?,
+            Pattern::Negation(_) => Err(ErrorMessage::RedundantNestedNegation())?,
             _ => Ok(()),
         }
     }
@@ -70,7 +70,7 @@ impl Normalisable for Negation {
         Negation::new(match self.pattern.as_ref() {
             Pattern::Conjunction(conjunction) => conjunction.compute_normalised(),
             Pattern::Disjunction(disjunction) => disjunction.compute_normalised(),
-            Pattern::Negation(_) => panic!("{}", REDUNDANT_NESTED_NEGATION.format(&[])),
+            Pattern::Negation(_) => panic!("{}", ErrorMessage::RedundantNestedNegation()),
             Pattern::Variable(variable) => {
                 Disjunction::new(vec![Conjunction::new(vec![variable.clone().into()]).into()])
                     .into()

--- a/rust/pattern/schema/mod.rs
+++ b/rust/pattern/schema/mod.rs
@@ -21,4 +21,5 @@
  */
 
 mod rule;
+
 pub use rule::{RuleDeclaration, RuleDefinition};

--- a/rust/pattern/schema/rule.rs
+++ b/rust/pattern/schema/rule.rs
@@ -24,7 +24,7 @@ use std::{fmt, iter};
 
 use crate::{
     common::{
-        error::{collect_err, ErrorMessage},
+        error::{collect_err, TypeQLError},
         string::indent,
         token,
         validatable::Validatable,
@@ -112,7 +112,7 @@ fn expect_no_nested_negations<'a>(
             Pattern::Disjunction(d) => expect_no_nested_negations(d.patterns.iter(), rule_label),
             Pattern::Negation(n) => {
                 if contains_negations(iter::once(n.pattern.as_ref())) {
-                    Err(ErrorMessage::InvalidRuleWhenNestedNegation(rule_label.clone()))?
+                    Err(TypeQLError::InvalidRuleWhenNestedNegation(rule_label.clone()))?
                 } else {
                     Ok(())
                 }
@@ -142,14 +142,14 @@ fn expect_infer_single_edge(then: &ThingVariable, rule_label: &Label) -> Result<
     {
         Ok(())
     } else {
-        Err(ErrorMessage::InvalidRuleThen(rule_label.clone(), then.clone()))?
+        Err(TypeQLError::InvalidRuleThen(rule_label.clone(), then.clone()))?
     }
 }
 
 fn expect_valid_inference(then: &ThingVariable, rule_label: &Label) -> Result<()> {
     if let Some(has) = then.has.get(0) {
         if has.type_.is_some() && has.attribute.reference.is_name() {
-            Err(ErrorMessage::InvalidRuleThenHas(
+            Err(TypeQLError::InvalidRuleThenHas(
                 rule_label.clone(),
                 then.clone(),
                 has.attribute.reference.clone(),
@@ -159,7 +159,7 @@ fn expect_valid_inference(then: &ThingVariable, rule_label: &Label) -> Result<()
         Ok(())
     } else if let Some(relation) = &then.relation {
         if !relation.role_players.iter().all(|rp| rp.role_type.is_some()) {
-            Err(ErrorMessage::InvalidRuleThenRoles(rule_label.clone(), then.clone()))?
+            Err(TypeQLError::InvalidRuleThenRoles(rule_label.clone(), then.clone()))?
         }
         Ok(())
     } else {
@@ -174,7 +174,7 @@ fn expect_then_bounded_by_when(
 ) -> Result<()> {
     let bounds = when.named_references();
     if !then.references().filter(|r| r.is_name()).all(|r| bounds.contains(r)) {
-        Err(ErrorMessage::InvalidRuleThenVariables(rule_label.clone()))?
+        Err(TypeQLError::InvalidRuleThenVariables(rule_label.clone()))?
     }
     Ok(())
 }

--- a/rust/pattern/schema/rule.rs
+++ b/rust/pattern/schema/rule.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{
         error::{collect_err, ErrorMessage},
@@ -31,7 +33,6 @@ use crate::{
     pattern::{Conjunction, NamedReferences, Pattern, ThingVariable},
     Label,
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RuleDeclaration {

--- a/rust/pattern/variable/builder/mod.rs
+++ b/rust/pattern/variable/builder/mod.rs
@@ -25,5 +25,7 @@ mod thing;
 mod type_;
 
 pub use concept::{ConceptConstrainable, ConceptVariableBuilder};
-pub use thing::{ RelationConstrainable, RelationVariableBuilder, ThingConstrainable, ThingVariableBuilder, };
+pub use thing::{
+    RelationConstrainable, RelationVariableBuilder, ThingConstrainable, ThingVariableBuilder,
+};
 pub use type_::{TypeConstrainable, TypeVariableBuilder};

--- a/rust/pattern/variable/builder/mod.rs
+++ b/rust/pattern/variable/builder/mod.rs
@@ -21,12 +21,9 @@
  */
 
 mod concept;
-pub use concept::{ConceptConstrainable, ConceptVariableBuilder};
-
 mod thing;
-pub use thing::{
-    RelationConstrainable, RelationVariableBuilder, ThingConstrainable, ThingVariableBuilder,
-};
-
 mod type_;
+
+pub use concept::{ConceptConstrainable, ConceptVariableBuilder};
+pub use thing::{ RelationConstrainable, RelationVariableBuilder, ThingConstrainable, ThingVariableBuilder, };
 pub use type_::{TypeConstrainable, TypeVariableBuilder};

--- a/rust/pattern/variable/concept.rs
+++ b/rust/pattern/variable/concept.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{error::collect_err, validatable::Validatable, Result},
     pattern::{
@@ -27,7 +29,6 @@ use crate::{
         variable::{builder::ConceptConstrainable, Reference},
     },
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ConceptVariable {

--- a/rust/pattern/variable/mod.rs
+++ b/rust/pattern/variable/mod.rs
@@ -40,7 +40,7 @@ pub use type_::TypeVariable;
 pub use unbound::UnboundVariable;
 
 use crate::{
-    common::{error::ErrorMessage, validatable::Validatable, Result},
+    common::{error::TypeQLError, validatable::Validatable, Result},
     enum_wrapper,
     pattern::{Normalisable, Pattern},
 };
@@ -69,7 +69,7 @@ impl Variable {
             Self::Unbound(_) => unreachable!(),
             _ => {
                 if !self.references().any(|r| r.is_name() && bounds.contains(r)) {
-                    Err(ErrorMessage::MatchHasUnboundedNestedPattern(self.clone().into()))?
+                    Err(TypeQLError::MatchHasUnboundedNestedPattern(self.clone().into()))?
                 }
                 Ok(())
             }

--- a/rust/pattern/variable/mod.rs
+++ b/rust/pattern/variable/mod.rs
@@ -44,7 +44,7 @@ pub use builder::{
 };
 
 use crate::{
-    common::{error::MATCH_HAS_UNBOUNDED_NESTED_PATTERN, validatable::Validatable, Result},
+    common::{error::ErrorMessage, validatable::Validatable, Result},
     enum_wrapper,
     pattern::{Normalisable, Pattern},
 };
@@ -74,8 +74,7 @@ impl Variable {
             Self::Unbound(_) => unreachable!(),
             _ => {
                 if !self.references().any(|r| r.is_name() && bounds.contains(r)) {
-                    Err(MATCH_HAS_UNBOUNDED_NESTED_PATTERN
-                        .format(&[&self.to_string().replace('\n', " ")]))?
+                    Err(ErrorMessage::MatchHasUnboundedNestedPattern(self.clone().into()))?
                 }
                 Ok(())
             }

--- a/rust/pattern/variable/mod.rs
+++ b/rust/pattern/variable/mod.rs
@@ -20,35 +20,30 @@
  *
  */
 
-mod reference;
-
-pub use reference::{Reference, Visibility};
-use std::collections::HashSet;
-
-mod concept;
-pub use concept::ConceptVariable;
-
-mod thing;
-pub use thing::ThingVariable;
-
-mod type_;
-pub use type_::TypeVariable;
-
-mod unbound;
-pub use unbound::UnboundVariable;
-
 mod builder;
+mod concept;
+mod reference;
+mod thing;
+mod type_;
+mod unbound;
+
+use std::{collections::HashSet, fmt};
+
 pub use builder::{
     ConceptConstrainable, ConceptVariableBuilder, RelationConstrainable, RelationVariableBuilder,
     ThingConstrainable, ThingVariableBuilder, TypeConstrainable, TypeVariableBuilder,
 };
+pub use concept::ConceptVariable;
+pub use reference::{Reference, Visibility};
+pub use thing::ThingVariable;
+pub use type_::TypeVariable;
+pub use unbound::UnboundVariable;
 
 use crate::{
     common::{error::ErrorMessage, validatable::Validatable, Result},
     enum_wrapper,
     pattern::{Normalisable, Pattern},
 };
-use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Variable {

--- a/rust/pattern/variable/reference.rs
+++ b/rust/pattern/variable/reference.rs
@@ -22,7 +22,7 @@
 
 use std::fmt;
 
-use crate::common::{error::ErrorMessage, validatable::Validatable, Result};
+use crate::common::{error::TypeQLError, validatable::Validatable, Result};
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub enum Visibility {
@@ -59,7 +59,7 @@ fn expect_valid_identifier(name: &str) -> Result<()> {
     if !name.starts_with(|c: char| c.is_ascii_alphanumeric())
         || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
     {
-        Err(ErrorMessage::InvalidVariableName(name.to_string()))?
+        Err(TypeQLError::InvalidVariableName(name.to_string()))?
     }
     Ok(())
 }

--- a/rust/pattern/variable/reference.rs
+++ b/rust/pattern/variable/reference.rs
@@ -20,8 +20,9 @@
  *
  */
 
-use crate::common::{error::ErrorMessage, validatable::Validatable, Result};
 use std::fmt;
+
+use crate::common::{error::ErrorMessage, validatable::Validatable, Result};
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub enum Visibility {

--- a/rust/pattern/variable/reference.rs
+++ b/rust/pattern/variable/reference.rs
@@ -20,7 +20,7 @@
  *
  */
 
-use crate::common::{error::INVALID_VARIABLE_NAME, validatable::Validatable, Result};
+use crate::common::{error::ErrorMessage, validatable::Validatable, Result};
 use std::fmt;
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
@@ -58,7 +58,7 @@ fn expect_valid_identifier(name: &str) -> Result<()> {
     if !name.starts_with(|c: char| c.is_ascii_alphanumeric())
         || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
     {
-        Err(INVALID_VARIABLE_NAME.format(&[name]))?
+        Err(ErrorMessage::InvalidVariableName(name.to_string()))?
     }
     Ok(())
 }

--- a/rust/pattern/variable/thing.rs
+++ b/rust/pattern/variable/thing.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{error::collect_err, validatable::Validatable, Result},
     pattern::{
@@ -28,7 +30,6 @@ use crate::{
     },
     write_joined,
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ThingVariable {

--- a/rust/pattern/variable/type_.rs
+++ b/rust/pattern/variable/type_.rs
@@ -24,7 +24,7 @@ use std::{fmt, iter};
 
 use crate::{
     common::{
-        error::{collect_err, ErrorMessage},
+        error::{collect_err, TypeQLError},
         validatable::Validatable,
         Result,
     },
@@ -85,7 +85,7 @@ impl TypeVariable {
 
     pub fn validate_definable(&self) -> Result<()> {
         if self.label.is_none() {
-            Err(ErrorMessage::InvalidDefineQueryVariable())?;
+            Err(TypeQLError::InvalidDefineQueryVariable())?;
         }
         Ok(())
     }

--- a/rust/pattern/variable/type_.rs
+++ b/rust/pattern/variable/type_.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{
         error::{collect_err, ErrorMessage},
@@ -32,7 +34,6 @@ use crate::{
     },
     write_joined,
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TypeVariable {

--- a/rust/pattern/variable/type_.rs
+++ b/rust/pattern/variable/type_.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     common::{
-        error::{collect_err, INVALID_DEFINE_QUERY_VARIABLE},
+        error::{collect_err, ErrorMessage},
         validatable::Validatable,
         Result,
     },
@@ -84,7 +84,7 @@ impl TypeVariable {
 
     pub fn validate_definable(&self) -> Result<()> {
         if self.label.is_none() {
-            Err(INVALID_DEFINE_QUERY_VARIABLE.format(&[]))?;
+            Err(ErrorMessage::InvalidDefineQueryVariable())?;
         }
         Ok(())
     }

--- a/rust/pattern/variable/unbound.rs
+++ b/rust/pattern/variable/unbound.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{validatable::Validatable, Result},
     pattern::{
@@ -30,7 +32,6 @@ use crate::{
         TypeVariable, ValueConstraint, ValueTypeConstraint, Visibility,
     },
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct UnboundVariable {

--- a/rust/query/aggregate.rs
+++ b/rust/query/aggregate.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     common::{
-        error::{collect_err, INVALID_COUNT_VARIABLE_ARGUMENT, VARIABLE_OUT_OF_SCOPE_MATCH},
+        error::{collect_err, ErrorMessage},
         token,
         validatable::Validatable,
         Result,
@@ -74,7 +74,7 @@ fn expect_method_variable_compatible(
     var: &Option<UnboundVariable>,
 ) -> Result<()> {
     if method == token::Aggregate::Count && var.is_some() {
-        Err(INVALID_COUNT_VARIABLE_ARGUMENT.format(&[]))?;
+        Err(ErrorMessage::InvalidCountVariableArgument())?
     }
     Ok(())
 }
@@ -84,7 +84,7 @@ fn expect_variable_in_scope(
     names_in_scope: HashSet<Reference>,
 ) -> Result<()> {
     if !names_in_scope.contains(&var.reference) {
-        Err(VARIABLE_OUT_OF_SCOPE_MATCH.format(&[]))?;
+        Err(ErrorMessage::VariableOutOfScopeMatch(var.reference.clone()))?;
     }
     Ok(())
 }

--- a/rust/query/aggregate.rs
+++ b/rust/query/aggregate.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::{collections::HashSet, fmt};
+
 use crate::{
     common::{
         error::{collect_err, ErrorMessage},
@@ -30,7 +32,6 @@ use crate::{
     pattern::{NamedReferences, Reference, UnboundVariable},
     query::{TypeQLMatch, TypeQLMatchGroup},
 };
-use std::{collections::HashSet, fmt};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AggregateQuery<T>

--- a/rust/query/aggregate.rs
+++ b/rust/query/aggregate.rs
@@ -24,7 +24,7 @@ use std::{collections::HashSet, fmt};
 
 use crate::{
     common::{
-        error::{collect_err, ErrorMessage},
+        error::{collect_err, TypeQLError},
         token,
         validatable::Validatable,
         Result,
@@ -75,7 +75,7 @@ fn expect_method_variable_compatible(
     var: &Option<UnboundVariable>,
 ) -> Result<()> {
     if method == token::Aggregate::Count && var.is_some() {
-        Err(ErrorMessage::InvalidCountVariableArgument())?
+        Err(TypeQLError::InvalidCountVariableArgument())?
     }
     Ok(())
 }
@@ -85,7 +85,7 @@ fn expect_variable_in_scope(
     names_in_scope: HashSet<Reference>,
 ) -> Result<()> {
     if !names_in_scope.contains(&var.reference) {
-        Err(ErrorMessage::VariableOutOfScopeMatch(var.reference.clone()))?;
+        Err(TypeQLError::VariableOutOfScopeMatch(var.reference.clone()))?;
     }
     Ok(())
 }

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -21,37 +21,31 @@
  */
 
 mod aggregate;
-pub use aggregate::{AggregateQueryBuilder, TypeQLMatchAggregate, TypeQLMatchGroupAggregate};
-
 mod typeql_define;
-pub use typeql_define::TypeQLDefine;
-
 mod typeql_delete;
-pub use typeql_delete::TypeQLDelete;
-
 mod typeql_insert;
-pub use typeql_insert::TypeQLInsert;
-
 mod typeql_match;
-pub use typeql_match::{sorting, Filter, Limit, Offset, Sorting, TypeQLMatch};
-
 mod typeql_match_group;
-pub use typeql_match_group::TypeQLMatchGroup;
-
 mod typeql_undefine;
-pub use typeql_undefine::TypeQLUndefine;
-
 mod typeql_update;
-pub use typeql_update::TypeQLUpdate;
-
 mod writable;
+
+use std::fmt;
+
+pub use aggregate::{AggregateQueryBuilder, TypeQLMatchAggregate, TypeQLMatchGroupAggregate};
+pub use typeql_define::TypeQLDefine;
+pub use typeql_delete::TypeQLDelete;
+pub use typeql_insert::TypeQLInsert;
+pub use typeql_match::{sorting, Filter, Limit, Offset, Sorting, TypeQLMatch};
+pub use typeql_match_group::TypeQLMatchGroup;
+pub use typeql_undefine::TypeQLUndefine;
+pub use typeql_update::TypeQLUpdate;
 pub use writable::Writable;
 
 use crate::{
     common::{error::ErrorMessage, validatable::Validatable, Result},
     enum_getter, enum_wrapper,
 };
-use std::fmt;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Query {

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -48,7 +48,7 @@ mod writable;
 pub use writable::Writable;
 
 use crate::{
-    common::{error::INVALID_CASTING, validatable::Validatable, Result},
+    common::{error::ErrorMessage, validatable::Validatable, Result},
     enum_getter, enum_wrapper,
 };
 use std::fmt;

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -43,7 +43,7 @@ pub use typeql_update::TypeQLUpdate;
 pub use writable::Writable;
 
 use crate::{
-    common::{error::ErrorMessage, validatable::Validatable, Result},
+    common::{error::TypeQLError, validatable::Validatable, Result},
     enum_getter, enum_wrapper,
 };
 

--- a/rust/query/typeql_define.rs
+++ b/rust/query/typeql_define.rs
@@ -24,7 +24,7 @@ use std::{fmt, iter};
 
 use crate::{
     common::{
-        error::{collect_err, ErrorMessage},
+        error::{collect_err, TypeQLError},
         token,
         validatable::Validatable,
         Result,
@@ -45,7 +45,7 @@ impl TypeQLDefine {
             Definable::RuleDefinition(rule) => define.add_rule(rule),
             Definable::TypeVariable(var) => define.add_definition(var),
             Definable::RuleDeclaration(r) => {
-                panic!("{}", ErrorMessage::InvalidRuleWhenMissingPatterns(r.label))
+                panic!("{}", TypeQLError::InvalidRuleWhenMissingPatterns(r.label))
             }
         })
     }
@@ -74,7 +74,7 @@ impl Validatable for TypeQLDefine {
 
 fn expect_non_empty(variables: &[TypeVariable], rules: &[RuleDefinition]) -> Result<()> {
     if variables.is_empty() && rules.is_empty() {
-        Err(ErrorMessage::MissingDefinables())?
+        Err(TypeQLError::MissingDefinables())?
     }
     Ok(())
 }

--- a/rust/query/typeql_define.rs
+++ b/rust/query/typeql_define.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{
         error::{collect_err, ErrorMessage},
@@ -30,7 +32,6 @@ use crate::{
     pattern::{Definable, RuleDefinition, TypeVariable},
     write_joined,
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct TypeQLDefine {

--- a/rust/query/typeql_define.rs
+++ b/rust/query/typeql_define.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     common::{
-        error::{collect_err, INVALID_RULE_WHEN_MISSING_PATTERNS, MISSING_DEFINABLES},
+        error::{collect_err, ErrorMessage},
         token,
         validatable::Validatable,
         Result,
@@ -44,7 +44,7 @@ impl TypeQLDefine {
             Definable::RuleDefinition(rule) => define.add_rule(rule),
             Definable::TypeVariable(var) => define.add_definition(var),
             Definable::RuleDeclaration(r) => {
-                panic!("{}", INVALID_RULE_WHEN_MISSING_PATTERNS.format(&[&r.to_string()]))
+                panic!("{}", ErrorMessage::InvalidRuleWhenMissingPatterns(r.label))
             }
         })
     }
@@ -73,7 +73,7 @@ impl Validatable for TypeQLDefine {
 
 fn expect_non_empty(variables: &[TypeVariable], rules: &[RuleDefinition]) -> Result<()> {
     if variables.is_empty() && rules.is_empty() {
-        Err(MISSING_DEFINABLES.format(&[]))?
+        Err(ErrorMessage::MissingDefinables())?
     }
     Ok(())
 }

--- a/rust/query/typeql_delete.rs
+++ b/rust/query/typeql_delete.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::fmt;
+
 use crate::{
     common::{
         error::{collect_err, ErrorMessage},
@@ -31,7 +33,6 @@ use crate::{
     query::{writable::expect_non_empty, TypeQLMatch, TypeQLUpdate, Writable},
     write_joined,
 };
-use std::fmt;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct TypeQLDelete {

--- a/rust/query/typeql_delete.rs
+++ b/rust/query/typeql_delete.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     common::{
-        error::{collect_err, VARIABLE_OUT_OF_SCOPE_DELETE},
+        error::{collect_err, ErrorMessage},
         token,
         validatable::Validatable,
         Result,
@@ -69,7 +69,7 @@ fn expect_delete_in_scope_of_match(
             if names_in_scope.contains(r) {
                 Ok(())
             } else {
-                Err(VARIABLE_OUT_OF_SCOPE_DELETE.format(&[&r.to_string()]))?
+                Err(ErrorMessage::VariableOutOfScopeDelete(r.clone()))?
             }
         },
     ))

--- a/rust/query/typeql_delete.rs
+++ b/rust/query/typeql_delete.rs
@@ -24,7 +24,7 @@ use std::fmt;
 
 use crate::{
     common::{
-        error::{collect_err, ErrorMessage},
+        error::{collect_err, TypeQLError},
         token,
         validatable::Validatable,
         Result,
@@ -70,7 +70,7 @@ fn expect_delete_in_scope_of_match(
             if names_in_scope.contains(r) {
                 Ok(())
             } else {
-                Err(ErrorMessage::VariableOutOfScopeDelete(r.clone()))?
+                Err(TypeQLError::VariableOutOfScopeDelete(r.clone()))?
             }
         },
     ))

--- a/rust/query/typeql_insert.rs
+++ b/rust/query/typeql_insert.rs
@@ -24,7 +24,7 @@ use std::fmt;
 
 use crate::{
     common::{
-        error::{collect_err, ErrorMessage},
+        error::{collect_err, TypeQLError},
         token,
         validatable::Validatable,
         Result,
@@ -79,7 +79,7 @@ fn expect_insert_in_scope_of_match(
                 .map(|r| r.to_string())
                 .collect::<Vec<String>>()
                 .join(", ");
-            Err(ErrorMessage::NoVariableInScopeInsert(variables_str, bounds_str))?
+            Err(TypeQLError::NoVariableInScopeInsert(variables_str, bounds_str))?
         }
     } else {
         Ok(())

--- a/rust/query/typeql_insert.rs
+++ b/rust/query/typeql_insert.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::fmt;
+
 use crate::{
     common::{
         error::{collect_err, ErrorMessage},
@@ -31,7 +33,6 @@ use crate::{
     query::{writable::expect_non_empty, TypeQLMatch},
     write_joined,
 };
-use std::fmt;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TypeQLInsert {

--- a/rust/query/typeql_insert.rs
+++ b/rust/query/typeql_insert.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     common::{
-        error::{collect_err, NO_VARIABLE_IN_SCOPE_INSERT},
+        error::{collect_err, ErrorMessage},
         token,
         validatable::Validatable,
         Result,
@@ -78,7 +78,7 @@ fn expect_insert_in_scope_of_match(
                 .map(|r| r.to_string())
                 .collect::<Vec<String>>()
                 .join(", ");
-            Err(NO_VARIABLE_IN_SCOPE_INSERT.format(&[&variables_str, &bounds_str]))?
+            Err(ErrorMessage::NoVariableInScopeInsert(variables_str, bounds_str))?
         }
     } else {
         Ok(())

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::{collections::HashSet, fmt, iter};
+
 use crate::{
     common::{
         error::{collect_err, Error, ErrorMessage},
@@ -31,7 +33,6 @@ use crate::{
     query::{AggregateQueryBuilder, TypeQLDelete, TypeQLInsert, TypeQLMatchGroup, Writable},
     var, write_joined,
 };
-use std::{collections::HashSet, fmt, iter};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TypeQLMatch {
@@ -251,8 +252,9 @@ impl fmt::Display for Filter {
 }
 
 pub mod sorting {
-    use crate::{common::token, pattern::UnboundVariable};
     use std::fmt;
+
+    use crate::{common::token, pattern::UnboundVariable};
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct OrderedVariable {

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -24,7 +24,7 @@ use std::{collections::HashSet, fmt, iter};
 
 use crate::{
     common::{
-        error::{collect_err, Error, ErrorMessage},
+        error::{collect_err, Error, TypeQLError},
         token,
         validatable::Validatable,
         Result,
@@ -118,7 +118,7 @@ fn expect_has_bounding_conjunction(conjunction: &Conjunction) -> Result<()> {
     if conjunction.has_named_variables() {
         Ok(())
     } else {
-        Err(ErrorMessage::MatchHasNoBoundingNamedVariable())?
+        Err(TypeQLError::MatchHasNoBoundingNamedVariable())?
     }
 }
 
@@ -133,7 +133,7 @@ fn expect_each_variable_is_bounded_by_named<'a>(
     collect_err(&mut patterns.map(|p| match p {
         Pattern::Variable(v) => {
             v.references().any(|r| r.is_name()).then_some(()).ok_or_else(|| {
-                Error::from(ErrorMessage::MatchPatternVariableHasNoNamedVariable(p.clone()))
+                Error::from(TypeQLError::MatchPatternVariableHasNoNamedVariable(p.clone()))
             })
         }
         Pattern::Conjunction(c) => expect_each_variable_is_bounded_by_named(c.patterns.iter()),
@@ -148,15 +148,15 @@ fn expect_filters_are_in_scope(conjunction: &Conjunction, filter: &Option<Filter
     let names_in_scope = conjunction.named_references();
     let mut seen = HashSet::new();
     if filter.as_ref().map_or(false, |f| f.vars.is_empty()) {
-        Err(ErrorMessage::EmptyMatchFilter())?;
+        Err(TypeQLError::EmptyMatchFilter())?;
     }
     collect_err(&mut filter.iter().flat_map(|f| &f.vars).map(|v| &v.reference).map(|r| {
         if !r.is_name() {
-            Err(ErrorMessage::VariableNotNamed().into())
+            Err(TypeQLError::VariableNotNamed().into())
         } else if !names_in_scope.contains(r) {
-            Err(ErrorMessage::VariableOutOfScopeMatch(r.clone()).into())
+            Err(TypeQLError::VariableOutOfScopeMatch(r.clone()).into())
         } else if seen.contains(&r) {
-            Err(ErrorMessage::IllegalFilterVariableRepeating(r.clone()).into())
+            Err(TypeQLError::IllegalFilterVariableRepeating(r.clone()).into())
         } else {
             seen.insert(r);
             Ok(())
@@ -178,7 +178,7 @@ fn expect_sort_vars_are_in_scope(
             names_in_scope
                 .contains(&r)
                 .then_some(())
-                .ok_or_else(|| ErrorMessage::VariableOutOfScopeMatch(r).into())
+                .ok_or_else(|| TypeQLError::VariableOutOfScopeMatch(r).into())
         },
     ))
 }
@@ -293,7 +293,7 @@ impl Sorting {
         self.vars
             .iter()
             .find_map(|v| (v.var == var).then_some(v.order.unwrap_or(token::Order::Asc)))
-            .ok_or_else(|| ErrorMessage::VariableNotSorted(var).into())
+            .ok_or_else(|| TypeQLError::VariableNotSorted(var).into())
     }
 }
 

--- a/rust/query/typeql_match_group.rs
+++ b/rust/query/typeql_match_group.rs
@@ -20,12 +20,13 @@
  *
  */
 
+use std::{collections::HashSet, fmt};
+
 use crate::{
     common::{error::collect_err, token, validatable::Validatable, Result},
     pattern::{NamedReferences, Reference, UnboundVariable},
     query::{AggregateQueryBuilder, TypeQLMatch},
 };
-use std::{collections::HashSet, fmt};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TypeQLMatchGroup {

--- a/rust/query/typeql_undefine.rs
+++ b/rust/query/typeql_undefine.rs
@@ -24,7 +24,7 @@ use std::{fmt, iter};
 
 use crate::{
     common::{
-        error::{collect_err, ErrorMessage},
+        error::{collect_err, TypeQLError},
         token,
         validatable::Validatable,
         Result,
@@ -46,7 +46,7 @@ impl TypeQLUndefine {
                 Definable::RuleDeclaration(rule) => undefine.add_rule(rule),
                 Definable::TypeVariable(var) => undefine.add_definition(var),
                 Definable::RuleDefinition(r) => {
-                    panic!("{}", ErrorMessage::InvalidUndefineQueryRule(r.label))
+                    panic!("{}", TypeQLError::InvalidUndefineQueryRule(r.label))
                 }
             }
         })
@@ -76,7 +76,7 @@ impl Validatable for TypeQLUndefine {
 
 fn expect_non_empty(variables: &[TypeVariable], rules: &[RuleDeclaration]) -> Result<()> {
     if variables.is_empty() && rules.is_empty() {
-        Err(ErrorMessage::MissingDefinables())?
+        Err(TypeQLError::MissingDefinables())?
     }
     Ok(())
 }

--- a/rust/query/typeql_undefine.rs
+++ b/rust/query/typeql_undefine.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     common::{
-        error::{collect_err, INVALID_UNDEFINE_QUERY_RULE, MISSING_DEFINABLES},
+        error::{collect_err, ErrorMessage},
         token,
         validatable::Validatable,
         Result,
@@ -45,7 +45,7 @@ impl TypeQLUndefine {
                 Definable::RuleDeclaration(rule) => undefine.add_rule(rule),
                 Definable::TypeVariable(var) => undefine.add_definition(var),
                 Definable::RuleDefinition(r) => {
-                    panic!("{}", INVALID_UNDEFINE_QUERY_RULE.format(&[&r.label.to_string()]))
+                    panic!("{}", ErrorMessage::InvalidUndefineQueryRule(r.label))
                 }
             }
         })
@@ -75,7 +75,7 @@ impl Validatable for TypeQLUndefine {
 
 fn expect_non_empty(variables: &[TypeVariable], rules: &[RuleDeclaration]) -> Result<()> {
     if variables.is_empty() && rules.is_empty() {
-        Err(MISSING_DEFINABLES.format(&[]))?
+        Err(ErrorMessage::MissingDefinables())?
     }
     Ok(())
 }

--- a/rust/query/typeql_undefine.rs
+++ b/rust/query/typeql_undefine.rs
@@ -20,6 +20,8 @@
  *
  */
 
+use std::{fmt, iter};
+
 use crate::{
     common::{
         error::{collect_err, ErrorMessage},
@@ -30,7 +32,6 @@ use crate::{
     pattern::{Definable, RuleDeclaration, TypeVariable},
     write_joined,
 };
-use std::{fmt, iter};
 
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct TypeQLUndefine {

--- a/rust/query/typeql_update.rs
+++ b/rust/query/typeql_update.rs
@@ -20,13 +20,14 @@
  *
  */
 
+use std::fmt;
+
 use crate::{
     common::{error::collect_err, token, validatable::Validatable, Result},
     pattern::ThingVariable,
     query::{writable::expect_non_empty, TypeQLDelete},
     write_joined,
 };
-use std::fmt;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct TypeQLUpdate {

--- a/rust/query/writable.rs
+++ b/rust/query/writable.rs
@@ -20,7 +20,7 @@
  *
  */
 
-use crate::{common::error::ErrorMessage, pattern::ThingVariable, Result};
+use crate::{common::error::TypeQLError, pattern::ThingVariable, Result};
 
 pub trait Writable {
     fn vars(self) -> Vec<ThingVariable>;
@@ -46,7 +46,7 @@ impl Writable for Vec<ThingVariable> {
 
 pub(crate) fn expect_non_empty(variables: &[ThingVariable]) -> Result<()> {
     if variables.is_empty() {
-        Err(ErrorMessage::MissingPatterns())?
+        Err(TypeQLError::MissingPatterns())?
     }
     Ok(())
 }

--- a/rust/query/writable.rs
+++ b/rust/query/writable.rs
@@ -20,7 +20,7 @@
  *
  */
 
-use crate::{common::error::MISSING_PATTERNS, pattern::ThingVariable, Result};
+use crate::{common::error::ErrorMessage, pattern::ThingVariable, Result};
 
 pub trait Writable {
     fn vars(self) -> Vec<ThingVariable>;
@@ -46,7 +46,7 @@ impl Writable for Vec<ThingVariable> {
 
 pub(crate) fn expect_non_empty(variables: &[ThingVariable]) -> Result<()> {
     if variables.is_empty() {
-        Err(MISSING_PATTERNS.format(&[]))?
+        Err(ErrorMessage::MissingPatterns())?
     }
     Ok(())
 }

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -21,4 +21,5 @@
 #
 
 imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
 use_small_heuristics = "Max"

--- a/rust/tests/behaviour/main.rs
+++ b/rust/tests/behaviour/main.rs
@@ -21,7 +21,6 @@
  */
 
 use cucumber::{gherkin::Step, given, then, when, World};
-
 use typeql_lang::{parse_query, query::Query};
 
 #[derive(Debug, Default, World)]

--- a/rust/typeql_lang.rs
+++ b/rust/typeql_lang.rs
@@ -26,7 +26,6 @@ pub mod common;
 pub mod parser;
 pub mod pattern;
 pub mod query;
-
 #[macro_use]
 mod util;
 

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -36,7 +36,7 @@ macro_rules! enum_getter {
             pub fn $fn_name(self) -> $classname {
                 match self {
                     Self::$enum_variant(x) => x,
-                    _ => panic!("{}", ErrorMessage::InvalidCasting(
+                    _ => panic!("{}", TypeQLError::InvalidCasting(
                         stringify!($enum_name),
                         self.__enum_getter_get_name(),
                         stringify!($enum_variant),

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -36,12 +36,12 @@ macro_rules! enum_getter {
             pub fn $fn_name(self) -> $classname {
                 match self {
                     Self::$enum_variant(x) => x,
-                    _ => panic!("{}", INVALID_CASTING.format(&[
+                    _ => panic!("{}", ErrorMessage::InvalidCasting(
                         stringify!($enum_name),
                         self.__enum_getter_get_name(),
                         stringify!($enum_variant),
                         stringify!($classname)
-                    ])),
+                    )),
                 }
             }
         })*


### PR DESCRIPTION
## What is the goal of this PR?

We replace the `Message` error struct with the `TypeQLError` enum, which greatly simplifies error handling on the user side.

## What are the changes implemented in this PR?

The `error_messages!` macro used to generate message templates has been replaced with one that generates an error enum instead. Returning an enum as the error is the established Rust approach as it greatly simplifies error handling. We also export the error generator macro so that it can be reused in e.g. typedb-client-rust.

Another minor change is adding the `group_imports = "StdExternalCrate"` to `rustfmt.toml`, a change backported from client-rust.