### PR TITLE
Migrate to crate-universe

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,9 +60,10 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 rules_rust_dependencies()
 rust_register_toolchains(include_rustc_srcs = True, edition="2021")
 
-load("@vaticle_dependencies//library/crates:crates.bzl", "raze_fetch_remote_crates")
-raze_fetch_remote_crates()
-
+load("@vaticle_dependencies//library/crates:crates.bzl", "fetch_crates")
+fetch_crates()
+load("@crates//:defs.bzl", "crate_repositories")
+crate_repositories()
 
 load("@rules_antlr//antlr:lang.bzl", "JAVA")
 load("@rules_antlr//antlr:repositories.bzl", "rules_antlr_dependencies")

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "812da3752022e7f1529b1e445c38fb8b11239c56", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "31ecccf097623824fde7a4c35aa95225e2fee1ae", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -42,13 +42,13 @@ rust_library(
         "parser/typeql.pest",
     ],
     deps = [
-        "@vaticle_dependencies//library/crates:chrono",
-        "@vaticle_dependencies//library/crates:itertools",
-        "@vaticle_dependencies//library/crates:pest",
-        "@vaticle_dependencies//library/crates:regex",
+        "@crates//:chrono",
+        "@crates//:itertools",
+        "@crates//:pest",
+        "@crates//:regex",
     ],
     proc_macro_deps = [
-        "@vaticle_dependencies//library/crates:pest_derive",
+        "@crates//:pest_derive",
     ],
     visibility = ["//visibility:public"]
 )

--- a/rust/tests/behaviour/BUILD
+++ b/rust/tests/behaviour/BUILD
@@ -32,8 +32,8 @@ rust_test(
     ],
     deps = [
         "//rust:typeql_lang",
-        "@vaticle_dependencies//library/crates:cucumber",
-        "@vaticle_dependencies//library/crates:futures",
+        "@crates//:cucumber",
+        "@crates//:futures",
     ],
     use_libtest_harness = False,
 )


### PR DESCRIPTION
## What is the goal of this PR?

We update dependencies and the Bazel build files to reflect the new style of crate imports using crate-universe instead of cargo-raze.
