### PR TITLE
Update rule printing in TypeQL Rust

### DIFF
--- a/dependencies/ide/rust/sync.sh
+++ b/dependencies/ide/rust/sync.sh
@@ -16,4 +16,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-bazel run @vaticle_dependencies//ide/rust:sync
+bazel run @vaticle_dependencies//tool/cargo:sync

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -987,15 +987,29 @@ public class ParserTest {
 
     @Test
     public void testDefineRules() {
-        final String when = "$x isa movie;";
-        final String then = "$x has genre 'drama';";
-        Conjunction<? extends Pattern> whenPattern = and((var("x").isa("movie")));
-        ThingVariable<?> thenPattern = var("x").has("genre", "drama");
+        final String when =
+                "    $x isa person;\n" +
+                "    not {\n" +
+                "        $x has name 'Alice';\n" +
+                "        $x has name 'Bob';\n" +
+                "    };\n" +
+                "    {\n" +
+                "        ($x) isa friendship;\n" +
+                "    } or {\n" +
+                "        ($x) isa employment;\n" +
+                "    };";
+        final String then = "$x has is_interesting true;";
+        Conjunction<? extends Pattern> whenPattern = and(
+                var("x").isa("person"),
+                not(and(var("x").has("name", "Alice"), var("x").has("name", "Bob"))),
+                or(rel(var("x")).isa("friendship"), rel(var("x")).isa("employment"))
+        );
+        ThingVariable<?> thenPattern = var("x").has("is_interesting", true);
 
         TypeQLDefine expected = define(rule("all-movies-are-drama").when(whenPattern).then(thenPattern));
         final String query = "define\n" +
                 "rule all-movies-are-drama: when {\n" +
-                "    " + when + "\n" +
+                when + "\n" +
                 "} then {\n" +
                 "    " + then + "\n" +
                 "};";

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -1033,13 +1033,11 @@ fn test_parsing_pattern() {
 #[test]
 fn test_define_rules() {
     let query = r#"define
-rule all-movies-are-drama:
-    when {
-        $x isa movie;
-    }
-    then {
-        $x has genre "drama";
-    };"#;
+rule all-movies-are-drama: when {
+    $x isa movie;
+} then {
+    $x has genre "drama";
+};"#;
 
     let parsed = parse_query(&query).unwrap().into_define();
     let expected = typeql_define!(rule("all-movies-are-drama")

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -1033,16 +1033,29 @@ fn test_parsing_pattern() {
 #[test]
 fn test_define_rules() {
     let query = r#"define
-rule all-movies-are-drama: when {
-    $x isa movie;
+rule a-rule: when {
+    $x isa person;
+    not {
+        $x has name "Alice";
+        $x has name "Bob";
+    };
+    {
+        ($x) isa friendship;
+    } or {
+        ($x) isa employment;
+    };
 } then {
-    $x has genre "drama";
+    $x has is_interesting true;
 };"#;
 
     let parsed = parse_query(&query).unwrap().into_define();
-    let expected = typeql_define!(rule("all-movies-are-drama")
-        .when(and!(var("x").isa("movie")))
-        .then(var("x").has(("genre", "drama"))));
+    let expected = typeql_define!(rule("a-rule")
+        .when(and!(
+            var("x").isa("person"),
+            not(and!(var("x").has(("name", "Alice")), var("x").has(("name", "Bob")))),
+            or!(rel(var("x")).isa("friendship"), rel(var("x")).isa("employment"))
+        ))
+        .then(var("x").has(("is_interesting", true))));
 
     assert_valid_eq_repr!(expected, parsed, query);
 }

--- a/rust/pattern/negation.rs
+++ b/rust/pattern/negation.rs
@@ -24,7 +24,7 @@ use core::fmt;
 use std::collections::HashSet;
 
 use crate::{
-    common::{error::TypeQLError, token, validatable::Validatable, Result},
+    common::{error::TypeQLError, string::indent, token, validatable::Validatable, Result},
     pattern::{Conjunction, Disjunction, Normalisable, Pattern, Reference},
 };
 
@@ -83,6 +83,13 @@ impl Normalisable for Negation {
 
 impl fmt::Display for Negation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {{ {}; }}", token::Operator::Not, self.pattern)
+        let pattern_string = self.pattern.to_string();
+        if matches!(*self.pattern, Pattern::Conjunction(_)) {
+            write!(f, "{} {}", token::Operator::Not, pattern_string)
+        } else if pattern_string.lines().count() > 1 {
+            write!(f, "{} {{\n{};\n}}", token::Operator::Not, indent(&pattern_string))
+        } else {
+            write!(f, "{} {{ {}; }}", token::Operator::Not, pattern_string)
+        }
     }
 }

--- a/rust/pattern/schema/rule.rs
+++ b/rust/pattern/schema/rule.rs
@@ -183,16 +183,13 @@ impl fmt::Display for RuleDefinition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{} {}:\n{}",
+            "{} {}: {} {} {} {{\n    {};\n}}",
             token::Schema::Rule,
             self.label,
-            indent(&format!(
-                "{} {}\n{} {{\n    {};\n}}",
-                token::Schema::When,
-                self.when,
-                token::Schema::Then,
-                self.then
-            ))
+            token::Schema::When,
+            self.when,
+            token::Schema::Then,
+            self.then
         )
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We update the way rules and queries are printed in the TypeQL rust implementation, following the format introduced in #275.