### PR TITLE
Introduce unique annotation

### DIFF
--- a/grammar/TypeQL.g4
+++ b/grammar/TypeQL.g4
@@ -113,19 +113,15 @@ variable_concept      :   VAR_  IS  VAR_  ;
 variable_type         :   type_any    type_constraint ( ',' type_constraint )*  ;
 type_constraint       :   ABSTRACT
                       |   SUB_        type_any
-                      |   OWNS        type         ( AS type )?     owns_annotations //value_annotations
-                      |   RELATES     type         ( AS type )?   //relates_annotations
+                      |   OWNS        type         ( AS type )?     annotations_owns
+                      |   RELATES     type         ( AS type )?
                       |   PLAYS       type_scoped  ( AS type )?
                       |   VALUE       value_type
                       |   REGEX       STRING_
                       |   TYPE        label_any
-                      // value_annotations
                       ;
-//annotations           :   ( ANNOTATION_KEY )?   ( ANNOTATION_UNIQUE )?  ( ANNOTATION_RANGE | ANNOTATION_REGEX )?     ;
 
-owns_annotations      :   ( ANNOTATION_KEY )?   ( ANNOTATION_UNIQUE )?          ;
-//relates_annotations :
-//value_annotations   :   ( ANNOTATION_RANGE | ANNOTATION_REGEX )?
+annotations_owns      :   ( ANNOTATION_KEY )?   ( ANNOTATION_UNIQUE )?          ;
 
 // THING VARIABLES =============================================================
 

--- a/grammar/TypeQL.g4
+++ b/grammar/TypeQL.g4
@@ -113,13 +113,19 @@ variable_concept      :   VAR_  IS  VAR_  ;
 variable_type         :   type_any    type_constraint ( ',' type_constraint )*  ;
 type_constraint       :   ABSTRACT
                       |   SUB_        type_any
-                      |   OWNS        type         ( AS type )? ( IS_KEY )?
-                      |   RELATES     type         ( AS type )?
+                      |   OWNS        type         ( AS type )?     owns_annotations //value_annotations
+                      |   RELATES     type         ( AS type )?   //relates_annotations
                       |   PLAYS       type_scoped  ( AS type )?
                       |   VALUE       value_type
                       |   REGEX       STRING_
                       |   TYPE        label_any
+                      // value_annotations
                       ;
+//annotations           :   ( ANNOTATION_KEY )?   ( ANNOTATION_UNIQUE )?          ;
+
+owns_annotations      :   ( ANNOTATION_KEY )?   ( ANNOTATION_UNIQUE )?          ;
+//relates_annotations :
+//value_annotations   :   ( ANNOTATION_RANGE | ANNOTATION_REGEX )?
 
 // THING VARIABLES =============================================================
 
@@ -225,10 +231,15 @@ ASC             : 'asc'         ;   DESC            : 'desc'        ;
 TYPE            : 'type'        ;
 ABSTRACT        : 'abstract'    ;   SUB_            : SUB | SUBX    ;
 SUB             : 'sub'         ;   SUBX            : 'sub!'        ;
-OWNS            : 'owns'        ;   IS_KEY          : '@key'        ;
+OWNS            : 'owns'        ;
 REGEX           : 'regex'       ;   AS              : 'as'          ;
 PLAYS           : 'plays'       ;   RELATES         : 'relates'     ;
 WHEN            : 'when'        ;   THEN            : 'then'        ;
+
+// TYPE ANNOTATIONS
+
+ANNOTATION_KEY            : '@key';
+ANNOTATION_UNIQUE         : '@unique';
 
 // THING VARIABLE CONSTRAINT KEYWORDS
 

--- a/grammar/TypeQL.g4
+++ b/grammar/TypeQL.g4
@@ -121,7 +121,7 @@ type_constraint       :   ABSTRACT
                       |   TYPE        label_any
                       // value_annotations
                       ;
-//annotations           :   ( ANNOTATION_KEY )?   ( ANNOTATION_UNIQUE )?          ;
+//annotations           :   ( ANNOTATION_KEY )?   ( ANNOTATION_UNIQUE )?  ( ANNOTATION_RANGE | ANNOTATION_REGEX )?     ;
 
 owns_annotations      :   ( ANNOTATION_KEY )?   ( ANNOTATION_UNIQUE )?          ;
 //relates_annotations :

--- a/java/common/TypeQLToken.java
+++ b/java/common/TypeQLToken.java
@@ -125,6 +125,7 @@ public class TypeQLToken {
         SPACE(" "),
         COMMA(","),
         COMMA_SPACE(", "),
+        AT("@"),
         COMMA_NEW_LINE(",\n"),
         CURLY_OPEN("{"),
         CURLY_CLOSE("}"),
@@ -316,7 +317,6 @@ public class TypeQLToken {
         HAS("has"),
         IID("iid"),
         IS("is"),
-        IS_KEY("@key"),
         ISA("isa"),
         ISAX("isa!"),
         OWNS("owns"),
@@ -344,6 +344,31 @@ public class TypeQLToken {
             for (Constraint c : Constraint.values()) {
                 if (c.name.equals(value)) {
                     return c;
+                }
+            }
+            return null;
+        }
+    }
+
+    public enum Annotation {
+        KEY("key"),
+        UNIQUE("unique");
+
+        private final String name;
+
+        Annotation(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return Char.AT + name;
+        }
+
+        public static Annotation of(String value) {
+            for (Annotation annotation: Annotation.values()) {
+                if (annotation.name.equals(value)) {
+                    return annotation;
                 }
             }
             return null;

--- a/java/common/TypeQLToken.java
+++ b/java/common/TypeQLToken.java
@@ -151,6 +151,10 @@ public class TypeQLToken {
             return Collectors.joining(character);
         }
 
+        public Collector<CharSequence, ?, String> joiner(CharSequence prefix, CharSequence suffix) {
+            return Collectors.joining(character, prefix, suffix);
+        }
+
         @Override
         public String toString() {
             return this.character;

--- a/java/common/TypeQLToken.java
+++ b/java/common/TypeQLToken.java
@@ -151,10 +151,6 @@ public class TypeQLToken {
             return Collectors.joining(character);
         }
 
-        public Collector<CharSequence, ?, String> joiner(CharSequence prefix, CharSequence suffix) {
-            return Collectors.joining(character, prefix, suffix);
-        }
-
         @Override
         public String toString() {
             return this.character;

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -101,7 +101,8 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
             new ErrorMessage(39, "Illegal grammar!");
     public static final ErrorMessage ILLEGAL_CHAR_IN_LABEL =
             new ErrorMessage(40, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
-
+    public static final ErrorMessage INVALID_ANNOTATION =
+            new ErrorMessage(41, "Invalid annotation '%s' on '%s' constraint");
 
     private static final String codePrefix = "TQL";
     private static final String messagePrefix = "TypeQL Error";

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -491,7 +491,7 @@ public class Parser extends TypeQLBaseVisitor {
                 type = type.constrain(new TypeConstraint.Sub(visitType_any(constraint.type_any()), sub == TypeQLToken.Constraint.SUBX));
             } else if (constraint.OWNS() != null) {
                 Either<String, UnboundVariable> overridden = constraint.AS() == null ? null : visitType(constraint.type(1));
-                type = type.constrain(new TypeConstraint.Owns(visitType(constraint.type(0)), overridden, constraint.IS_KEY() != null));
+                type = type.constrain(new TypeConstraint.Owns(visitType(constraint.type(0)), overridden, visitOwns_annotations(constraint.owns_annotations())));
             } else if (constraint.PLAYS() != null) {
                 Either<String, UnboundVariable> overridden = constraint.AS() == null ? null : visitType(constraint.type(0));
                 type = type.constrain(new TypeConstraint.Plays(visitType_scoped(constraint.type_scoped()), overridden));
@@ -514,11 +514,11 @@ public class Parser extends TypeQLBaseVisitor {
     }
 
     @Override
-    public TypeConstraint.Owns.Annotations visitOwns_annotations(TypeQLParser.Owns_annotationsContext ctx) {
+    public Set<TypeQLToken.Annotation> visitOwns_annotations(TypeQLParser.Owns_annotationsContext ctx) {
         Set<TypeQLToken.Annotation> annotations = new HashSet<>();
         if (ctx.ANNOTATION_KEY() != null) annotations.add(parseAnnotation(ctx.ANNOTATION_KEY()));
         else if (ctx.ANNOTATION_UNIQUE() != null) annotations.add(parseAnnotation(ctx.ANNOTATION_UNIQUE()));
-        return new TypeConstraint.Owns.Annotations(annotations);
+        return annotations;
     }
 
     private TypeQLToken.Annotation parseAnnotation(TerminalNode terminalNode) {

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -56,7 +56,6 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.DefaultErrorStrategy;
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.antlr.v4.runtime.tree.TerminalNode;
@@ -491,7 +490,7 @@ public class Parser extends TypeQLBaseVisitor {
                 type = type.constrain(new TypeConstraint.Sub(visitType_any(constraint.type_any()), sub == TypeQLToken.Constraint.SUBX));
             } else if (constraint.OWNS() != null) {
                 Either<String, UnboundVariable> overridden = constraint.AS() == null ? null : visitType(constraint.type(1));
-                type = type.constrain(new TypeConstraint.Owns(visitType(constraint.type(0)), overridden, visitOwns_annotations(constraint.owns_annotations())));
+                type = type.constrain(new TypeConstraint.Owns(visitType(constraint.type(0)), overridden, visitAnnotations_owns(constraint.annotations_owns())));
             } else if (constraint.PLAYS() != null) {
                 Either<String, UnboundVariable> overridden = constraint.AS() == null ? null : visitType(constraint.type(0));
                 type = type.constrain(new TypeConstraint.Plays(visitType_scoped(constraint.type_scoped()), overridden));
@@ -514,8 +513,8 @@ public class Parser extends TypeQLBaseVisitor {
     }
 
     @Override
-    public Set<TypeQLToken.Annotation> visitOwns_annotations(TypeQLParser.Owns_annotationsContext ctx) {
-        Set<TypeQLToken.Annotation> annotations = new HashSet<>();
+    public List<TypeQLToken.Annotation> visitAnnotations_owns(TypeQLParser.Annotations_ownsContext ctx) {
+        List<TypeQLToken.Annotation> annotations = new ArrayList<>();
         if (ctx.ANNOTATION_KEY() != null) annotations.add(parseAnnotation(ctx.ANNOTATION_KEY()));
         else if (ctx.ANNOTATION_UNIQUE() != null) annotations.add(parseAnnotation(ctx.ANNOTATION_UNIQUE()));
         return annotations;

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -513,6 +513,19 @@ public class Parser extends TypeQLBaseVisitor {
         return type;
     }
 
+    @Override
+    public TypeConstraint.Owns.Annotations visitOwns_annotations(TypeQLParser.Owns_annotationsContext ctx) {
+        Set<TypeQLToken.Annotation> annotations = new HashSet<>();
+        if (ctx.ANNOTATION_KEY() != null) annotations.add(parseAnnotation(ctx.ANNOTATION_KEY()));
+        else if (ctx.ANNOTATION_UNIQUE() != null) annotations.add(parseAnnotation(ctx.ANNOTATION_UNIQUE()));
+        return new TypeConstraint.Owns.Annotations(annotations);
+    }
+
+    private TypeQLToken.Annotation parseAnnotation(TerminalNode terminalNode) {
+        assert !terminalNode.getText().isEmpty() && terminalNode.getText().startsWith(TypeQLToken.Char.AT.toString());
+        return TypeQLToken.Annotation.of(terminalNode.getText().substring(1));
+    }
+
     // THING VARIABLES =========================================================
 
     @Override

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -513,10 +513,22 @@ public class Parser extends TypeQLBaseVisitor {
     }
 
     @Override
-    public List<TypeQLToken.Annotation> visitAnnotations_owns(TypeQLParser.Annotations_ownsContext ctx) {
-        List<TypeQLToken.Annotation> annotations = new ArrayList<>();
-        if (ctx.ANNOTATION_KEY() != null) annotations.add(parseAnnotation(ctx.ANNOTATION_KEY()));
-        else if (ctx.ANNOTATION_UNIQUE() != null) annotations.add(parseAnnotation(ctx.ANNOTATION_UNIQUE()));
+    public TypeQLToken.Annotation[] visitAnnotations_owns(TypeQLParser.Annotations_ownsContext ctx) {
+        // precompute array length to avoid double allocation of arrays
+        int count = 0;
+        if (ctx.ANNOTATION_KEY() != null) count++;
+        if (ctx.ANNOTATION_UNIQUE() != null) count++;
+        TypeQLToken.Annotation[] annotations = new TypeQLToken.Annotation[count];
+        int index = 0;
+        if (ctx.ANNOTATION_KEY() != null) {
+            annotations[index] = parseAnnotation(ctx.ANNOTATION_KEY());
+            index++;
+        }
+        if (ctx.ANNOTATION_UNIQUE() != null) {
+            annotations[index] = parseAnnotation(ctx.ANNOTATION_UNIQUE());
+            index++;
+        }
+        assert index == count;
         return annotations;
     }
 

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -23,6 +23,7 @@ package com.vaticle.typeql.lang.parser.test;
 
 import com.vaticle.typeql.lang.TypeQL;
 import com.vaticle.typeql.lang.common.TypeQLArg;
+import com.vaticle.typeql.lang.common.TypeQLToken;
 import com.vaticle.typeql.lang.common.exception.TypeQLException;
 import com.vaticle.typeql.lang.pattern.Conjunction;
 import com.vaticle.typeql.lang.pattern.Pattern;
@@ -1143,8 +1144,15 @@ public class ParserTest {
     }
 
     @Test
-    public void testParseKey() {
-        assertEquals("match\n$x owns name @key;\nget $x;", parseQuery("match\n$x owns name @key;\nget $x;").toString());
+    public void testParseAnnotations() {
+        final String defineString = "define\n" +
+                "e1 owns a1 @key;\n" +
+                "e2 owns a2 @unique;";
+        assertEquals(
+                TypeQL.define(
+                        type("e1").owns("a1", TypeQLToken.Annotation.KEY),
+                        type("e2").owns("a2", TypeQLToken.Annotation.UNIQUE)),
+                parseQuery(defineString));
     }
 
     @Test

--- a/java/pattern/constraint/TypeConstraint.java
+++ b/java/pattern/constraint/TypeConstraint.java
@@ -41,8 +41,6 @@ import java.util.regex.PatternSyntaxException;
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.common.util.Objects.className;
-import static com.vaticle.typeql.lang.common.TypeQLToken.Annotation.UNIQUE;
-import static com.vaticle.typeql.lang.common.TypeQLToken.Annotation.KEY;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COLON;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.SPACE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Constraint.AS;
@@ -413,7 +411,6 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         private final TypeVariable attributeType;
         private final TypeVariable overriddenAttributeType;
         private final List<Annotation> annotations;
-        private final Annotation uniqueness;
         private final int hash;
 
         public Owns(String attributeType) {
@@ -475,9 +472,6 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
             this.overriddenAttributeType = overriddenAttributeType;
             validateAnnotations(annotations);
             this.annotations = annotations;
-            if (annotations.contains(KEY)) this.uniqueness = KEY;
-            else if (annotations.contains(UNIQUE)) this.uniqueness = UNIQUE;
-            else this.uniqueness = null;
             this.hash = Objects.hash(Owns.class, this.attributeType, this.overriddenAttributeType, this.annotations);
         }
 
@@ -516,10 +510,6 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         @Override
         public List<Annotation> annotations() {
             return annotations;
-        }
-
-        public Optional<Annotation> uniqueness() {
-            return Optional.ofNullable(uniqueness);
         }
 
         @Override

--- a/java/pattern/constraint/TypeConstraint.java
+++ b/java/pattern/constraint/TypeConstraint.java
@@ -492,7 +492,7 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         public String toString() {
             return "" + OWNS + SPACE + attributeType +
                     (overriddenAttributeType != null ? "" + SPACE + AS + SPACE + overriddenAttributeType : "") +
-                    annotations.stream().map(Annotation::toString).collect(SPACE.joiner());
+                    annotations.stream().map(Annotation::toString).collect(SPACE.joiner(SPACE.toString(), ""));
         }
 
         @Override

--- a/java/pattern/constraint/TypeConstraint.java
+++ b/java/pattern/constraint/TypeConstraint.java
@@ -31,6 +31,7 @@ import com.vaticle.typeql.lang.pattern.variable.TypeVariable;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -38,7 +39,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.PatternSyntaxException;
 
-import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COLON;
@@ -111,7 +111,7 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
     }
 
     public List<Annotation> annotations() {
-        return list();
+        return Collections.emptyList();
     }
 
     public TypeConstraint.Label asLabel() {
@@ -454,7 +454,7 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         private static void validateAnnotations(Annotation[] annotations) {
             for (Annotation annotation : annotations) {
                 if (!VALID_ANNOTATIONS.contains(annotation)) {
-                    throw TypeQLException.of(INVALID_ANNOTATION.message("owns", annotation));
+                    throw TypeQLException.of(INVALID_ANNOTATION.message(annotation, "owns"));
                 }
             }
         }
@@ -492,7 +492,7 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         public String toString() {
             return "" + OWNS + SPACE + attributeType +
                     (overriddenAttributeType != null ? "" + SPACE + AS + SPACE + overriddenAttributeType : "") +
-                    annotations.stream().map(a -> a.toString()).reduce("", (x, y) -> x + SPACE + y);
+                    annotations.stream().map(Annotation::toString).collect(SPACE.joiner());
         }
 
         @Override

--- a/java/pattern/constraint/TypeConstraint.java
+++ b/java/pattern/constraint/TypeConstraint.java
@@ -492,7 +492,7 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         public String toString() {
             return "" + OWNS + SPACE + attributeType +
                     (overriddenAttributeType != null ? "" + SPACE + AS + SPACE + overriddenAttributeType : "") +
-                    annotations.stream().map(Annotation::toString).collect(SPACE.joiner(SPACE.toString(), ""));
+                    (!annotations.isEmpty() ? SPACE + annotations.stream().map(Annotation::toString).collect(SPACE.joiner()) : "");
         }
 
         @Override

--- a/java/pattern/constraint/TypeConstraint.java
+++ b/java/pattern/constraint/TypeConstraint.java
@@ -97,8 +97,8 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         return false;
     }
 
-    public boolean isOwns() {
-        return false;
+    public Set<Annotation> annotations() {
+        return set();
     }
 
     public boolean isPlays() {
@@ -408,24 +408,48 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         private final Set<Annotation> annotations;
         private final int hash;
 
+        public Owns(String attributeType) {
+            this(hidden().type(attributeType), null, set());
+        }
+
         public Owns(String attributeType, Set<Annotation> annotations) {
             this(hidden().type(attributeType), null, annotations);
+        }
+
+        public Owns(UnboundVariable attributeTypeVar) {
+            this(attributeTypeVar.toType(), null, set());
         }
 
         public Owns(UnboundVariable attributeTypeVar, Set<Annotation> annotations) {
             this(attributeTypeVar.toType(), null, annotations);
         }
 
+        public Owns(String attributeType, String overriddenAttributeType) {
+            this(hidden().type(attributeType), overriddenAttributeType == null ? null : hidden().type(overriddenAttributeType), set());
+        }
+
         public Owns(String attributeType, String overriddenAttributeType, Set<Annotation> annotations) {
             this(hidden().type(attributeType), overriddenAttributeType == null ? null : hidden().type(overriddenAttributeType), annotations);
+        }
+
+        public Owns(UnboundVariable attributeTypeVar, String overriddenAttributeType) {
+            this(attributeTypeVar.toType(), overriddenAttributeType == null ? null : hidden().type(overriddenAttributeType), set());
         }
 
         public Owns(UnboundVariable attributeTypeVar, String overriddenAttributeType, Set<Annotation> annotations) {
             this(attributeTypeVar.toType(), overriddenAttributeType == null ? null : hidden().type(overriddenAttributeType), annotations);
         }
 
+        public Owns(String attributeType, UnboundVariable overriddenAttributeTypeVar) {
+            this(hidden().type(attributeType), overriddenAttributeTypeVar == null ? null : overriddenAttributeTypeVar.toType(), set());
+        }
+
         public Owns(String attributeType, UnboundVariable overriddenAttributeTypeVar, Set<Annotation> annotations) {
             this(hidden().type(attributeType), overriddenAttributeTypeVar == null ? null : overriddenAttributeTypeVar.toType(), annotations);
+        }
+
+        public Owns(UnboundVariable attributeTypeVar, UnboundVariable overriddenAttributeTypeVar) {
+            this(attributeTypeVar.toType(), overriddenAttributeTypeVar == null ? null : overriddenAttributeTypeVar.toType(), set());
         }
 
         public Owns(UnboundVariable attributeTypeVar, UnboundVariable overriddenAttributeTypeVar, Set<Annotation> annotations) {
@@ -445,16 +469,20 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
             this.hash = Objects.hash(Owns.class, this.attributeType, this.overriddenAttributeType, this.annotations);
         }
 
+        private static void validateAnnotations(Set<Annotation> annotations) {
+            for (Annotation annotation : annotations) {
+                if (!VALID_ANNOTATIONS.contains(annotation)) {
+                    throw null; // TODO
+                }
+            }
+        }
+
         public TypeVariable attribute() {
             return attributeType;
         }
 
         public Optional<TypeVariable> overridden() {
             return Optional.ofNullable(overriddenAttributeType);
-        }
-
-        public boolean isKey() {
-            return isKey;
         }
 
         @Override
@@ -465,11 +493,10 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         }
 
         @Override
-        public boolean isOwns() {
-            return true;
+        public Set<Annotation> annotations() {
+            return annotations;
         }
 
-        @Override
         public TypeConstraint.Owns asOwns() {
             return this;
         }
@@ -494,44 +521,6 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         @Override
         public int hashCode() {
             return hash;
-        }
-
-        public static class Annotations {
-
-            private static final Set<Annotation> VALID_ANNOTATIONS = set(KEY, UNIQUE);
-            private final Set<Annotation> annotations;
-
-            public Annotations(Set<Annotation> annotations) {
-                validateAnnotations(annotations);
-                this.annotations = annotations;
-            }
-
-            private static void validateAnnotations(Set<Annotation> annotations) {
-                for (Annotation annotation : annotations) {
-                    if (!VALID_ANNOTATIONS.contains(annotation)) {
-                        throw null; // TODO
-                    }
-                }
-            }
-
-            @Override
-            public int hashCode() {
-                return annotations.hashCode();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                if (this == o) return true;
-                if (o == null || getClass() != o.getClass()) return false;
-                Annotations that = (Annotations) o;
-                return annotations.equals(that.annotations);
-            }
-
-            @Override
-            public String toString() {
-                // TODO sort and print
-                return null;
-            }
         }
     }
 

--- a/java/pattern/constraint/TypeConstraint.java
+++ b/java/pattern/constraint/TypeConstraint.java
@@ -413,69 +413,45 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         private final List<Annotation> annotations;
         private final int hash;
 
-        public Owns(String attributeType) {
-            this(hidden().type(attributeType), null, list());
-        }
-
-        public Owns(String attributeType, List<Annotation> annotations) {
+        public Owns(String attributeType, Annotation... annotations) {
             this(hidden().type(attributeType), null, annotations);
         }
 
-        public Owns(UnboundVariable attributeTypeVar) {
-            this(attributeTypeVar.toType(), null, list());
-        }
-
-        public Owns(UnboundVariable attributeTypeVar, List<Annotation> annotations) {
+        public Owns(UnboundVariable attributeTypeVar, Annotation... annotations) {
             this(attributeTypeVar.toType(), null, annotations);
         }
 
-        public Owns(String attributeType, String overriddenAttributeType) {
-            this(hidden().type(attributeType), overriddenAttributeType == null ? null : hidden().type(overriddenAttributeType), list());
-        }
-
-        public Owns(String attributeType, String overriddenAttributeType, List<Annotation> annotations) {
+        public Owns(String attributeType, String overriddenAttributeType, Annotation... annotations) {
             this(hidden().type(attributeType), overriddenAttributeType == null ? null : hidden().type(overriddenAttributeType), annotations);
         }
 
-        public Owns(UnboundVariable attributeTypeVar, String overriddenAttributeType) {
-            this(attributeTypeVar.toType(), overriddenAttributeType == null ? null : hidden().type(overriddenAttributeType), list());
-        }
-
-        public Owns(UnboundVariable attributeTypeVar, String overriddenAttributeType, List<Annotation> annotations) {
+        public Owns(UnboundVariable attributeTypeVar, String overriddenAttributeType, Annotation... annotations) {
             this(attributeTypeVar.toType(), overriddenAttributeType == null ? null : hidden().type(overriddenAttributeType), annotations);
         }
 
-        public Owns(String attributeType, UnboundVariable overriddenAttributeTypeVar) {
-            this(hidden().type(attributeType), overriddenAttributeTypeVar == null ? null : overriddenAttributeTypeVar.toType(), list());
-        }
-
-        public Owns(String attributeType, UnboundVariable overriddenAttributeTypeVar, List<Annotation> annotations) {
+        public Owns(String attributeType, UnboundVariable overriddenAttributeTypeVar, Annotation... annotations) {
             this(hidden().type(attributeType), overriddenAttributeTypeVar == null ? null : overriddenAttributeTypeVar.toType(), annotations);
         }
 
-        public Owns(UnboundVariable attributeTypeVar, UnboundVariable overriddenAttributeTypeVar) {
-            this(attributeTypeVar.toType(), overriddenAttributeTypeVar == null ? null : overriddenAttributeTypeVar.toType(), list());
-        }
-
-        public Owns(UnboundVariable attributeTypeVar, UnboundVariable overriddenAttributeTypeVar, List<Annotation> annotations) {
+        public Owns(UnboundVariable attributeTypeVar, UnboundVariable overriddenAttributeTypeVar, Annotation... annotations) {
             this(attributeTypeVar.toType(), overriddenAttributeTypeVar == null ? null : overriddenAttributeTypeVar.toType(), annotations);
         }
 
-        public Owns(Either<String, UnboundVariable> attributeTypeArg, Either<String, UnboundVariable> overriddenAttributeTypeArg, List<Annotation> annotations) {
+        public Owns(Either<String, UnboundVariable> attributeTypeArg, Either<String, UnboundVariable> overriddenAttributeTypeArg, Annotation... annotations) {
             this(attributeTypeArg.apply(label -> hidden().type(label), UnboundVariable::toType),
                     overriddenAttributeTypeArg == null ? null : overriddenAttributeTypeArg.apply(label -> hidden().type(label), UnboundVariable::toType),
                     annotations);
         }
 
-        private Owns(TypeVariable attributeType, @Nullable TypeVariable overriddenAttributeType, List<Annotation> annotations) {
+        private Owns(TypeVariable attributeType, @Nullable TypeVariable overriddenAttributeType, Annotation... annotations) {
             this.attributeType = attributeType;
             this.overriddenAttributeType = overriddenAttributeType;
             validateAnnotations(annotations);
-            this.annotations = annotations;
+            this.annotations = List.of(annotations);
             this.hash = Objects.hash(Owns.class, this.attributeType, this.overriddenAttributeType, this.annotations);
         }
 
-        private static void validateAnnotations(List<Annotation> annotations) {
+        private static void validateAnnotations(Annotation[] annotations) {
             for (Annotation annotation : annotations) {
                 if (!VALID_ANNOTATIONS.contains(annotation)) {
                     throw TypeQLException.of(INVALID_ANNOTATION.message("owns", annotation));

--- a/java/pattern/constraint/TypeConstraint.java
+++ b/java/pattern/constraint/TypeConstraint.java
@@ -100,8 +100,8 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         return false;
     }
 
-    public List<Annotation> annotations() {
-        return list();
+    public boolean isOwns() {
+        return false;
     }
 
     public boolean isPlays() {
@@ -110,6 +110,10 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
 
     public boolean isRelates() {
         return false;
+    }
+
+    public List<Annotation> annotations() {
+        return list();
     }
 
     public TypeConstraint.Label asLabel() {
@@ -497,6 +501,11 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         }
 
         @Override
+        public boolean isOwns() {
+            return true;
+        }
+
+        @Override
         public List<Annotation> annotations() {
             return annotations;
         }
@@ -509,7 +518,7 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         public String toString() {
             return "" + OWNS + SPACE + attributeType +
                     (overriddenAttributeType != null ? "" + SPACE + AS + SPACE + overriddenAttributeType : "") +
-                    annotations.stream().map(a -> a.toString()).reduce("", (x,y) -> x + SPACE + y);
+                    annotations.stream().map(a -> a.toString()).reduce("", (x, y) -> x + SPACE + y);
         }
 
         @Override

--- a/java/pattern/constraint/TypeConstraint.java
+++ b/java/pattern/constraint/TypeConstraint.java
@@ -408,11 +408,12 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
 
     public static class Owns extends TypeConstraint {
 
-        private static final Set<Annotation> VALID_ANNOTATIONS = set(KEY, UNIQUE);
+        private static final Set<Annotation> VALID_ANNOTATIONS = set(Annotation.KEY, Annotation.UNIQUE);
 
         private final TypeVariable attributeType;
         private final TypeVariable overriddenAttributeType;
         private final List<Annotation> annotations;
+        private final Annotation uniqueness;
         private final int hash;
 
         public Owns(String attributeType) {
@@ -474,6 +475,9 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
             this.overriddenAttributeType = overriddenAttributeType;
             validateAnnotations(annotations);
             this.annotations = annotations;
+            if (annotations.contains(KEY)) this.uniqueness = KEY;
+            else if (annotations.contains(UNIQUE)) this.uniqueness = UNIQUE;
+            else this.uniqueness = null;
             this.hash = Objects.hash(Owns.class, this.attributeType, this.overriddenAttributeType, this.annotations);
         }
 
@@ -505,13 +509,17 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
             return true;
         }
 
+        public TypeConstraint.Owns asOwns() {
+            return this;
+        }
+
         @Override
         public List<Annotation> annotations() {
             return annotations;
         }
 
-        public TypeConstraint.Owns asOwns() {
-            return this;
+        public Optional<Annotation> uniqueness() {
+            return Optional.ofNullable(uniqueness);
         }
 
         @Override

--- a/java/pattern/variable/builder/TypeVariableBuilder.java
+++ b/java/pattern/variable/builder/TypeVariableBuilder.java
@@ -27,6 +27,8 @@ import com.vaticle.typeql.lang.pattern.constraint.TypeConstraint;
 import com.vaticle.typeql.lang.pattern.variable.TypeVariable;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
 
+import static com.vaticle.typedb.common.collection.Collections.set;
+
 public interface TypeVariableBuilder {
 
     default TypeVariable type(TypeQLToken.Type type) {
@@ -78,51 +80,51 @@ public interface TypeVariableBuilder {
     }
 
     default TypeVariable owns(String attributeType) {
-        return constrain(new TypeConstraint.Owns(attributeType, false));
+        return constrain(new TypeConstraint.Owns(attributeType));
     }
 
-    default TypeVariable owns(String attributeType, boolean isKey) {
-        return constrain(new TypeConstraint.Owns(attributeType, isKey));
+    default TypeVariable owns(String attributeType, TypeQLToken.Annotation... annotations) {
+        return constrain(new TypeConstraint.Owns(attributeType, set(annotations)));
     }
 
     default TypeVariable owns(UnboundVariable attributeTypeVar) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, false));
+        return constrain(new TypeConstraint.Owns(attributeTypeVar));
     }
 
-    default TypeVariable owns(UnboundVariable attributeTypeVar, boolean isKey) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, isKey));
+    default TypeVariable owns(UnboundVariable attributeTypeVar, TypeQLToken.Annotation... annotations) {
+        return constrain(new TypeConstraint.Owns(attributeTypeVar, set(annotations)));
     }
 
     default TypeVariable owns(String attributeType, String overriddenAttributeType) {
-        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeType, false));
+        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeType));
     }
 
-    default TypeVariable owns(String attributeType, String overriddenAttributeType, boolean isKey) {
-        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeType, isKey));
+    default TypeVariable owns(String attributeType, String overriddenAttributeType, TypeQLToken.Annotation... annotations) {
+        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeType, set(annotations)));
     }
 
     default TypeVariable owns(String attributeType, UnboundVariable overriddenAttributeTypeVar) {
-        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeTypeVar, false));
+        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeTypeVar));
     }
 
-    default TypeVariable owns(String attributeType, UnboundVariable overriddenAttributeTypeVar, boolean isKey) {
-        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeTypeVar, isKey));
+    default TypeVariable owns(String attributeType, UnboundVariable overriddenAttributeTypeVar, TypeQLToken.Annotation... annotations) {
+        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeTypeVar, set(annotations)));
     }
 
     default TypeVariable owns(UnboundVariable attributeTypeVar, String overriddenAttributeType) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeType, false));
+        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeType));
     }
 
-    default TypeVariable owns(UnboundVariable attributeTypeVar, String overriddenAttributeType, boolean isKey) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeType, isKey));
+    default TypeVariable owns(UnboundVariable attributeTypeVar, String overriddenAttributeType, TypeQLToken.Annotation... annotations) {
+        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeType, set(annotations)));
     }
 
     default TypeVariable owns(UnboundVariable attributeTypeVar, UnboundVariable overriddenAttributeTypeVar) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeTypeVar, false));
+        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeTypeVar));
     }
 
-    default TypeVariable owns(UnboundVariable attributeTypeVar, UnboundVariable overriddenAttributeTypeVar, boolean isKey) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeTypeVar, isKey));
+    default TypeVariable owns(UnboundVariable attributeTypeVar, UnboundVariable overriddenAttributeTypeVar, TypeQLToken.Annotation... annotations) {
+        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeTypeVar, set(annotations)));
     }
 
     default TypeVariable plays(String relationType, String roleType) {

--- a/java/pattern/variable/builder/TypeVariableBuilder.java
+++ b/java/pattern/variable/builder/TypeVariableBuilder.java
@@ -27,7 +27,7 @@ import com.vaticle.typeql.lang.pattern.constraint.TypeConstraint;
 import com.vaticle.typeql.lang.pattern.variable.TypeVariable;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
 
-import static com.vaticle.typedb.common.collection.Collections.set;
+import static com.vaticle.typedb.common.collection.Collections.list;
 
 public interface TypeVariableBuilder {
 
@@ -84,7 +84,7 @@ public interface TypeVariableBuilder {
     }
 
     default TypeVariable owns(String attributeType, TypeQLToken.Annotation... annotations) {
-        return constrain(new TypeConstraint.Owns(attributeType, set(annotations)));
+        return constrain(new TypeConstraint.Owns(attributeType, list(annotations)));
     }
 
     default TypeVariable owns(UnboundVariable attributeTypeVar) {
@@ -92,7 +92,7 @@ public interface TypeVariableBuilder {
     }
 
     default TypeVariable owns(UnboundVariable attributeTypeVar, TypeQLToken.Annotation... annotations) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, set(annotations)));
+        return constrain(new TypeConstraint.Owns(attributeTypeVar, list(annotations)));
     }
 
     default TypeVariable owns(String attributeType, String overriddenAttributeType) {
@@ -100,7 +100,7 @@ public interface TypeVariableBuilder {
     }
 
     default TypeVariable owns(String attributeType, String overriddenAttributeType, TypeQLToken.Annotation... annotations) {
-        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeType, set(annotations)));
+        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeType, list(annotations)));
     }
 
     default TypeVariable owns(String attributeType, UnboundVariable overriddenAttributeTypeVar) {
@@ -108,7 +108,7 @@ public interface TypeVariableBuilder {
     }
 
     default TypeVariable owns(String attributeType, UnboundVariable overriddenAttributeTypeVar, TypeQLToken.Annotation... annotations) {
-        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeTypeVar, set(annotations)));
+        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeTypeVar, list(annotations)));
     }
 
     default TypeVariable owns(UnboundVariable attributeTypeVar, String overriddenAttributeType) {
@@ -116,7 +116,7 @@ public interface TypeVariableBuilder {
     }
 
     default TypeVariable owns(UnboundVariable attributeTypeVar, String overriddenAttributeType, TypeQLToken.Annotation... annotations) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeType, set(annotations)));
+        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeType, list(annotations)));
     }
 
     default TypeVariable owns(UnboundVariable attributeTypeVar, UnboundVariable overriddenAttributeTypeVar) {
@@ -124,7 +124,7 @@ public interface TypeVariableBuilder {
     }
 
     default TypeVariable owns(UnboundVariable attributeTypeVar, UnboundVariable overriddenAttributeTypeVar, TypeQLToken.Annotation... annotations) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeTypeVar, set(annotations)));
+        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeTypeVar, list(annotations)));
     }
 
     default TypeVariable plays(String relationType, String roleType) {

--- a/java/pattern/variable/builder/TypeVariableBuilder.java
+++ b/java/pattern/variable/builder/TypeVariableBuilder.java
@@ -27,8 +27,6 @@ import com.vaticle.typeql.lang.pattern.constraint.TypeConstraint;
 import com.vaticle.typeql.lang.pattern.variable.TypeVariable;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
 
-import static com.vaticle.typedb.common.collection.Collections.list;
-
 public interface TypeVariableBuilder {
 
     default TypeVariable type(TypeQLToken.Type type) {
@@ -79,52 +77,29 @@ public interface TypeVariableBuilder {
         return constrain(new TypeConstraint.Sub(typeVar, true));
     }
 
-    default TypeVariable owns(String attributeType) {
-        return constrain(new TypeConstraint.Owns(attributeType));
-    }
-
     default TypeVariable owns(String attributeType, TypeQLToken.Annotation... annotations) {
-        return constrain(new TypeConstraint.Owns(attributeType, list(annotations)));
-    }
-
-    default TypeVariable owns(UnboundVariable attributeTypeVar) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar));
+        return constrain(new TypeConstraint.Owns(attributeType, annotations));
     }
 
     default TypeVariable owns(UnboundVariable attributeTypeVar, TypeQLToken.Annotation... annotations) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, list(annotations)));
+        return constrain(new TypeConstraint.Owns(attributeTypeVar, annotations));
     }
 
-    default TypeVariable owns(String attributeType, String overriddenAttributeType) {
-        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeType));
-    }
 
     default TypeVariable owns(String attributeType, String overriddenAttributeType, TypeQLToken.Annotation... annotations) {
-        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeType, list(annotations)));
-    }
-
-    default TypeVariable owns(String attributeType, UnboundVariable overriddenAttributeTypeVar) {
-        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeTypeVar));
+        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeType, annotations));
     }
 
     default TypeVariable owns(String attributeType, UnboundVariable overriddenAttributeTypeVar, TypeQLToken.Annotation... annotations) {
-        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeTypeVar, list(annotations)));
-    }
-
-    default TypeVariable owns(UnboundVariable attributeTypeVar, String overriddenAttributeType) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeType));
+        return constrain(new TypeConstraint.Owns(attributeType, overriddenAttributeTypeVar, annotations));
     }
 
     default TypeVariable owns(UnboundVariable attributeTypeVar, String overriddenAttributeType, TypeQLToken.Annotation... annotations) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeType, list(annotations)));
-    }
-
-    default TypeVariable owns(UnboundVariable attributeTypeVar, UnboundVariable overriddenAttributeTypeVar) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeTypeVar));
+        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeType, annotations));
     }
 
     default TypeVariable owns(UnboundVariable attributeTypeVar, UnboundVariable overriddenAttributeTypeVar, TypeQLToken.Annotation... annotations) {
-        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeTypeVar, list(annotations)));
+        return constrain(new TypeConstraint.Owns(attributeTypeVar, overriddenAttributeTypeVar, annotations));
     }
 
     default TypeVariable plays(String relationType, String roleType) {


### PR DESCRIPTION
## What is the goal of this PR?

We generalise the annotation syntax and parsing to be able to handle a new type of annotation: the `@unique` annotation, which is available only on the `owns` constraint:

```
define
person sub entity, owns email @unique;
email sub attribute, value string;
```

This annotation indicates that any `email`s a person owns must be unique to that person. It does not place any restrictions on the number of emails any given person may own.

The language builder API has also been updated to use a generalised form of any number of annotations, rather than having a particular boolean per annotation type (now, pass annotation `UNIQUE` or `KEY` instead of booleans).

## What are the changes implemented in this PR?

* Introduce `annotations_owns` in the grammar
* Introduce new grammar rules for `annotations`: `@key` becomes an `annotation`, as does the new `@unique`
* Introduce generalised `annotations` in the grammar and the language builders
