### PR TITLE
Update crate assembly

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "31ecccf097623824fde7a4c35aa95225e2fee1ae", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "87d228da9d5b0c5a53cc1e0426161916a59a318c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -38,6 +38,7 @@ rust_library(
         "*.rs",
         "**/*.rs",
     ]),
+    crate_root = "typeql_lang.rs",
     compile_data = [
         "parser/typeql.pest",
     ],


### PR DESCRIPTION
## What is the goal of this PR?

We update dependencies and explicitly specify the root of the typeql-rust crate. This allows us to have non-`lib.rs` root to our library in the assembled crate. Cf. https://github.com/vaticle/bazel-distribution/pull/366