### PR TITLE
Export error enum generation macro

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,8 +39,9 @@ java_deps()
 # Load //builder/kotlin
 load("@vaticle_dependencies//builder/kotlin:deps.bzl", kotlin_deps = "deps")
 kotlin_deps()
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
 kotlin_repositories()
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
 kt_register_toolchains()
 
 # Load //builder/python

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -70,6 +70,8 @@
 @maven//:org_hamcrest_hamcrest_core_1_3
 @maven//:org_hamcrest_hamcrest_library
 @maven//:org_hamcrest_hamcrest_library_1_3
+@maven//:org_jetbrains_compose_compiler_compiler
+@maven//:org_jetbrains_compose_compiler_compiler_1_3_2
 @maven//:org_slf4j_slf4j_api
 @maven//:org_slf4j_slf4j_api_1_7_32
 @maven//:org_yaml_snakeyaml

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "96acc1b80fc5e663e116a73d155d1373720dcaed", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "812da3752022e7f1529b1e445c38fb8b11239c56", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -24,117 +24,86 @@
 macro_rules! error_messages {
     {
         $name:ident code: $code_pfx:literal, type: $message_pfx:literal,
-        $(
-            $error_name:ident( $($inner:ty),* $(,)? ) = $code:literal: $body:literal
-        ),* $(,)?
+        $($error_name:ident( $($inner:ty),* $(,)? ) = $code:literal: $body:literal),+ $(,)?
     } => {
-        error_messages_impl!(
-            $name, $code_pfx, max!($($code),*), $message_pfx,
-            $(($error_name, $code, $body, ($($inner),*))),*
-        );
-    };
-}
-
-macro_rules! error_messages_impl {
-    (
-        $name:ident, $code_pfx:literal, $max_code:expr, $message_pfx:literal,
-        $(($error_name:ident, $code:literal, $body:literal, ($($inner:ty),*))),*
-    ) => {
         #[derive(Clone, Debug, Eq, PartialEq)]
         pub enum $name {$(
             $error_name($($inner),*),
         )*}
 
         impl $name {
-            pub fn code(&self) -> usize {
+            const fn __max_code() -> usize {
+                let mut max = usize::MIN;
+                $(max = if $code > max { $code } else { max };)*
+                max
+            }
+            const fn __num_digits(x: usize) -> usize {
+                if (x < 10) { 1 } else { 1 + Self::__num_digits(x/10) }
+            }
+            const fn __padding(&self) -> &'static str {
+                match Self::__num_digits(Self::__max_code()) - Self::__num_digits(self.code()) {
+                    0 => "",
+                    1 => "0",
+                    2 => "00",
+                    3 => "000",
+                    _ => unreachable!(),
+                }
+            }
+
+            pub const fn code(&self) -> usize {
                 match self {$(
                     Self::$error_name(..) => $code,
                 )*}
             }
 
-            fn __padding_len(&self) -> usize {
-                let num_digits = |mut x: usize| -> usize {
-                    let mut len = 1;
-                    while x > 10 {
-                        len += 1;
-                        x /= 10;
-                    }
-                    len
-                };
-                match self {$(
-                    Self::$error_name(..) => num_digits($max_code) - num_digits($code),
-                )*}
-            }
-
             pub fn message(&self) -> String {
-                match self {$(
-                    Self::$error_name(..) => format_message!(self, $error_name, $body, $($inner),*),
-                )*}
+                $(error_messages!(@format self, $error_name, $body $(, $inner)*);)*
+                unreachable!()
             }
         }
 
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(f, concat!("[", $code_pfx, "{}{}] ", $message_pfx, ": {}"), "0".repeat(self.__padding_len()), self.code(), self.message())
+                write!(
+                    f,
+                    concat!("[", $code_pfx, "{}{}] ", $message_pfx, ": {}"),
+                    self.__padding(),
+                    self.code(),
+                    self.message()
+                )
+            }
+        }
+
+        impl std::error::Error for $name {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                None
             }
         }
     };
-}
 
-macro_rules! format_message {
-    ($self:ident, $error_name:ident, $body:literal, ) => {
-        format!($body)
-    };
-    ($self:ident, $error_name:ident, $body:literal, $t1:ty) => {
-        if let Self::$error_name(a) = &$self {
-            format!($body, a)
-        } else {
-            unreachable!()
+    (@format $self:ident, $error_name:ident, $body:literal) => {
+        if let Self::$error_name() = &$self {
+            return format!($body)
         }
     };
-    ($self:ident, $error_name:ident, $body:literal, $t1:ty, $t2:ty) => {
-        if let Self::$error_name(a, b) = &$self {
-            format!($body, a, b)
-        } else {
-            unreachable!()
+    (@format $self:ident, $error_name:ident, $body:literal, $t1:ty) => {
+        if let Self::$error_name(_0) = &$self {
+            return format!($body, _0)
         }
     };
-    ($self:ident, $error_name:ident, $body:literal, $t1:ty, $t2:ty, $t3:ty) => {
-        if let Self::$error_name(a, b, c) = &$self {
-            format!($body, a, b, c)
-        } else {
-            unreachable!()
+    (@format $self:ident, $error_name:ident, $body:literal, $t1:ty, $t2:ty) => {
+        if let Self::$error_name(_0, _1) = &$self {
+            return format!($body, _0, _1)
         }
     };
-    ($self:ident, $error_name:ident, $body:literal, $t1:ty, $t2:ty, $t3:ty, $t4:ty) => {
-        if let Self::$error_name(a, b, c, d) = &$self {
-            format!($body, a, b, c, d)
-        } else {
-            unreachable!()
+    (@format $self:ident, $error_name:ident, $body:literal, $t1:ty, $t2:ty, $t3:ty) => {
+        if let Self::$error_name(_0, _1, _2) = &$self {
+            return format!($body, _0, _1, _2)
         }
     };
-}
-
-macro_rules! max {
-    (
-        $x0:literal, $x1:literal, $x2:literal, $x3:literal, $x4:literal,
-        $x5:literal, $x6:literal, $x7:literal, $x8:literal, $x9:literal,
-        $($xs:literal),*
-    ) => {
-        max_branch!(max!($x0, $x1, $x2, $x3, $x4, $x5, $x6, $x7, $x8, $x9), max!($($xs),*))
-    };
-    ($x:literal, $($xs:literal),*) => { max_branch!($x, max!($($xs),*)) };
-    ($x:literal) => ($x);
-}
-
-macro_rules! max_branch {
-    ($lhs:expr, $rhs:expr) => {{
-        let lhs = $lhs;
-        let rhs = $rhs;
-        if lhs > rhs {
-            lhs
-        } else {
-            rhs
+    (@format $self:ident, $error_name:ident, $body:literal, $t1:ty, $t2:ty, $t3:ty, $t4:ty) => {
+        if let Self::$error_name(_0, _1, _2, _3) = &$self {
+            return format!($body, _0, _1, _2, _3)
         }
-    }};
+    };
 }

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -24,7 +24,7 @@
 macro_rules! enum_getter {
     {$enum_name:ident $($fn_name:ident ( $enum_variant:ident ) => $classname:ty),* $(,)?} => {
         impl $enum_name {
-            fn __enum_getter_get_name(&self) -> &'static str {
+            fn enum_getter_get_name(&self) -> &'static str {
                 match self {
                     $(
                     Self::$enum_variant(_) => stringify!($enum_variant),
@@ -38,7 +38,7 @@ macro_rules! enum_getter {
                     Self::$enum_variant(x) => x,
                     _ => panic!("{}", TypeQLError::InvalidCasting(
                         stringify!($enum_name),
-                        self.__enum_getter_get_name(),
+                        self.enum_getter_get_name(),
                         stringify!($enum_variant),
                         stringify!($classname)
                     )),


### PR DESCRIPTION
## What is the goal of this PR?

We repackage the `error_message!` macro to be importable by other crates. That involved packaging all other macros used by `error_messages!` as private methods and internal rules within `error_messages!` (e.g. `max_code()` and `@format`). 

## What are the changes implemented in this PR?

Helper macros are replaced by private constant functions generated by the macro where possible. The message formatting macro is replaced by an internal rule of the main `error_messages!` macro.
