### PR TITLE
Simplify rule pretty printing

### DIFF
--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -175,13 +175,11 @@ public class Rule implements Definable {
         StringBuilder rule = new StringBuilder("" + RULE + SPACE + label);
         if (when != null) {
             if (pretty) {
-                rule.append(COLON).append(NEW_LINE);
-                StringBuilder body = new StringBuilder();
-                body.append(WHEN).append(SPACE).append(when.toString(pretty)).append(NEW_LINE);
-                body.append(THEN).append(SPACE).append(CURLY_OPEN).append(NEW_LINE);
-                body.append(indent(then)).append(SEMICOLON);
-                body.append(NEW_LINE).append(CURLY_CLOSE);
-                rule.append(indent(body));
+                rule.append(COLON).append(SPACE).append(WHEN).append(SPACE);
+                rule.append(when.toString(pretty))
+                        .append(SPACE).append(THEN).append(SPACE).append(CURLY_OPEN).append(NEW_LINE)
+                        .append(indent(then.toString(true))).append(SEMICOLON).append(NEW_LINE)
+                        .append(CURLY_CLOSE);
             } else {
                 rule.append(COLON).append(SPACE);
                 String content = String.valueOf(WHEN) + SPACE + when.toString(pretty) + THEN + SPACE + CURLY_OPEN +


### PR DESCRIPTION
## What is the goal of this PR?

We update and simplify the way rules are pretty-printed. Rules now print the `when` inline and produce a more compact output:

```
rule a-rule: when {
    $x isa person;
    not {
        $x has name "Alice";
        $x has name "Bob";
    };
    {
        ($x) isa friendship;
    } or {
        ($x) isa employment;
    };
} then {
    $x has is_interesting true;
};
```

## What are the changes implemented in this PR?

