### PR TITLE
Fix TypeQL Python build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -43,14 +43,16 @@ checkstyle_test(
     name = "checkstyle",
     include = [
         ".bazelrc",
-        ".bazel-remote-cache.rc",
-        ".bazel-cache-credential.json",
         ".gitignore",
         ".factory/automation.yml",
         "BUILD",
         "WORKSPACE",
         "deployment.bzl",
         "requirements.txt",
+    ],
+    exclude = [
+        ".bazel-remote-cache.rc",
+        ".bazel-cache-credential.json",
     ],
     license_type = "apache-header",
 )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "b968cab9c4d2f85d80a0069b8d15cce5afdd0da5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/dmitrii-ubskii/vaticle-dependencies",
+        commit = "0164a8ee178c6e54a7b4d624ecb2cdd3cc8389ed", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/dmitrii-ubskii/vaticle-dependencies",
-        commit = "0164a8ee178c6e54a7b4d624ecb2cdd3cc8389ed", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "2604b6932dd82405ceabafaea528aa97816deb18", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/grammar/python/BUILD
+++ b/grammar/python/BUILD
@@ -46,7 +46,7 @@ genrule(
         "TypeQLPythonVisitor.py",
     ],
     srcs = [":python-antlr"],
-    cmd = "mv $(execpath :python-src)/com/vaticle/typeql/grammar/*.py $(@D)",
+    cmd = "mv $(execpath :python-antlr)/com/vaticle/typeql/grammar/*.py $(@D)",
 )
 
 py_library(

--- a/grammar/python/BUILD
+++ b/grammar/python/BUILD
@@ -30,11 +30,23 @@ python_grammar_adapter(
 )
 
 antlr(
-    name = "python-src",
+    name = "python-antlr",
     srcs = [":python-grammar"],
     language = "Python3",
     visitor = True,
     package = "com.vaticle.typeql.grammar",
+)
+
+genrule(
+    name = "python-src",
+    outs = [
+        "TypeQLPythonLexer.py",
+        "TypeQLPythonListener.py",
+        "TypeQLPythonParser.py",
+        "TypeQLPythonVisitor.py",
+    ],
+    srcs = [":python-antlr"],
+    cmd = "mv $(execpath :python-src)/com/vaticle/typeql/grammar/*.py $(@D)",
 )
 
 py_library(


### PR DESCRIPTION
## What is the goal of this PR?

We fix the issue with grammar-python producing empty pip packages.

## What are the changes implemented in this PR?

`rules_antlr` cheats: since the `py_library` expects `*.py` sources, `antlr(language = "Python3")` names the package _folder_ `*.py` so that the `py_library()` rule would accept its output as an input. Unfortunately, the current version of `py_library()` is not so easily tricked and produces `error: can't copy 'bazel-bin/grammar/python/python-src.py': doesn't exist or not a regular file`.

In this PR, we explicitly redeclare the python sources produced by the `antlr()` rule for use by `py_library()`.

Drive-by: fix top-level checkstyle to _exclude_ rather than include the bazel remote cache files.