### PR TITLE
Implement unique annotation in TypeQL Rust

### DIFF
--- a/rust/builder/mod.rs
+++ b/rust/builder/mod.rs
@@ -23,8 +23,8 @@
 use crate::{
     common::token::Predicate,
     pattern::{
-        Negation, RelationVariableBuilder, RolePlayerConstraint, RuleDeclaration, ThingVariable,
-        TypeVariable, TypeVariableBuilder, UnboundVariable, Value, ValueConstraint,
+        Negation, RelationVariableBuilder, RolePlayerConstraint, RuleDeclaration, ThingVariable, TypeVariable,
+        TypeVariableBuilder, UnboundVariable, Value, ValueConstraint,
     },
     Pattern,
 };

--- a/rust/common/string.rs
+++ b/rust/common/string.rs
@@ -21,7 +21,7 @@
  */
 
 pub(crate) fn quote(string: &str) -> String {
-    format!("\"{}\"", string)
+    format!("\"{string}\"")
 }
 
 pub(crate) fn unquote(quoted_string: &str) -> String {
@@ -41,7 +41,7 @@ pub(crate) fn unescape_regex(regex: &str) -> String {
 }
 
 pub(crate) fn format_double(double: f64) -> String {
-    let formatted = format!("{:.12}", double).trim_end_matches('0').to_string();
+    let formatted = format!("{double:.12}").trim_end_matches('0').to_string();
     if formatted.ends_with('.') {
         formatted + "0"
     } else {

--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -123,7 +123,6 @@ string_enum! { Constraint
     Has = "has",
     IID = "iid",
     Is = "is",
-    IsKey = "@key",
     Isa = "isa",
     IsaX = "isa!",
     Owns = "owns",
@@ -134,6 +133,11 @@ string_enum! { Constraint
     SubX = "sub!",
     Type = "type",
     ValueType = "value",
+}
+
+string_enum! { Annotation
+    Key = "key",
+    Unique = "unique",
 }
 
 string_enum! { Aggregate

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -39,17 +39,15 @@ use crate::{
         Result,
     },
     pattern::{
-        Annotation, ConceptVariable, ConceptVariableBuilder, Conjunction, Definable, Disjunction,
-        HasConstraint, IsaConstraint, Label, Negation, OwnsConstraint, Pattern, PlaysConstraint,
-        RelatesConstraint, RelationConstraint, RolePlayerConstraint, RuleDeclaration,
-        RuleDefinition, SubConstraint, ThingConstrainable, ThingVariable, ThingVariableBuilder,
-        Type, TypeConstrainable, TypeVariable, TypeVariableBuilder, UnboundVariable, Value,
-        ValueConstraint, Variable,
+        Annotation, ConceptVariable, ConceptVariableBuilder, Conjunction, Definable, Disjunction, HasConstraint,
+        IsaConstraint, Label, Negation, OwnsConstraint, Pattern, PlaysConstraint, RelatesConstraint,
+        RelationConstraint, RolePlayerConstraint, RuleDeclaration, RuleDefinition, SubConstraint, ThingConstrainable,
+        ThingVariable, ThingVariableBuilder, Type, TypeConstrainable, TypeVariable, TypeVariableBuilder,
+        UnboundVariable, Value, ValueConstraint, Variable,
     },
     query::{
-        sorting, AggregateQueryBuilder, Query, Sorting, TypeQLDefine, TypeQLDelete, TypeQLInsert,
-        TypeQLMatch, TypeQLMatchAggregate, TypeQLMatchGroup, TypeQLMatchGroupAggregate,
-        TypeQLUndefine, TypeQLUpdate,
+        sorting, AggregateQueryBuilder, Query, Sorting, TypeQLDefine, TypeQLDelete, TypeQLInsert, TypeQLMatch,
+        TypeQLMatchAggregate, TypeQLMatchGroup, TypeQLMatchGroupAggregate, TypeQLUndefine, TypeQLUpdate,
     },
 };
 
@@ -137,28 +135,18 @@ pub(crate) fn visit_eof_queries(queries: &str) -> Result<impl Iterator<Item = Re
 }
 
 pub(crate) fn visit_eof_pattern(pattern: &str) -> Result<Pattern> {
-    visit_pattern(
-        parse_single(Rule::eof_pattern, pattern)?.into_children().consume_expected(Rule::pattern),
-    )
-    .validated()
+    visit_pattern(parse_single(Rule::eof_pattern, pattern)?.into_children().consume_expected(Rule::pattern)).validated()
 }
 
 pub(crate) fn visit_eof_patterns(patterns: &str) -> Result<Vec<Pattern>> {
-    visit_patterns(
-        parse_single(Rule::eof_patterns, patterns)?
-            .into_children()
-            .consume_expected(Rule::eof_patterns),
-    )
-    .into_iter()
-    .map(Validatable::validated)
-    .collect()
-}
-
-pub(crate) fn visit_eof_definables(definables: &str) -> Result<Vec<Definable>> {
-    visit_definables(parse_single(Rule::eof_definables, definables)?)
+    visit_patterns(parse_single(Rule::eof_patterns, patterns)?.into_children().consume_expected(Rule::eof_patterns))
         .into_iter()
         .map(Validatable::validated)
         .collect()
+}
+
+pub(crate) fn visit_eof_definables(definables: &str) -> Result<Vec<Definable>> {
+    visit_definables(parse_single(Rule::eof_definables, definables)?).into_iter().map(Validatable::validated).collect()
 }
 
 pub(crate) fn visit_eof_variable(variable: &str) -> Result<Variable> {
@@ -186,23 +174,15 @@ fn get_regex(string: SyntaxTree) -> String {
 }
 
 fn get_long(long: SyntaxTree) -> i64 {
-    long.as_str()
-        .parse()
-        .unwrap_or_else(|_| panic!("{}", TypeQLError::IllegalGrammar(long.to_string())))
+    long.as_str().parse().unwrap_or_else(|_| panic!("{}", TypeQLError::IllegalGrammar(long.to_string())))
 }
 
 fn get_double(double: SyntaxTree) -> f64 {
-    double
-        .as_str()
-        .parse()
-        .unwrap_or_else(|_| panic!("{}", TypeQLError::IllegalGrammar(double.to_string())))
+    double.as_str().parse().unwrap_or_else(|_| panic!("{}", TypeQLError::IllegalGrammar(double.to_string())))
 }
 
 fn get_boolean(boolean: SyntaxTree) -> bool {
-    boolean
-        .as_str()
-        .parse()
-        .unwrap_or_else(|_| panic!("{}", TypeQLError::IllegalGrammar(boolean.to_string())))
+    boolean.as_str().parse().unwrap_or_else(|_| panic!("{}", TypeQLError::IllegalGrammar(boolean.to_string())))
 }
 
 fn get_date(date: SyntaxTree) -> NaiveDate {
@@ -285,34 +265,24 @@ fn visit_query_undefine(tree: SyntaxTree) -> TypeQLUndefine {
 fn visit_query_insert(tree: SyntaxTree) -> TypeQLInsert {
     let mut children = tree.into_children();
     match children.consume_any().as_rule() {
-        Rule::MATCH => {
-            TypeQLMatch::from_patterns(visit_patterns(children.consume_expected(Rule::patterns)))
-                .insert(visit_variable_things(
-                    children.skip_expected(Rule::INSERT).consume_expected(Rule::variable_things),
-                ))
-        }
-        Rule::INSERT => TypeQLInsert::new(visit_variable_things(
-            children.consume_expected(Rule::variable_things),
-        )),
+        Rule::MATCH => TypeQLMatch::from_patterns(visit_patterns(children.consume_expected(Rule::patterns))).insert(
+            visit_variable_things(children.skip_expected(Rule::INSERT).consume_expected(Rule::variable_things)),
+        ),
+        Rule::INSERT => TypeQLInsert::new(visit_variable_things(children.consume_expected(Rule::variable_things))),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar(children.to_string())),
     }
 }
 
 fn visit_query_delete(tree: SyntaxTree) -> TypeQLDelete {
     let mut children = tree.into_children();
-    TypeQLMatch::from_patterns(visit_patterns(
-        children.skip_expected(Rule::MATCH).consume_expected(Rule::patterns),
-    ))
-    .delete(visit_variable_things(
-        children.skip_expected(Rule::DELETE).consume_expected(Rule::variable_things),
-    ))
+    TypeQLMatch::from_patterns(visit_patterns(children.skip_expected(Rule::MATCH).consume_expected(Rule::patterns)))
+        .delete(visit_variable_things(children.skip_expected(Rule::DELETE).consume_expected(Rule::variable_things)))
 }
 
 fn visit_query_update(tree: SyntaxTree) -> TypeQLUpdate {
     let mut children = tree.into_children();
-    visit_query_delete(children.consume_expected(Rule::query_delete)).insert(visit_variable_things(
-        children.skip_expected(Rule::INSERT).consume_expected(Rule::variable_things),
-    ))
+    visit_query_delete(children.consume_expected(Rule::query_delete))
+        .insert(visit_variable_things(children.skip_expected(Rule::INSERT).consume_expected(Rule::variable_things)))
 }
 
 fn visit_query_match(tree: SyntaxTree) -> TypeQLMatch {
@@ -326,17 +296,11 @@ fn visit_query_match(tree: SyntaxTree) -> TypeQLMatch {
                 Rule::filter => match_query.filter(visit_filter(modifier)),
                 Rule::sort => match_query.sort(visit_sort(modifier)),
                 Rule::offset => match_query.offset(get_long(
-                    modifier
-                        .into_children()
-                        .skip_expected(Rule::OFFSET)
-                        .consume_expected(Rule::LONG_),
+                    modifier.into_children().skip_expected(Rule::OFFSET).consume_expected(Rule::LONG_),
                 ) as usize),
-                Rule::limit => match_query.limit(get_long(
-                    modifier
-                        .into_children()
-                        .skip_expected(Rule::LIMIT)
-                        .consume_expected(Rule::LONG_),
-                ) as usize),
+                Rule::limit => match_query
+                    .limit(get_long(modifier.into_children().skip_expected(Rule::LIMIT).consume_expected(Rule::LONG_))
+                        as usize),
                 _ => unreachable!("{}", TypeQLError::IllegalGrammar(modifier.to_string())),
             };
         }
@@ -393,9 +357,7 @@ fn visit_var_order(tree: SyntaxTree) -> sorting::OrderedVariable {
     let mut children = tree.into_children();
     sorting::OrderedVariable {
         var: get_var(children.consume_expected(Rule::VAR_)),
-        order: children
-            .consume_if_matches(Rule::ORDER_)
-            .map(|child| token::Order::from(child.as_str())),
+        order: children.consume_if_matches(Rule::ORDER_).map(|child| token::Order::from(child.as_str())),
     }
 }
 
@@ -450,9 +412,7 @@ fn visit_pattern_disjunction(tree: SyntaxTree) -> Disjunction {
 }
 
 fn visit_pattern_negation(tree: SyntaxTree) -> Negation {
-    let mut patterns = visit_patterns(
-        tree.into_children().skip_expected(Rule::NOT).consume_expected(Rule::patterns),
-    );
+    let mut patterns = visit_patterns(tree.into_children().skip_expected(Rule::NOT).consume_expected(Rule::patterns));
     match patterns.len() {
         1 => Negation::new(patterns.pop().unwrap()),
         _ => Negation::new(Conjunction::new(patterns).into()),
@@ -477,53 +437,45 @@ fn visit_variable_concept(tree: SyntaxTree) -> ConceptVariable {
 
 fn visit_variable_type(tree: SyntaxTree) -> TypeVariable {
     let mut children = tree.into_children();
-    let mut var_type =
-        visit_type_any(children.consume_expected(Rule::type_any)).into_type_variable();
-    var_type =
-        children.map(SyntaxTree::into_children).fold(var_type, |var_type, mut constraint| {
-            let keyword = constraint.consume_any();
-            match keyword.as_rule() {
-                Rule::ABSTRACT => var_type.abstract_(),
-                Rule::OWNS => {
-                    let type_ =
-                        visit_type(constraint.consume_expected(Rule::type_)).into_type_variable();
-                    let overridden = constraint.consume_if_matches(Rule::AS).map(|_| {
-                        visit_type(constraint.consume_expected(Rule::type_)).into_type_variable()
-                    });
-                    let annotations =
-                        visit_annotations_owns(constraint.consume_expected(Rule::annotations_owns));
-                    var_type.constrain_owns(OwnsConstraint::new(type_, overridden, annotations))
-                }
-                Rule::PLAYS => {
-                    let type_ = visit_type_scoped(constraint.consume_expected(Rule::type_scoped));
-                    let overridden = constraint
-                        .consume_if_matches(Rule::AS)
-                        .map(|_| visit_type(constraint.consume_expected(Rule::type_)));
-                    var_type.constrain_plays(PlaysConstraint::from((type_, overridden)))
-                }
-                Rule::REGEX => {
-                    var_type.regex(get_regex(constraint.consume_expected(Rule::STRING_)))
-                }
-                Rule::RELATES => {
-                    let type_ = visit_type(constraint.consume_expected(Rule::type_));
-                    let overridden = constraint
-                        .consume_if_matches(Rule::AS)
-                        .map(|_| visit_type(constraint.consume_expected(Rule::type_)));
-                    var_type.constrain_relates(RelatesConstraint::from((type_, overridden)))
-                }
-                Rule::SUB_ => var_type.constrain_sub(SubConstraint::from((
-                    visit_type_any(constraint.consume_expected(Rule::type_any)),
-                    matches!(keyword.into_child().as_rule(), Rule::SUBX).into(),
-                ))),
-                Rule::TYPE => {
-                    var_type.type_(visit_label_any(constraint.consume_expected(Rule::label_any)))
-                }
-                Rule::VALUE => var_type.value(token::ValueType::from(
-                    constraint.consume_expected(Rule::value_type).as_str(),
-                )),
-                _ => unreachable!("{}", TypeQLError::IllegalGrammar(constraint.to_string())),
+    let mut var_type = visit_type_any(children.consume_expected(Rule::type_any)).into_type_variable();
+    var_type = children.map(SyntaxTree::into_children).fold(var_type, |var_type, mut constraint| {
+        let keyword = constraint.consume_any();
+        match keyword.as_rule() {
+            Rule::ABSTRACT => var_type.abstract_(),
+            Rule::OWNS => {
+                let type_ = visit_type(constraint.consume_expected(Rule::type_)).into_type_variable();
+                let overridden = constraint
+                    .consume_if_matches(Rule::AS)
+                    .map(|_| visit_type(constraint.consume_expected(Rule::type_)).into_type_variable());
+                let annotations = visit_annotations_owns(constraint.consume_expected(Rule::annotations_owns));
+                var_type.constrain_owns(OwnsConstraint::new(type_, overridden, annotations))
             }
-        });
+            Rule::PLAYS => {
+                let type_ = visit_type_scoped(constraint.consume_expected(Rule::type_scoped));
+                let overridden = constraint
+                    .consume_if_matches(Rule::AS)
+                    .map(|_| visit_type(constraint.consume_expected(Rule::type_)));
+                var_type.constrain_plays(PlaysConstraint::from((type_, overridden)))
+            }
+            Rule::REGEX => var_type.regex(get_regex(constraint.consume_expected(Rule::STRING_))),
+            Rule::RELATES => {
+                let type_ = visit_type(constraint.consume_expected(Rule::type_));
+                let overridden = constraint
+                    .consume_if_matches(Rule::AS)
+                    .map(|_| visit_type(constraint.consume_expected(Rule::type_)));
+                var_type.constrain_relates(RelatesConstraint::from((type_, overridden)))
+            }
+            Rule::SUB_ => var_type.constrain_sub(SubConstraint::from((
+                visit_type_any(constraint.consume_expected(Rule::type_any)),
+                matches!(keyword.into_child().as_rule(), Rule::SUBX).into(),
+            ))),
+            Rule::TYPE => var_type.type_(visit_label_any(constraint.consume_expected(Rule::label_any))),
+            Rule::VALUE => {
+                var_type.value(token::ValueType::from(constraint.consume_expected(Rule::value_type).as_str()))
+            }
+            _ => unreachable!("{}", TypeQLError::IllegalGrammar(constraint.to_string())),
+        }
+    });
 
     var_type
 }
@@ -559,15 +511,13 @@ fn visit_variable_thing(tree: SyntaxTree) -> ThingVariable {
         let keyword = children.consume_any();
         var_thing = match keyword.as_rule() {
             Rule::IID => var_thing.iid(children.consume_expected(Rule::IID_).as_str()),
-            Rule::ISA_ => var_thing
-                .constrain_isa(get_isa_constraint(keyword, children.consume_expected(Rule::type_))),
+            Rule::ISA_ => var_thing.constrain_isa(get_isa_constraint(keyword, children.consume_expected(Rule::type_))),
             _ => unreachable!("{}", TypeQLError::IllegalGrammar(children.to_string())),
         }
     }
     if let Some(attributes) = children.consume_if_matches(Rule::attributes) {
-        var_thing = visit_attributes(attributes)
-            .into_iter()
-            .fold(var_thing, |var_thing, has| var_thing.constrain_has(has));
+        var_thing =
+            visit_attributes(attributes).into_iter().fold(var_thing, |var_thing, has| var_thing.constrain_has(has));
     }
     var_thing
 }
@@ -585,9 +535,7 @@ fn visit_variable_relation(tree: SyntaxTree) -> ThingVariable {
         relation = relation.constrain_isa(get_isa_constraint(isa, type_));
     }
     if let Some(attributes) = children.consume_if_matches(Rule::attributes) {
-        relation = visit_attributes(attributes)
-            .into_iter()
-            .fold(relation, |relation, has| relation.constrain_has(has));
+        relation = visit_attributes(attributes).into_iter().fold(relation, |relation, has| relation.constrain_has(has));
     }
 
     relation
@@ -606,9 +554,8 @@ fn visit_variable_attribute(tree: SyntaxTree) -> ThingVariable {
         attribute = attribute.constrain_isa(get_isa_constraint(isa, type_));
     }
     if let Some(attributes) = children.consume_if_matches(Rule::attributes) {
-        attribute = visit_attributes(attributes)
-            .into_iter()
-            .fold(attribute, |attribute, has| attribute.constrain_has(has));
+        attribute =
+            visit_attributes(attributes).into_iter().fold(attribute, |attribute, has| attribute.constrain_has(has));
     }
 
     attribute
@@ -629,13 +576,10 @@ fn visit_attribute(tree: SyntaxTree) -> HasConstraint {
         Some(Rule::label) => {
             let label = children.consume_expected(Rule::label).as_str().to_owned();
             match children.peek_rule() {
-                Some(Rule::VAR_) => {
-                    HasConstraint::from((label, get_var(children.consume_expected(Rule::VAR_))))
+                Some(Rule::VAR_) => HasConstraint::from((label, get_var(children.consume_expected(Rule::VAR_)))),
+                Some(Rule::predicate) => {
+                    HasConstraint::new((label, visit_predicate(children.consume_expected(Rule::predicate))))
                 }
-                Some(Rule::predicate) => HasConstraint::new((
-                    label,
-                    visit_predicate(children.consume_expected(Rule::predicate)),
-                )),
                 _ => unreachable!("{}", TypeQLError::IllegalGrammar(children.to_string())),
             }
         }
@@ -647,10 +591,9 @@ fn visit_attribute(tree: SyntaxTree) -> HasConstraint {
 fn visit_predicate(tree: SyntaxTree) -> ValueConstraint {
     let mut children = tree.into_children();
     match children.peek_rule() {
-        Some(Rule::value) => ValueConstraint::new(
-            token::Predicate::Eq,
-            visit_value(children.consume_expected(Rule::value)),
-        ),
+        Some(Rule::value) => {
+            ValueConstraint::new(token::Predicate::Eq, visit_value(children.consume_expected(Rule::value)))
+        }
         Some(Rule::predicate_equality) => ValueConstraint::new(
             token::Predicate::from(children.consume_expected(Rule::predicate_equality).as_str()),
             {
@@ -663,19 +606,13 @@ fn visit_predicate(tree: SyntaxTree) -> ValueConstraint {
             },
         ),
         Some(Rule::predicate_substring) => {
-            let predicate = token::Predicate::from(
-                children.consume_expected(Rule::predicate_substring).as_str(),
-            );
+            let predicate = token::Predicate::from(children.consume_expected(Rule::predicate_substring).as_str());
             ValueConstraint::new(
                 predicate,
                 {
                     match predicate {
-                        token::Predicate::Like => {
-                            get_regex(children.consume_expected(Rule::STRING_))
-                        }
-                        token::Predicate::Contains => {
-                            get_string(children.consume_expected(Rule::STRING_))
-                        }
+                        token::Predicate::Like => get_regex(children.consume_expected(Rule::STRING_)),
+                        token::Predicate::Contains => get_string(children.consume_expected(Rule::STRING_)),
                         _ => unreachable!("{}", TypeQLError::IllegalGrammar(children.to_string())),
                     }
                 }
@@ -688,15 +625,9 @@ fn visit_predicate(tree: SyntaxTree) -> ValueConstraint {
 
 fn visit_schema_rule(tree: SyntaxTree) -> RuleDefinition {
     let mut children = tree.into_children();
-    RuleDeclaration::new(Label::from(
-        children.skip_expected(Rule::RULE).consume_expected(Rule::label).as_str(),
-    ))
-    .when(Conjunction::new(visit_patterns(
-        children.skip_expected(Rule::WHEN).consume_expected(Rule::patterns),
-    )))
-    .then(visit_variable_thing_any(
-        children.skip_expected(Rule::THEN).consume_expected(Rule::variable_thing_any),
-    ))
+    RuleDeclaration::new(Label::from(children.skip_expected(Rule::RULE).consume_expected(Rule::label).as_str()))
+        .when(Conjunction::new(visit_patterns(children.skip_expected(Rule::WHEN).consume_expected(Rule::patterns))))
+        .then(visit_variable_thing_any(children.skip_expected(Rule::THEN).consume_expected(Rule::variable_thing_any)))
 }
 
 fn visit_schema_rule_declaration(tree: SyntaxTree) -> RuleDeclaration {

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -498,7 +498,7 @@ fn visit_variable_type(tree: SyntaxTree) -> TypeVariable {
                     let type_ = visit_type_scoped(constraint.consume_expected(Rule::type_scoped));
                     let overridden = constraint
                         .consume_if_matches(Rule::AS)
-                        .and_then(|_| Some(visit_type(constraint.consume_expected(Rule::type_))));
+                        .map(|_| visit_type(constraint.consume_expected(Rule::type_)));
                     var_type.constrain_plays(PlaysConstraint::from((type_, overridden)))
                 }
                 Rule::REGEX => {
@@ -508,7 +508,7 @@ fn visit_variable_type(tree: SyntaxTree) -> TypeVariable {
                     let type_ = visit_type(constraint.consume_expected(Rule::type_));
                     let overridden = constraint
                         .consume_if_matches(Rule::AS)
-                        .and_then(|_| Some(visit_type(constraint.consume_expected(Rule::type_))));
+                        .map(|_| visit_type(constraint.consume_expected(Rule::type_)));
                     var_type.constrain_relates(RelatesConstraint::from((type_, overridden)))
                 }
                 Rule::SUB_ => var_type.constrain_sub(SubConstraint::from((

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -23,8 +23,6 @@
 #[cfg(test)]
 mod test;
 
-use std::collections::HashSet;
-
 use chrono::{NaiveDate, NaiveDateTime};
 use pest::Parser;
 use pest_derive::Parser;
@@ -495,7 +493,7 @@ fn visit_variable_type(tree: SyntaxTree) -> TypeVariable {
     var_type
 }
 
-fn visit_annotations_owns(tree: SyntaxTree) -> HashSet<Annotation> {
+fn visit_annotations_owns(tree: SyntaxTree) -> Vec<Annotation> {
     tree.into_children()
         .map(|annotation| match annotation.as_rule() {
             Rule::ANNOTATION_KEY => Annotation::Key,

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -138,11 +138,7 @@ $t != "Apocalypse Now";"#;
     let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(
         var("x").isa("movie").has(("title", var("t"))),
-        or!(
-            var("t").eq("Apocalypse Now"),
-            and!(var("t").lt("Juno"), var("t").gt("Godfather")),
-            var("t").eq("Spy"),
-        ),
+        or!(var("t").eq("Apocalypse Now"), and!(var("t").lt("Juno"), var("t").gt("Godfather")), var("t").eq("Spy"),),
         var("t").neq("Apocalypse Now"),
     );
 
@@ -165,10 +161,7 @@ $x isa movie,
     let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(
         var("x").isa("movie").has(("title", var("t"))),
-        or!(
-            and!(var("t").lte("Juno"), var("t").gte("Godfather"), var("t").neq("Heat")),
-            var("t").eq("The Muppets"),
-        ),
+        or!(and!(var("t").lte("Juno"), var("t").gte("Godfather"), var("t").neq("Heat")), var("t").eq("The Muppets"),),
     );
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -203,11 +196,7 @@ $y >= $z;
 $z 18 isa age;"#;
 
     let parsed = parse_query(query).unwrap().into_match();
-    let expected = typeql_match!(
-        var("x").has(("age", var("y"))),
-        var("y").gte(var("z")),
-        var("z").eq(18).isa("age"),
-    );
+    let expected = typeql_match!(var("x").has(("age", var("y"))), var("y").gte(var("z")), var("z").eq(18).isa("age"),);
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -307,10 +296,7 @@ $x has release-date +12345-12-25T00:00;"#;
     let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").has((
         "release-date",
-        NaiveDateTime::new(
-            NaiveDate::from_ymd_opt(12345, 12, 25).unwrap(),
-            NaiveTime::from_hms_opt(0, 0, 0).unwrap()
-        ),
+        NaiveDateTime::new(NaiveDate::from_ymd_opt(12345, 12, 25).unwrap(), NaiveTime::from_hms_opt(0, 0, 0).unwrap()),
     )));
 
     assert_valid_eq_repr!(expected, parsed, query);
@@ -324,10 +310,7 @@ $x has release-date 0867-01-01T00:00;"#;
     let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").has((
         "release-date",
-        NaiveDateTime::new(
-            NaiveDate::from_ymd_opt(867, 1, 1).unwrap(),
-            NaiveTime::from_hms_opt(0, 0, 0).unwrap()
-        ),
+        NaiveDateTime::new(NaiveDate::from_ymd_opt(867, 1, 1).unwrap(), NaiveTime::from_hms_opt(0, 0, 0).unwrap()),
     )));
 
     assert_valid_eq_repr!(expected, parsed, query);
@@ -341,10 +324,7 @@ $x has release-date -3200-01-01T00:00;"#;
     let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").has((
         "release-date",
-        NaiveDateTime::new(
-            NaiveDate::from_ymd_opt(-3200, 1, 1).unwrap(),
-            NaiveTime::from_hms_opt(0, 0, 0).unwrap()
-        ),
+        NaiveDateTime::new(NaiveDate::from_ymd_opt(-3200, 1, 1).unwrap(), NaiveTime::from_hms_opt(0, 0, 0).unwrap()),
     )));
 
     assert_valid_eq_repr!(expected, parsed, query);
@@ -442,8 +422,7 @@ $x isa movie,
 sort $r desc;"#;
 
     let parsed = parse_query(query).unwrap().into_match();
-    let expected =
-        typeql_match!(var("x").isa("movie").has(("rating", var("r")))).sort([("r", Desc)]);
+    let expected = typeql_match!(var("x").isa("movie").has(("rating", var("r")))).sort([("r", Desc)]);
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -456,8 +435,7 @@ $x isa movie,
 sort $r; limit 10;"#;
 
     let parsed = parse_query(query).unwrap().into_match();
-    let expected =
-        typeql_match!(var("x").isa("movie").has(("rating", var("r")))).sort("r").limit(10);
+    let expected = typeql_match!(var("x").isa("movie").has(("rating", var("r")))).sort("r").limit(10);
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -470,10 +448,8 @@ $x isa movie,
 sort $r desc; offset 10; limit 10;"#;
 
     let parsed = parse_query(query).unwrap().into_match();
-    let expected = typeql_match!(var("x").isa("movie").has(("rating", var("r"))))
-        .sort([("r", Desc)])
-        .offset(10)
-        .limit(10);
+    let expected =
+        typeql_match!(var("x").isa("movie").has(("rating", var("r")))).sort([("r", Desc)]).offset(10).limit(10);
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -616,8 +592,7 @@ get $x, $y;
 group $x; count;"#;
 
     let parsed = parse_query(query).unwrap().into_group_aggregate();
-    let expected =
-        typeql_match!(rel("x").rel("y").isa("friendship")).get(["x", "y"]).group("x").count();
+    let expected = typeql_match!(rel("x").rel("y").isa("friendship")).get(["x", "y"]).group("x").count();
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -643,9 +618,7 @@ group $x; max $z;"#;
 
     let parsed = parse_query(query).unwrap().into_group_aggregate();
     let expected =
-        typeql_match!(rel("x").rel("y").isa("friendship"), var("y").has(("age", var("z"))))
-            .group("x")
-            .max("z");
+        typeql_match!(rel("x").rel("y").isa("friendship"), var("y").has(("age", var("z")))).group("x").max("z");
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -659,11 +632,10 @@ get $x, $y, $z;
 group $x; max $z;"#;
 
     let parsed = parse_query(query).unwrap().into_group_aggregate();
-    let expected =
-        typeql_match!(rel("x").rel("y").isa("friendship"), var("y").has(("age", var("z"))))
-            .get(["x", "y", "z"])
-            .group("x")
-            .max("z");
+    let expected = typeql_match!(rel("x").rel("y").isa("friendship"), var("y").has(("age", var("z"))))
+        .get(["x", "y", "z"])
+        .group("x")
+        .max("z");
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -704,9 +676,8 @@ $x isa movie;
 $y isa movie;"#;
 
     let parsed = parse_query(query).unwrap().into_delete();
-    let expected =
-        typeql_match!(var("x").isa("movie").has(("title", "The Title")), var("y").isa("movie"))
-            .delete([var("x").isa("movie"), var("y").isa("movie")]);
+    let expected = typeql_match!(var("x").isa("movie").has(("title", "The Title")), var("y").isa("movie"))
+        .delete([var("x").isa("movie"), var("y").isa("movie")]);
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -747,10 +718,9 @@ insert
 $x has age 25;"#;
 
     let parsed = parse_query(query).unwrap().into_update();
-    let expected =
-        typeql_match!(var("x").isa("person").has(("name", "alice")).has(("age", var("a"))))
-            .delete(var("x").has(var("a")))
-            .insert(var("x").has(("age", 25)));
+    let expected = typeql_match!(var("x").isa("person").has(("name", "alice")).has(("age", var("a"))))
+        .delete(var("x").has(var("a")))
+        .insert(var("x").has(("age", 25)));
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -772,10 +742,7 @@ fatherhood sub parenthood,
         type_("parent").sub("role"),
         type_("child").sub("role"),
         type_("parenthood").sub("relation").relates("parent").relates("child"),
-        type_("fatherhood")
-            .sub("parenthood")
-            .relates(("father", "parent"))
-            .relates(("son", "child"))
+        type_("fatherhood").sub("parenthood").relates(("father", "parent")).relates(("son", "child"))
     );
 
     assert_valid_eq_repr!(expected, parsed, query);
@@ -789,10 +756,7 @@ $f sub parenthood,
     relates son as child;"#;
 
     let parsed = parse_query(query).unwrap().into_match();
-    let expected = typeql_match!(var("f")
-        .sub("parenthood")
-        .relates(("father", "parent"))
-        .relates(("son", "child")));
+    let expected = typeql_match!(var("f").sub("parenthood").relates(("father", "parent")).relates(("son", "child")));
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -945,10 +909,8 @@ abstract-type sub entity,
     abstract;"#;
 
     let parsed = parse_query(query).unwrap().into_define();
-    let expected = typeql_define!(
-        type_("concrete-type").sub("entity"),
-        type_("abstract-type").sub("entity").abstract_()
-    );
+    let expected =
+        typeql_define!(type_("concrete-type").sub("entity"), type_("abstract-type").sub("entity").abstract_());
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -1176,8 +1138,7 @@ $_ has title "Godfather",
     has tmdb-vote-count $x;"#;
 
     let parsed = parse_query(query).unwrap().into_match();
-    let expected =
-        typeql_match!(var(()).has(("title", "Godfather")).has(("tmdb-vote-count", var("x"))));
+    let expected = typeql_match!(var(()).has(("title", "Godfather")).has(("tmdb-vote-count", var("x"))));
     assert_valid_eq_repr!(expected, parsed, query);
 }
 
@@ -1215,8 +1176,7 @@ fn test_parse_empty_string() {
 #[test]
 fn test_parse_list_one_match() {
     let queries = "match $y isa movie;";
-    let parsed =
-        parse_queries(queries).unwrap().map(|q| q.unwrap().into_match()).collect::<Vec<_>>();
+    let parsed = parse_queries(queries).unwrap().map(|q| q.unwrap().into_match()).collect::<Vec<_>>();
     let expected = vec![typeql_match!(var("y").isa("movie"))];
     assert_eq!(parsed, expected);
 }
@@ -1224,8 +1184,7 @@ fn test_parse_list_one_match() {
 #[test]
 fn test_parse_list_one_insert() {
     let queries = "insert $x isa movie;";
-    let parsed =
-        parse_queries(queries).unwrap().map(|q| q.unwrap().into_insert()).collect::<Vec<_>>();
+    let parsed = parse_queries(queries).unwrap().map(|q| q.unwrap().into_insert()).collect::<Vec<_>>();
     let expected = vec![typeql_insert!(var("x").isa("movie"))];
     assert_eq!(parsed, expected);
 }
@@ -1233,8 +1192,7 @@ fn test_parse_list_one_insert() {
 #[test]
 fn test_parse_list_one_insert_with_whitespace_prefix() {
     let queries = " insert $x isa movie;";
-    let parsed =
-        parse_queries(queries).unwrap().map(|q| q.unwrap().into_insert()).collect::<Vec<_>>();
+    let parsed = parse_queries(queries).unwrap().map(|q| q.unwrap().into_insert()).collect::<Vec<_>>();
     let expected = vec![typeql_insert!(var("x").isa("movie"))];
     assert_eq!(parsed, expected);
 }
@@ -1243,8 +1201,7 @@ fn test_parse_list_one_insert_with_whitespace_prefix() {
 fn test_parse_list_one_insert_with_prefix_comment() {
     let queries = r#"#hola
 insert $x isa movie;"#;
-    let parsed =
-        parse_queries(queries).unwrap().map(|q| q.unwrap().into_insert()).collect::<Vec<_>>();
+    let parsed = parse_queries(queries).unwrap().map(|q| q.unwrap().into_insert()).collect::<Vec<_>>();
     let expected = vec![typeql_insert!(var("x").isa("movie"))];
     assert_eq!(parsed, expected);
 }
@@ -1253,10 +1210,7 @@ insert $x isa movie;"#;
 fn test_parse_list() {
     let queries = "insert $x isa movie; match $y isa movie;";
     let parsed = parse_queries(queries).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
-    let expected = vec![
-        typeql_insert!(var("x").isa("movie")).into(),
-        typeql_match!(var("y").isa("movie")).into(),
-    ];
+    let expected = vec![typeql_insert!(var("x").isa("movie")).into(), typeql_match!(var("y").isa("movie")).into()];
     assert_eq!(parsed, expected);
 }
 

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -271,7 +271,10 @@ $x has release-date < 1986-03-03T00:00,
     let expected = typeql_match!(var("x")
         .has((
             "release-date",
-            lt(NaiveDateTime::new(NaiveDate::from_ymd(1986, 3, 3), NaiveTime::from_hms(0, 0, 0)))
+            lt(NaiveDateTime::new(
+                NaiveDate::from_ymd_opt(1986, 3, 3).unwrap(),
+                NaiveTime::from_hms_opt(0, 0, 0).unwrap()
+            ))
         ))
         .has(("tmdb-vote-count", 100))
         .has(("tmdb-vote-average", lte(9.0))));
@@ -287,7 +290,10 @@ $x has release-date 1000-11-12T13:14:15;"#;
     let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").has((
         "release-date",
-        NaiveDateTime::new(NaiveDate::from_ymd(1000, 11, 12), NaiveTime::from_hms(13, 14, 15)),
+        NaiveDateTime::new(
+            NaiveDate::from_ymd_opt(1000, 11, 12).unwrap(),
+            NaiveTime::from_hms_opt(13, 14, 15).unwrap()
+        ),
     )));
 
     assert_valid_eq_repr!(expected, parsed, query);
@@ -301,7 +307,10 @@ $x has release-date +12345-12-25T00:00;"#;
     let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").has((
         "release-date",
-        NaiveDateTime::new(NaiveDate::from_ymd(12345, 12, 25), NaiveTime::from_hms(0, 0, 0)),
+        NaiveDateTime::new(
+            NaiveDate::from_ymd_opt(12345, 12, 25).unwrap(),
+            NaiveTime::from_hms_opt(0, 0, 0).unwrap()
+        ),
     )));
 
     assert_valid_eq_repr!(expected, parsed, query);
@@ -315,7 +324,10 @@ $x has release-date 0867-01-01T00:00;"#;
     let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").has((
         "release-date",
-        NaiveDateTime::new(NaiveDate::from_ymd(867, 1, 1), NaiveTime::from_hms(0, 0, 0)),
+        NaiveDateTime::new(
+            NaiveDate::from_ymd_opt(867, 1, 1).unwrap(),
+            NaiveTime::from_hms_opt(0, 0, 0).unwrap()
+        ),
     )));
 
     assert_valid_eq_repr!(expected, parsed, query);
@@ -329,7 +341,10 @@ $x has release-date -3200-01-01T00:00;"#;
     let parsed = parse_query(query).unwrap().into_match();
     let expected = typeql_match!(var("x").has((
         "release-date",
-        NaiveDateTime::new(NaiveDate::from_ymd(-3200, 1, 1), NaiveTime::from_hms(0, 0, 0)),
+        NaiveDateTime::new(
+            NaiveDate::from_ymd_opt(-3200, 1, 1).unwrap(),
+            NaiveTime::from_hms_opt(0, 0, 0).unwrap()
+        ),
     )));
 
     assert_valid_eq_repr!(expected, parsed, query);
@@ -344,8 +359,8 @@ $x has release-date 1000-11-12T13:14:15.123;"#;
     let expected = typeql_match!(var("x").has((
         "release-date",
         NaiveDateTime::new(
-            NaiveDate::from_ymd(1000, 11, 12),
-            NaiveTime::from_hms_milli(13, 14, 15, 123),
+            NaiveDate::from_ymd_opt(1000, 11, 12).unwrap(),
+            NaiveTime::from_hms_milli_opt(13, 14, 15, 123).unwrap(),
         ),
     )));
 
@@ -361,8 +376,8 @@ $x has release-date 1000-11-12T13:14:15.1;"#;
     let expected = typeql_match!(var("x").has((
         "release-date",
         NaiveDateTime::new(
-            NaiveDate::from_ymd(1000, 11, 12),
-            NaiveTime::from_hms_milli(13, 14, 15, 100),
+            NaiveDate::from_ymd_opt(1000, 11, 12).unwrap(),
+            NaiveTime::from_hms_milli_opt(13, 14, 15, 100).unwrap(),
         ),
     )));
 
@@ -386,8 +401,8 @@ fn when_parsing_date_error_when_handling_overly_precise_nanos() {
     let validated = typeql_match!(var("x").has((
         "release-date",
         NaiveDateTime::new(
-            NaiveDate::from_ymd(1000, 11, 12),
-            NaiveTime::from_hms_nano(13, 14, 15, 123450000),
+            NaiveDate::from_ymd_opt(1000, 11, 12).unwrap(),
+            NaiveTime::from_hms_nano_opt(13, 14, 15, 123450000).unwrap(),
         ),
     )))
     .validated();

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -1005,8 +1005,7 @@ fn test_escape_string() {
     let query = format!(
         r#"insert
 $_ isa movie,
-    has title "{}";"#,
-        input
+    has title "{input}";"#
     );
 
     let parsed = parse_query(&query).unwrap().into_insert();
@@ -1396,8 +1395,7 @@ fn test_iid_constraint() {
     let iid = "0x0123456789abcdefdeadbeef";
     let query = format!(
         r#"match
-$x iid {};"#,
-        iid
+$x iid {iid};"#
     );
 
     let parsed = parse_query(&query).unwrap().into_match();
@@ -1410,8 +1408,7 @@ fn when_parsing_invalid_iid_throw() {
     let iid = "invalid";
     let query = format!(
         r#"match
-$x iid {};"#,
-        iid
+$x iid {iid};"#
     );
 
     let parsed = parse_query(&query);

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -1062,7 +1062,7 @@ rule a-rule: when {
     $x has is_interesting true;
 };"#;
 
-    let parsed = parse_query(&query).unwrap().into_define();
+    let parsed = parse_query(query).unwrap().into_define();
     let expected = typeql_define!(rule("a-rule")
         .when(and!(
             var("x").isa("person"),

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -33,8 +33,8 @@ use crate::{
     },
     gte, lt, lte, not, or, parse_pattern, parse_queries, parse_query,
     pattern::{
-        ConceptVariableBuilder, Conjunction, Disjunction, RelationVariableBuilder,
-        ThingVariableBuilder, TypeVariableBuilder, KEY,
+        Annotation::Key, ConceptVariableBuilder, Conjunction, Disjunction, RelationVariableBuilder,
+        ThingVariableBuilder, TypeVariableBuilder,
     },
     query::{AggregateQueryBuilder, TypeQLDefine, TypeQLInsert, TypeQLMatch, TypeQLUndefine},
     rel, rule, type_, typeql_insert, typeql_match, var, Query,
@@ -1204,7 +1204,7 @@ $x owns name @key;
 get $x;"#;
 
     let parsed = parse_query(query).unwrap().into_match();
-    let expected = typeql_match!(var("x").owns(("name", KEY))).get(["x"]);
+    let expected = typeql_match!(var("x").owns(("name", Key))).get(["x"]);
     assert_valid_eq_repr!(expected, parsed, query);
 }
 

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -103,7 +103,7 @@ variable_concept = { VAR_ ~ IS ~ VAR_ }
 
 variable_type = { type_any ~ type_constraint ~ ( "," ~ type_constraint )* }
 type_constraint = { ABSTRACT
-                  | OWNS ~ type_ ~ ( AS ~ type_)? ~ ( IS_KEY )?
+                  | OWNS ~ type_ ~ ( AS ~ type_)? ~ annotations_owns
                   | PLAYS ~ type_scoped ~ ( AS ~ type_)?
                   | REGEX ~ STRING_
                   | RELATES ~ type_ ~ ( AS ~ type_)?
@@ -111,6 +111,8 @@ type_constraint = { ABSTRACT
                   | TYPE ~ label_any
                   | VALUE ~ value_type
                   }
+
+annotations_owns = { ( ANNOTATION_KEY )? ~ ( ANNOTATION_UNIQUE )? }
 
 // THING VARIABLES =============================================================
 
@@ -220,13 +222,17 @@ SUB_ = ${ SUBX | SUB }
 SUB = @{ "sub" ~ WB }
 SUBX = @{ "sub!" ~ WB }
 OWNS = @{ "owns" ~ WB }
-IS_KEY = @{ "@key" ~ WB }
 REGEX = @{ "regex" ~ WB }
 AS = @{ "as" ~ WB }
 PLAYS = @{ "plays" ~ WB }
 RELATES = @{ "relates" ~ WB }
 WHEN = @{ "when" ~ WB }
 THEN = @{ "then" ~ WB }
+
+// TYPE ANNOTATIONS
+
+ANNOTATION_KEY = @{ "@key" ~ WB }
+ANNOTATION_UNIQUE = @{ "@unique" ~ WB}
 
 // THING VARIABLE CONSTRAINT KEYWORDS
 

--- a/rust/pattern/conjunction.rs
+++ b/rust/pattern/conjunction.rs
@@ -52,16 +52,13 @@ impl Conjunction {
     }
 
     pub fn references(&self) -> Box<dyn Iterator<Item = &Reference> + '_> {
-        Box::new(
-            self.patterns
-                .iter()
-                .filter(|p| matches!(p, Pattern::Variable(_) | Pattern::Conjunction(_)))
-                .flat_map(|p| match p {
-                    Pattern::Variable(v) => v.references(),
-                    Pattern::Conjunction(c) => c.references(),
-                    _ => unreachable!(),
-                }),
-        )
+        Box::new(self.patterns.iter().filter(|p| matches!(p, Pattern::Variable(_) | Pattern::Conjunction(_))).flat_map(
+            |p| match p {
+                Pattern::Variable(v) => v.references(),
+                Pattern::Conjunction(c) => c.references(),
+                _ => unreachable!(),
+            },
+        ))
     }
 
     pub fn has_named_variables(&self) -> bool {
@@ -78,11 +75,7 @@ impl Conjunction {
     }
 }
 
-fn expect_bounded(
-    names: &HashSet<Reference>,
-    bounds: &HashSet<Reference>,
-    conjunction: &Conjunction,
-) -> Result<()> {
+fn expect_bounded(names: &HashSet<Reference>, bounds: &HashSet<Reference>, conjunction: &Conjunction) -> Result<()> {
     if bounds.is_disjoint(names) {
         Err(TypeQLError::MatchHasUnboundedNestedPattern(conjunction.clone().into()))?;
     }
@@ -129,12 +122,8 @@ impl Normalisable for Conjunction {
                 .into_iter()
                 .multi_cartesian_product()
                 .map(|v| {
-                    Conjunction::new(
-                        v.into_iter()
-                            .flat_map(|c| c.into_conjunction().patterns.into_iter())
-                            .collect(),
-                    )
-                    .into()
+                    Conjunction::new(v.into_iter().flat_map(|c| c.into_conjunction().patterns.into_iter()).collect())
+                        .into()
                 })
                 .collect(),
         )
@@ -145,9 +134,7 @@ impl Normalisable for Conjunction {
 impl fmt::Display for Conjunction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("{\n")?;
-        f.write_str(
-            &self.patterns.iter().map(|p| indent(&p.to_string()) + ";\n").collect::<String>(),
-        )?;
+        f.write_str(&self.patterns.iter().map(|p| indent(&p.to_string()) + ";\n").collect::<String>())?;
         f.write_str("}")
     }
 }

--- a/rust/pattern/constraint/mod.rs
+++ b/rust/pattern/constraint/mod.rs
@@ -26,12 +26,11 @@ mod type_;
 
 pub use concept::IsConstraint;
 pub use thing::{
-    HasConstraint, IIDConstraint, IsaConstraint, RelationConstraint, RolePlayerConstraint, Value,
-    ValueConstraint,
+    HasConstraint, IIDConstraint, IsaConstraint, RelationConstraint, RolePlayerConstraint, Value, ValueConstraint,
 };
 pub use type_::{
-    AbstractConstraint, Annotation, LabelConstraint, OwnsConstraint, PlaysConstraint,
-    RegexConstraint, RelatesConstraint, SubConstraint, ValueTypeConstraint,
+    AbstractConstraint, Annotation, LabelConstraint, OwnsConstraint, PlaysConstraint, RegexConstraint,
+    RelatesConstraint, SubConstraint, ValueTypeConstraint,
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/rust/pattern/constraint/mod.rs
+++ b/rust/pattern/constraint/mod.rs
@@ -30,8 +30,8 @@ pub use thing::{
     ValueConstraint,
 };
 pub use type_::{
-    AbstractConstraint, IsKeyAttribute, LabelConstraint, OwnsConstraint, PlaysConstraint,
-    RegexConstraint, RelatesConstraint, SubConstraint, ValueTypeConstraint, KEY,
+    AbstractConstraint, Annotation, LabelConstraint, OwnsConstraint, PlaysConstraint,
+    RegexConstraint, RelatesConstraint, SubConstraint, ValueTypeConstraint,
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/rust/pattern/constraint/thing/has.rs
+++ b/rust/pattern/constraint/thing/has.rs
@@ -25,8 +25,8 @@ use std::{fmt, iter};
 use crate::{
     common::{error::collect_err, token, validatable::Validatable, Result},
     pattern::{
-        Reference, ThingConstrainable, ThingVariable, TypeVariable, TypeVariableBuilder,
-        UnboundVariable, Value, ValueConstraint,
+        Reference, ThingConstrainable, ThingVariable, TypeVariable, TypeVariableBuilder, UnboundVariable, Value,
+        ValueConstraint,
     },
 };
 
@@ -38,18 +38,13 @@ pub struct HasConstraint {
 
 impl HasConstraint {
     pub fn references(&self) -> Box<dyn Iterator<Item = &Reference> + '_> {
-        Box::new(
-            (self.type_.iter().map(|t| &t.reference)).chain(iter::once(&self.attribute.reference)),
-        )
+        Box::new((self.type_.iter().map(|t| &t.reference)).chain(iter::once(&self.attribute.reference)))
     }
 }
 
 impl Validatable for HasConstraint {
     fn validate(&self) -> Result<()> {
-        collect_err(
-            &mut iter::once(self.attribute.validate())
-                .chain(self.type_.iter().map(Validatable::validate)),
-        )
+        collect_err(&mut iter::once(self.attribute.validate()).chain(self.type_.iter().map(Validatable::validate)))
     }
 }
 
@@ -62,14 +57,12 @@ impl From<UnboundVariable> for HasConstraint {
 impl<S: Into<String>, T: Into<Value>> From<(S, T)> for HasConstraint {
     fn from((type_name, value): (S, T)) -> Self {
         match value.into() {
-            Value::Variable(variable) => HasConstraint {
-                type_: Some(UnboundVariable::hidden().type_(type_name.into())),
-                attribute: *variable,
-            },
+            Value::Variable(variable) => {
+                HasConstraint { type_: Some(UnboundVariable::hidden().type_(type_name.into())), attribute: *variable }
+            }
             value => HasConstraint {
                 type_: Some(UnboundVariable::hidden().type_(type_name.into())),
-                attribute: UnboundVariable::hidden()
-                    .constrain_value(ValueConstraint::new(token::Predicate::Eq, value)),
+                attribute: UnboundVariable::hidden().constrain_value(ValueConstraint::new(token::Predicate::Eq, value)),
             },
         }
     }

--- a/rust/pattern/constraint/thing/relation.rs
+++ b/rust/pattern/constraint/thing/relation.rs
@@ -96,18 +96,13 @@ impl RolePlayerConstraint {
     }
 
     pub fn references(&self) -> Box<dyn Iterator<Item = &Reference> + '_> {
-        Box::new(
-            (self.role_type.iter().map(|r| &r.reference)).chain(iter::once(&self.player.reference)),
-        )
+        Box::new((self.role_type.iter().map(|r| &r.reference)).chain(iter::once(&self.player.reference)))
     }
 }
 
 impl Validatable for RolePlayerConstraint {
     fn validate(&self) -> Result<()> {
-        collect_err(
-            &mut (self.role_type.iter().map(Validatable::validate))
-                .chain(iter::once(self.player.validate())),
-        )
+        collect_err(&mut (self.role_type.iter().map(Validatable::validate)).chain(iter::once(self.player.validate())))
     }
 }
 

--- a/rust/pattern/constraint/thing/value.rs
+++ b/rust/pattern/constraint/thing/value.rs
@@ -108,7 +108,7 @@ impl Validatable for Value {
         match &self {
             Self::DateTime(date_time) => {
                 if date_time.nanosecond() % 1000000 > 0 {
-                    Err(TypeQLError::InvalidConstraintDatetimePrecision(date_time.clone()))?
+                    Err(TypeQLError::InvalidConstraintDatetimePrecision(*date_time))?
                 }
                 Ok(())
             }

--- a/rust/pattern/constraint/thing/value.rs
+++ b/rust/pattern/constraint/thing/value.rs
@@ -58,19 +58,13 @@ impl ValueConstraint {
 impl Validatable for ValueConstraint {
     fn validate(&self) -> Result<()> {
         collect_err(
-            &mut [
-                expect_string_value_with_substring_predicate(self.predicate, &self.value),
-                self.value.validate(),
-            ]
-            .into_iter(),
+            &mut [expect_string_value_with_substring_predicate(self.predicate, &self.value), self.value.validate()]
+                .into_iter(),
         )
     }
 }
 
-fn expect_string_value_with_substring_predicate(
-    predicate: token::Predicate,
-    value: &Value,
-) -> Result<()> {
+fn expect_string_value_with_substring_predicate(predicate: token::Predicate, value: &Value) -> Result<()> {
     if predicate.is_substring() && !matches!(value, Value::String(_)) {
         Err(TypeQLError::InvalidConstraintPredicate(predicate, value.clone()))?
     }
@@ -82,9 +76,7 @@ impl fmt::Display for ValueConstraint {
         if self.predicate == token::Predicate::Like {
             assert!(matches!(self.value, Value::String(_)));
             write!(f, "{} {}", self.predicate, escape_regex(&self.value.to_string()))
-        } else if self.predicate == token::Predicate::Eq
-            && !matches!(self.value, Value::Variable(_))
-        {
+        } else if self.predicate == token::Predicate::Eq && !matches!(self.value, Value::Variable(_)) {
             write!(f, "{}", self.value)
         } else {
             write!(f, "{} {}", self.predicate, self.value)

--- a/rust/pattern/constraint/thing/value.rs
+++ b/rust/pattern/constraint/thing/value.rs
@@ -170,9 +170,9 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Value::*;
         match self {
-            Long(long) => write!(f, "{}", long),
+            Long(long) => write!(f, "{long}"),
             Double(double) => write!(f, "{}", format_double(*double)),
-            Boolean(boolean) => write!(f, "{}", boolean),
+            Boolean(boolean) => write!(f, "{boolean}"),
             String(string) => write!(f, "{}", quote(string)),
             DateTime(date_time) => write!(f, "{}", date_time::format(date_time)),
             Variable(var) => write!(f, "{}", var.reference),

--- a/rust/pattern/constraint/type_/mod.rs
+++ b/rust/pattern/constraint/type_/mod.rs
@@ -31,7 +31,7 @@ mod value_type;
 
 pub use abstract_::AbstractConstraint;
 pub use label::LabelConstraint;
-pub use owns::{IsKeyAttribute, OwnsConstraint, KEY};
+pub use owns::{Annotation, OwnsConstraint};
 pub use plays::PlaysConstraint;
 pub use relates::RelatesConstraint;
 pub use sub::SubConstraint;

--- a/rust/pattern/constraint/type_/owns.rs
+++ b/rust/pattern/constraint/type_/owns.rs
@@ -159,31 +159,31 @@ impl From<(TypeVariable, TypeVariable)> for OwnsConstraint {
 
 impl From<(&str, Annotation)> for OwnsConstraint {
     fn from((attribute_type, annotation): (&str, Annotation)) -> Self {
-        OwnsConstraint::from((Label::from(attribute_type), annotation))
+        OwnsConstraint::from((Label::from(attribute_type), [annotation]))
     }
 }
 
 impl From<(String, Annotation)> for OwnsConstraint {
     fn from((attribute_type, annotation): (String, Annotation)) -> Self {
-        OwnsConstraint::from((Label::from(attribute_type), annotation))
+        OwnsConstraint::from((Label::from(attribute_type), [annotation]))
     }
 }
 
 impl From<(Label, Annotation)> for OwnsConstraint {
     fn from((attribute_type, annotation): (Label, Annotation)) -> Self {
-        OwnsConstraint::from((UnboundVariable::hidden().type_(attribute_type), annotation))
+        OwnsConstraint::from((UnboundVariable::hidden().type_(attribute_type), [annotation]))
     }
 }
 
 impl From<(Type, Annotation)> for OwnsConstraint {
     fn from((attribute_type, annotation): (Type, Annotation)) -> Self {
-        OwnsConstraint::from((attribute_type.into_type_variable(), annotation))
+        OwnsConstraint::from((attribute_type.into_type_variable(), [annotation]))
     }
 }
 
 impl From<(UnboundVariable, Annotation)> for OwnsConstraint {
     fn from((attribute_type, annotation): (UnboundVariable, Annotation)) -> Self {
-        OwnsConstraint::from((attribute_type.into_type(), annotation))
+        OwnsConstraint::from((attribute_type.into_type(), [annotation]))
     }
 }
 
@@ -200,7 +200,7 @@ impl From<(&str, &str, Annotation)> for OwnsConstraint {
         OwnsConstraint::from((
             Label::from(attribute_type),
             Label::from(overridden_attribute_type),
-            annotation,
+            [annotation],
         ))
     }
 }
@@ -212,7 +212,7 @@ impl From<(String, String, Annotation)> for OwnsConstraint {
         OwnsConstraint::from((
             Label::from(attribute_type),
             Label::from(overridden_attribute_type),
-            annotation,
+            [annotation],
         ))
     }
 }
@@ -224,7 +224,7 @@ impl From<(Label, Label, Annotation)> for OwnsConstraint {
         OwnsConstraint::from((
             UnboundVariable::hidden().type_(attribute_type),
             UnboundVariable::hidden().type_(overridden_attribute_type),
-            annotation,
+            [annotation],
         ))
     }
 }
@@ -236,7 +236,7 @@ impl From<(Type, Type, Annotation)> for OwnsConstraint {
         OwnsConstraint::from((
             attribute_type.into_type_variable(),
             overridden_attribute_type.into_type_variable(),
-            annotation,
+            [annotation],
         ))
     }
 }
@@ -252,7 +252,7 @@ impl From<(UnboundVariable, UnboundVariable, Annotation)> for OwnsConstraint {
         OwnsConstraint::from((
             attribute_type.into_type(),
             overridden_attribute_type.into_type(),
-            annotation,
+            [annotation],
         ))
     }
 }
@@ -266,6 +266,118 @@ impl From<(TypeVariable, TypeVariable, Annotation)> for OwnsConstraint {
         ),
     ) -> Self {
         OwnsConstraint::new(attribute_type, Some(overridden_attribute_type), [annotation].into())
+    }
+}
+
+impl<const N: usize> From<(&str, [Annotation; N])> for OwnsConstraint {
+    fn from((attribute_type, annotations): (&str, [Annotation; N])) -> Self {
+        OwnsConstraint::from((Label::from(attribute_type), annotations))
+    }
+}
+
+impl<const N: usize> From<(String, [Annotation; N])> for OwnsConstraint {
+    fn from((attribute_type, annotations): (String, [Annotation; N])) -> Self {
+        OwnsConstraint::from((Label::from(attribute_type), annotations))
+    }
+}
+
+impl<const N: usize> From<(Label, [Annotation; N])> for OwnsConstraint {
+    fn from((attribute_type, annotations): (Label, [Annotation; N])) -> Self {
+        OwnsConstraint::from((UnboundVariable::hidden().type_(attribute_type), annotations))
+    }
+}
+
+impl<const N: usize> From<(Type, [Annotation; N])> for OwnsConstraint {
+    fn from((attribute_type, annotations): (Type, [Annotation; N])) -> Self {
+        OwnsConstraint::from((attribute_type.into_type_variable(), annotations))
+    }
+}
+
+impl<const N: usize> From<(UnboundVariable, [Annotation; N])> for OwnsConstraint {
+    fn from((attribute_type, annotations): (UnboundVariable, [Annotation; N])) -> Self {
+        OwnsConstraint::from((attribute_type.into_type(), annotations))
+    }
+}
+
+impl<const N: usize> From<(TypeVariable, [Annotation; N])> for OwnsConstraint {
+    fn from((attribute_type, annotations): (TypeVariable, [Annotation; N])) -> Self {
+        OwnsConstraint::new(attribute_type, None, annotations.into())
+    }
+}
+
+impl<const N: usize> From<(&str, &str, [Annotation; N])> for OwnsConstraint {
+    fn from(
+        (attribute_type, overridden_attribute_type, annotations): (&str, &str, [Annotation; N]),
+    ) -> Self {
+        OwnsConstraint::from((
+            Label::from(attribute_type),
+            Label::from(overridden_attribute_type),
+            annotations,
+        ))
+    }
+}
+
+impl<const N: usize> From<(String, String, [Annotation; N])> for OwnsConstraint {
+    fn from(
+        (attribute_type, overridden_attribute_type, annotations): (String, String, [Annotation; N]),
+    ) -> Self {
+        OwnsConstraint::from((
+            Label::from(attribute_type),
+            Label::from(overridden_attribute_type),
+            annotations,
+        ))
+    }
+}
+
+impl<const N: usize> From<(Label, Label, [Annotation; N])> for OwnsConstraint {
+    fn from(
+        (attribute_type, overridden_attribute_type, annotations): (Label, Label, [Annotation; N]),
+    ) -> Self {
+        OwnsConstraint::from((
+            UnboundVariable::hidden().type_(attribute_type),
+            UnboundVariable::hidden().type_(overridden_attribute_type),
+            annotations,
+        ))
+    }
+}
+
+impl<const N: usize> From<(Type, Type, [Annotation; N])> for OwnsConstraint {
+    fn from(
+        (attribute_type, overridden_attribute_type, annotations): (Type, Type, [Annotation; N]),
+    ) -> Self {
+        OwnsConstraint::from((
+            attribute_type.into_type_variable(),
+            overridden_attribute_type.into_type_variable(),
+            annotations,
+        ))
+    }
+}
+
+impl<const N: usize> From<(UnboundVariable, UnboundVariable, [Annotation; N])> for OwnsConstraint {
+    fn from(
+        (attribute_type, overridden_attribute_type, annotations): (
+            UnboundVariable,
+            UnboundVariable,
+            [Annotation; N],
+        ),
+    ) -> Self {
+        OwnsConstraint::from((
+            attribute_type.into_type(),
+            overridden_attribute_type.into_type(),
+            annotations,
+        ))
+    }
+}
+
+impl<const N: usize> From<(TypeVariable, TypeVariable, [Annotation; N])> for OwnsConstraint {
+    fn from(
+        (attribute_type, overridden_attribute_type, annotations): (
+            TypeVariable,
+            TypeVariable,
+            [Annotation; N],
+        ),
+    ) -> Self {
+        OwnsConstraint::new(attribute_type, Some(overridden_attribute_type), annotations.into())
     }
 }
 

--- a/rust/pattern/constraint/type_/owns.rs
+++ b/rust/pattern/constraint/type_/owns.rs
@@ -136,17 +136,12 @@ impl From<(Label, Label)> for OwnsConstraint {
 
 impl From<(Type, Type)> for OwnsConstraint {
     fn from((attribute_type, overridden_attribute_type): (Type, Type)) -> Self {
-        OwnsConstraint::from((
-            attribute_type.into_type_variable(),
-            overridden_attribute_type.into_type_variable(),
-        ))
+        OwnsConstraint::from((attribute_type.into_type_variable(), overridden_attribute_type.into_type_variable()))
     }
 }
 
 impl From<(UnboundVariable, UnboundVariable)> for OwnsConstraint {
-    fn from(
-        (attribute_type, overridden_attribute_type): (UnboundVariable, UnboundVariable),
-    ) -> Self {
+    fn from((attribute_type, overridden_attribute_type): (UnboundVariable, UnboundVariable)) -> Self {
         OwnsConstraint::from((attribute_type.into_type(), overridden_attribute_type.into_type()))
     }
 }
@@ -194,33 +189,19 @@ impl From<(TypeVariable, Annotation)> for OwnsConstraint {
 }
 
 impl From<(&str, &str, Annotation)> for OwnsConstraint {
-    fn from(
-        (attribute_type, overridden_attribute_type, annotation): (&str, &str, Annotation),
-    ) -> Self {
-        OwnsConstraint::from((
-            Label::from(attribute_type),
-            Label::from(overridden_attribute_type),
-            [annotation],
-        ))
+    fn from((attribute_type, overridden_attribute_type, annotation): (&str, &str, Annotation)) -> Self {
+        OwnsConstraint::from((Label::from(attribute_type), Label::from(overridden_attribute_type), [annotation]))
     }
 }
 
 impl From<(String, String, Annotation)> for OwnsConstraint {
-    fn from(
-        (attribute_type, overridden_attribute_type, annotation): (String, String, Annotation),
-    ) -> Self {
-        OwnsConstraint::from((
-            Label::from(attribute_type),
-            Label::from(overridden_attribute_type),
-            [annotation],
-        ))
+    fn from((attribute_type, overridden_attribute_type, annotation): (String, String, Annotation)) -> Self {
+        OwnsConstraint::from((Label::from(attribute_type), Label::from(overridden_attribute_type), [annotation]))
     }
 }
 
 impl From<(Label, Label, Annotation)> for OwnsConstraint {
-    fn from(
-        (attribute_type, overridden_attribute_type, annotation): (Label, Label, Annotation),
-    ) -> Self {
+    fn from((attribute_type, overridden_attribute_type, annotation): (Label, Label, Annotation)) -> Self {
         OwnsConstraint::from((
             UnboundVariable::hidden().type_(attribute_type),
             UnboundVariable::hidden().type_(overridden_attribute_type),
@@ -230,9 +211,7 @@ impl From<(Label, Label, Annotation)> for OwnsConstraint {
 }
 
 impl From<(Type, Type, Annotation)> for OwnsConstraint {
-    fn from(
-        (attribute_type, overridden_attribute_type, annotation): (Type, Type, Annotation),
-    ) -> Self {
+    fn from((attribute_type, overridden_attribute_type, annotation): (Type, Type, Annotation)) -> Self {
         OwnsConstraint::from((
             attribute_type.into_type_variable(),
             overridden_attribute_type.into_type_variable(),
@@ -243,28 +222,14 @@ impl From<(Type, Type, Annotation)> for OwnsConstraint {
 
 impl From<(UnboundVariable, UnboundVariable, Annotation)> for OwnsConstraint {
     fn from(
-        (attribute_type, overridden_attribute_type, annotation): (
-            UnboundVariable,
-            UnboundVariable,
-            Annotation,
-        ),
+        (attribute_type, overridden_attribute_type, annotation): (UnboundVariable, UnboundVariable, Annotation),
     ) -> Self {
-        OwnsConstraint::from((
-            attribute_type.into_type(),
-            overridden_attribute_type.into_type(),
-            [annotation],
-        ))
+        OwnsConstraint::from((attribute_type.into_type(), overridden_attribute_type.into_type(), [annotation]))
     }
 }
 
 impl From<(TypeVariable, TypeVariable, Annotation)> for OwnsConstraint {
-    fn from(
-        (attribute_type, overridden_attribute_type, annotation): (
-            TypeVariable,
-            TypeVariable,
-            Annotation,
-        ),
-    ) -> Self {
+    fn from((attribute_type, overridden_attribute_type, annotation): (TypeVariable, TypeVariable, Annotation)) -> Self {
         OwnsConstraint::new(attribute_type, Some(overridden_attribute_type), [annotation].into())
     }
 }
@@ -306,33 +271,19 @@ impl<const N: usize> From<(TypeVariable, [Annotation; N])> for OwnsConstraint {
 }
 
 impl<const N: usize> From<(&str, &str, [Annotation; N])> for OwnsConstraint {
-    fn from(
-        (attribute_type, overridden_attribute_type, annotations): (&str, &str, [Annotation; N]),
-    ) -> Self {
-        OwnsConstraint::from((
-            Label::from(attribute_type),
-            Label::from(overridden_attribute_type),
-            annotations,
-        ))
+    fn from((attribute_type, overridden_attribute_type, annotations): (&str, &str, [Annotation; N])) -> Self {
+        OwnsConstraint::from((Label::from(attribute_type), Label::from(overridden_attribute_type), annotations))
     }
 }
 
 impl<const N: usize> From<(String, String, [Annotation; N])> for OwnsConstraint {
-    fn from(
-        (attribute_type, overridden_attribute_type, annotations): (String, String, [Annotation; N]),
-    ) -> Self {
-        OwnsConstraint::from((
-            Label::from(attribute_type),
-            Label::from(overridden_attribute_type),
-            annotations,
-        ))
+    fn from((attribute_type, overridden_attribute_type, annotations): (String, String, [Annotation; N])) -> Self {
+        OwnsConstraint::from((Label::from(attribute_type), Label::from(overridden_attribute_type), annotations))
     }
 }
 
 impl<const N: usize> From<(Label, Label, [Annotation; N])> for OwnsConstraint {
-    fn from(
-        (attribute_type, overridden_attribute_type, annotations): (Label, Label, [Annotation; N]),
-    ) -> Self {
+    fn from((attribute_type, overridden_attribute_type, annotations): (Label, Label, [Annotation; N])) -> Self {
         OwnsConstraint::from((
             UnboundVariable::hidden().type_(attribute_type),
             UnboundVariable::hidden().type_(overridden_attribute_type),
@@ -342,9 +293,7 @@ impl<const N: usize> From<(Label, Label, [Annotation; N])> for OwnsConstraint {
 }
 
 impl<const N: usize> From<(Type, Type, [Annotation; N])> for OwnsConstraint {
-    fn from(
-        (attribute_type, overridden_attribute_type, annotations): (Type, Type, [Annotation; N]),
-    ) -> Self {
+    fn from((attribute_type, overridden_attribute_type, annotations): (Type, Type, [Annotation; N])) -> Self {
         OwnsConstraint::from((
             attribute_type.into_type_variable(),
             overridden_attribute_type.into_type_variable(),
@@ -355,27 +304,15 @@ impl<const N: usize> From<(Type, Type, [Annotation; N])> for OwnsConstraint {
 
 impl<const N: usize> From<(UnboundVariable, UnboundVariable, [Annotation; N])> for OwnsConstraint {
     fn from(
-        (attribute_type, overridden_attribute_type, annotations): (
-            UnboundVariable,
-            UnboundVariable,
-            [Annotation; N],
-        ),
+        (attribute_type, overridden_attribute_type, annotations): (UnboundVariable, UnboundVariable, [Annotation; N]),
     ) -> Self {
-        OwnsConstraint::from((
-            attribute_type.into_type(),
-            overridden_attribute_type.into_type(),
-            annotations,
-        ))
+        OwnsConstraint::from((attribute_type.into_type(), overridden_attribute_type.into_type(), annotations))
     }
 }
 
 impl<const N: usize> From<(TypeVariable, TypeVariable, [Annotation; N])> for OwnsConstraint {
     fn from(
-        (attribute_type, overridden_attribute_type, annotations): (
-            TypeVariable,
-            TypeVariable,
-            [Annotation; N],
-        ),
+        (attribute_type, overridden_attribute_type, annotations): (TypeVariable, TypeVariable, [Annotation; N]),
     ) -> Self {
         OwnsConstraint::new(attribute_type, Some(overridden_attribute_type), annotations.into())
     }

--- a/rust/pattern/constraint/type_/owns.rs
+++ b/rust/pattern/constraint/type_/owns.rs
@@ -273,7 +273,7 @@ impl fmt::Display for OwnsConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", token::Constraint::Owns, self.attribute_type)?;
         for annotation in &self.annotations {
-            write!(f, " {}", annotation)?;
+            write!(f, " {annotation}")?;
         }
         if let Some(overridden) = &self.overridden_attribute_type {
             write!(f, " {} {}", token::Constraint::As, overridden)?;

--- a/rust/pattern/constraint/type_/owns.rs
+++ b/rust/pattern/constraint/type_/owns.rs
@@ -24,7 +24,7 @@ use std::{collections::HashSet, fmt, iter};
 
 use crate::{
     common::{error::collect_err, token, validatable::Validatable, Result},
-    pattern::{variable::Reference, Type, TypeVariable, TypeVariableBuilder, UnboundVariable},
+    pattern::{variable::Reference, TypeVariable, TypeVariableBuilder, UnboundVariable},
     Label,
 };
 
@@ -95,12 +95,6 @@ impl From<Label> for OwnsConstraint {
     }
 }
 
-impl From<Type> for OwnsConstraint {
-    fn from(attribute_type: Type) -> Self {
-        OwnsConstraint::from(attribute_type.into_type_variable())
-    }
-}
-
 impl From<UnboundVariable> for OwnsConstraint {
     fn from(attribute_type: UnboundVariable) -> Self {
         OwnsConstraint::from(attribute_type.into_type())
@@ -134,12 +128,6 @@ impl From<(Label, Label)> for OwnsConstraint {
     }
 }
 
-impl From<(Type, Type)> for OwnsConstraint {
-    fn from((attribute_type, overridden_attribute_type): (Type, Type)) -> Self {
-        OwnsConstraint::from((attribute_type.into_type_variable(), overridden_attribute_type.into_type_variable()))
-    }
-}
-
 impl From<(UnboundVariable, UnboundVariable)> for OwnsConstraint {
     fn from((attribute_type, overridden_attribute_type): (UnboundVariable, UnboundVariable)) -> Self {
         OwnsConstraint::from((attribute_type.into_type(), overridden_attribute_type.into_type()))
@@ -167,12 +155,6 @@ impl From<(String, Annotation)> for OwnsConstraint {
 impl From<(Label, Annotation)> for OwnsConstraint {
     fn from((attribute_type, annotation): (Label, Annotation)) -> Self {
         OwnsConstraint::from((UnboundVariable::hidden().type_(attribute_type), [annotation]))
-    }
-}
-
-impl From<(Type, Annotation)> for OwnsConstraint {
-    fn from((attribute_type, annotation): (Type, Annotation)) -> Self {
-        OwnsConstraint::from((attribute_type.into_type_variable(), [annotation]))
     }
 }
 
@@ -210,16 +192,6 @@ impl From<(Label, Label, Annotation)> for OwnsConstraint {
     }
 }
 
-impl From<(Type, Type, Annotation)> for OwnsConstraint {
-    fn from((attribute_type, overridden_attribute_type, annotation): (Type, Type, Annotation)) -> Self {
-        OwnsConstraint::from((
-            attribute_type.into_type_variable(),
-            overridden_attribute_type.into_type_variable(),
-            [annotation],
-        ))
-    }
-}
-
 impl From<(UnboundVariable, UnboundVariable, Annotation)> for OwnsConstraint {
     fn from(
         (attribute_type, overridden_attribute_type, annotation): (UnboundVariable, UnboundVariable, Annotation),
@@ -252,12 +224,6 @@ impl<const N: usize> From<(Label, [Annotation; N])> for OwnsConstraint {
     }
 }
 
-impl<const N: usize> From<(Type, [Annotation; N])> for OwnsConstraint {
-    fn from((attribute_type, annotations): (Type, [Annotation; N])) -> Self {
-        OwnsConstraint::from((attribute_type.into_type_variable(), annotations))
-    }
-}
-
 impl<const N: usize> From<(UnboundVariable, [Annotation; N])> for OwnsConstraint {
     fn from((attribute_type, annotations): (UnboundVariable, [Annotation; N])) -> Self {
         OwnsConstraint::from((attribute_type.into_type(), annotations))
@@ -287,16 +253,6 @@ impl<const N: usize> From<(Label, Label, [Annotation; N])> for OwnsConstraint {
         OwnsConstraint::from((
             UnboundVariable::hidden().type_(attribute_type),
             UnboundVariable::hidden().type_(overridden_attribute_type),
-            annotations,
-        ))
-    }
-}
-
-impl<const N: usize> From<(Type, Type, [Annotation; N])> for OwnsConstraint {
-    fn from((attribute_type, overridden_attribute_type, annotations): (Type, Type, [Annotation; N])) -> Self {
-        OwnsConstraint::from((
-            attribute_type.into_type_variable(),
-            overridden_attribute_type.into_type_variable(),
             annotations,
         ))
     }

--- a/rust/pattern/constraint/type_/owns.rs
+++ b/rust/pattern/constraint/type_/owns.rs
@@ -20,7 +20,7 @@
  *
  */
 
-use std::{collections::HashSet, fmt, iter};
+use std::{fmt, iter};
 
 use crate::{
     common::{error::collect_err, token, validatable::Validatable, Result},
@@ -48,14 +48,14 @@ impl fmt::Display for Annotation {
 pub struct OwnsConstraint {
     pub attribute_type: TypeVariable,
     pub overridden_attribute_type: Option<TypeVariable>,
-    pub annotations: HashSet<Annotation>,
+    pub annotations: Vec<Annotation>,
 }
 
 impl OwnsConstraint {
     pub(crate) fn new(
         attribute_type: TypeVariable,
         overridden_attribute_type: Option<TypeVariable>,
-        annotations: HashSet<Annotation>,
+        annotations: Vec<Annotation>,
     ) -> Self {
         OwnsConstraint { attribute_type, overridden_attribute_type, annotations }
     }
@@ -103,7 +103,7 @@ impl From<UnboundVariable> for OwnsConstraint {
 
 impl From<TypeVariable> for OwnsConstraint {
     fn from(attribute_type: TypeVariable) -> Self {
-        OwnsConstraint::new(attribute_type, None, HashSet::new())
+        OwnsConstraint::new(attribute_type, None, vec![])
     }
 }
 
@@ -136,7 +136,7 @@ impl From<(UnboundVariable, UnboundVariable)> for OwnsConstraint {
 
 impl From<(TypeVariable, TypeVariable)> for OwnsConstraint {
     fn from((attribute_type, overridden_attribute_type): (TypeVariable, TypeVariable)) -> Self {
-        OwnsConstraint::new(attribute_type, Some(overridden_attribute_type), HashSet::new())
+        OwnsConstraint::new(attribute_type, Some(overridden_attribute_type), vec![])
     }
 }
 

--- a/rust/pattern/constraint/type_/plays.rs
+++ b/rust/pattern/constraint/type_/plays.rs
@@ -24,7 +24,7 @@ use std::{fmt, iter};
 
 use crate::{
     common::{error::collect_err, token, validatable::Validatable, Result},
-    pattern::{variable::Reference, Type, TypeVariable, TypeVariableBuilder, UnboundVariable},
+    pattern::{variable::Reference, TypeVariable, TypeVariableBuilder, UnboundVariable},
     Label,
 };
 
@@ -36,7 +36,7 @@ pub struct PlaysConstraint {
 }
 
 impl PlaysConstraint {
-    fn new(role_type: TypeVariable, overridden_role_type: Option<TypeVariable>) -> Self {
+    pub(crate) fn new(role_type: TypeVariable, overridden_role_type: Option<TypeVariable>) -> Self {
         PlaysConstraint {
             relation_type: role_type
                 .label
@@ -112,18 +112,6 @@ impl From<(Label, Label)> for PlaysConstraint {
 impl From<UnboundVariable> for PlaysConstraint {
     fn from(role_type: UnboundVariable) -> Self {
         PlaysConstraint::from(role_type.into_type())
-    }
-}
-
-impl From<Type> for PlaysConstraint {
-    fn from(role_type: Type) -> Self {
-        PlaysConstraint::new(role_type.into_type_variable(), None)
-    }
-}
-
-impl From<(Type, Option<Type>)> for PlaysConstraint {
-    fn from((role_type, overridden_role_type): (Type, Option<Type>)) -> Self {
-        PlaysConstraint::new(role_type.into_type_variable(), overridden_role_type.map(Type::into_type_variable))
     }
 }
 

--- a/rust/pattern/constraint/type_/plays.rs
+++ b/rust/pattern/constraint/type_/plays.rs
@@ -38,9 +38,10 @@ pub struct PlaysConstraint {
 impl PlaysConstraint {
     fn new(role_type: TypeVariable, overridden_role_type: Option<TypeVariable>) -> Self {
         PlaysConstraint {
-            relation_type: role_type.label.as_ref().map(|label| {
-                UnboundVariable::hidden().type_(label.label.scope.as_ref().cloned().unwrap())
-            }),
+            relation_type: role_type
+                .label
+                .as_ref()
+                .map(|label| UnboundVariable::hidden().type_(label.label.scope.as_ref().cloned().unwrap())),
             role_type,
             overridden_role_type,
         }
@@ -89,10 +90,7 @@ impl From<(String, String)> for PlaysConstraint {
 
 impl From<(String, String, String)> for PlaysConstraint {
     fn from((relation_type, role_type, overridden_role_type): (String, String, String)) -> Self {
-        PlaysConstraint::from((
-            Label::from((relation_type, role_type)),
-            Label::from(overridden_role_type),
-        ))
+        PlaysConstraint::from((Label::from((relation_type, role_type)), Label::from(overridden_role_type)))
     }
 }
 
@@ -125,10 +123,7 @@ impl From<Type> for PlaysConstraint {
 
 impl From<(Type, Option<Type>)> for PlaysConstraint {
     fn from((role_type, overridden_role_type): (Type, Option<Type>)) -> Self {
-        PlaysConstraint::new(
-            role_type.into_type_variable(),
-            overridden_role_type.map(Type::into_type_variable),
-        )
+        PlaysConstraint::new(role_type.into_type_variable(), overridden_role_type.map(Type::into_type_variable))
     }
 }
 

--- a/rust/pattern/constraint/type_/regex.rs
+++ b/rust/pattern/constraint/type_/regex.rs
@@ -24,9 +24,7 @@ use std::fmt;
 
 use regex::Regex;
 
-use crate::common::{
-    error::TypeQLError, string::escape_regex, token, validatable::Validatable, Result,
-};
+use crate::common::{error::TypeQLError, string::escape_regex, token, validatable::Validatable, Result};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RegexConstraint {

--- a/rust/pattern/constraint/type_/relates.rs
+++ b/rust/pattern/constraint/type_/relates.rs
@@ -24,7 +24,7 @@ use std::{fmt, iter};
 
 use crate::{
     common::{error::collect_err, token, validatable::Validatable, Result},
-    pattern::{variable::Reference, Type, TypeVariable, TypeVariableBuilder, UnboundVariable},
+    pattern::{variable::Reference, TypeVariable, TypeVariableBuilder, UnboundVariable},
     Label,
 };
 
@@ -91,18 +91,6 @@ impl From<TypeVariable> for RelatesConstraint {
 impl From<(TypeVariable, Option<TypeVariable>)> for RelatesConstraint {
     fn from((role_type, overridden_role_type): (TypeVariable, Option<TypeVariable>)) -> Self {
         RelatesConstraint { role_type, overridden_role_type }
-    }
-}
-
-impl From<Type> for RelatesConstraint {
-    fn from(role_type: Type) -> Self {
-        RelatesConstraint::from(role_type.into_type_variable())
-    }
-}
-
-impl From<(Type, Option<Type>)> for RelatesConstraint {
-    fn from((role_type, overridden): (Type, Option<Type>)) -> Self {
-        RelatesConstraint::from((role_type.into_type_variable(), overridden.map(Type::into_type_variable)))
     }
 }
 

--- a/rust/pattern/constraint/type_/relates.rs
+++ b/rust/pattern/constraint/type_/relates.rs
@@ -36,10 +36,7 @@ pub struct RelatesConstraint {
 
 impl RelatesConstraint {
     pub fn references(&self) -> Box<dyn Iterator<Item = &Reference> + '_> {
-        Box::new(
-            iter::once(&self.role_type.reference)
-                .chain(self.overridden_role_type.iter().map(|v| &v.reference)),
-        )
+        Box::new(iter::once(&self.role_type.reference).chain(self.overridden_role_type.iter().map(|v| &v.reference)))
     }
 }
 
@@ -75,10 +72,7 @@ impl From<(&str, &str)> for RelatesConstraint {
 
 impl From<Label> for RelatesConstraint {
     fn from(type_: Label) -> Self {
-        RelatesConstraint {
-            role_type: UnboundVariable::hidden().type_(type_),
-            overridden_role_type: None,
-        }
+        RelatesConstraint { role_type: UnboundVariable::hidden().type_(type_), overridden_role_type: None }
     }
 }
 
@@ -108,10 +102,7 @@ impl From<Type> for RelatesConstraint {
 
 impl From<(Type, Option<Type>)> for RelatesConstraint {
     fn from((role_type, overridden): (Type, Option<Type>)) -> Self {
-        RelatesConstraint::from((
-            role_type.into_type_variable(),
-            overridden.map(Type::into_type_variable),
-        ))
+        RelatesConstraint::from((role_type.into_type_variable(), overridden.map(Type::into_type_variable)))
     }
 }
 

--- a/rust/pattern/constraint/type_/sub.rs
+++ b/rust/pattern/constraint/type_/sub.rs
@@ -24,9 +24,7 @@ use std::{fmt, iter};
 
 use crate::{
     common::{token, validatable::Validatable, Result},
-    pattern::{
-        variable::Reference, IsExplicit, Type, TypeVariable, TypeVariableBuilder, UnboundVariable,
-    },
+    pattern::{variable::Reference, IsExplicit, Type, TypeVariable, TypeVariableBuilder, UnboundVariable},
     Label,
 };
 

--- a/rust/pattern/constraint/type_/sub.rs
+++ b/rust/pattern/constraint/type_/sub.rs
@@ -24,7 +24,7 @@ use std::{fmt, iter};
 
 use crate::{
     common::{token, validatable::Validatable, Result},
-    pattern::{variable::Reference, IsExplicit, Type, TypeVariable, TypeVariableBuilder, UnboundVariable},
+    pattern::{variable::Reference, IsExplicit, TypeVariable, TypeVariableBuilder, UnboundVariable},
     Label,
 };
 
@@ -67,12 +67,6 @@ impl From<TypeVariable> for SubConstraint {
     }
 }
 
-impl From<Type> for SubConstraint {
-    fn from(type_: Type) -> Self {
-        Self::from(type_.into_type_variable())
-    }
-}
-
 impl<T: Into<Label>> From<(T, IsExplicit)> for SubConstraint {
     fn from((scoped_type, is_explicit): (T, IsExplicit)) -> Self {
         Self::from((UnboundVariable::hidden().type_(scoped_type), is_explicit))
@@ -87,12 +81,6 @@ impl From<(UnboundVariable, IsExplicit)> for SubConstraint {
 impl From<(TypeVariable, IsExplicit)> for SubConstraint {
     fn from((type_, is_explicit): (TypeVariable, IsExplicit)) -> Self {
         Self::new(type_, is_explicit)
-    }
-}
-
-impl From<(Type, IsExplicit)> for SubConstraint {
-    fn from((type_, is_explicit): (Type, IsExplicit)) -> Self {
-        Self::from((type_.into_type_variable(), is_explicit))
     }
 }
 

--- a/rust/pattern/disjunction.rs
+++ b/rust/pattern/disjunction.rs
@@ -75,8 +75,7 @@ impl Normalisable for Disjunction {
                         disjunction.compute_normalised().into_disjunction().patterns.into_iter()
                     }
                     Pattern::Negation(negation) => {
-                        vec![Conjunction::new(vec![negation.compute_normalised()]).into()]
-                            .into_iter()
+                        vec![Conjunction::new(vec![negation.compute_normalised()]).into()].into_iter()
                     }
                     Pattern::Variable(variable) => {
                         vec![Conjunction::new(vec![variable.clone().into()]).into()].into_iter()

--- a/rust/pattern/label.rs
+++ b/rust/pattern/label.rs
@@ -84,7 +84,7 @@ impl From<(String, String)> for Label {
 impl fmt::Display for Label {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(scope) = &self.scope {
-            write!(f, "{}:", scope)?;
+            write!(f, "{scope}:")?;
         }
         write!(f, "{}", self.name)
     }

--- a/rust/pattern/label.rs
+++ b/rust/pattern/label.rs
@@ -22,28 +22,7 @@
 
 use std::fmt;
 
-use crate::{
-    common::token,
-    pattern::{
-        variable::{TypeVariable, UnboundVariable},
-        TypeVariableBuilder,
-    },
-};
-
-#[derive(Debug)]
-pub enum Type {
-    Label(Label),
-    Variable(UnboundVariable),
-}
-
-impl Type {
-    pub fn into_type_variable(self) -> TypeVariable {
-        match self {
-            Self::Label(label) => UnboundVariable::hidden().type_(label),
-            Self::Variable(var) => var.into_type(),
-        }
-    }
-}
+use crate::common::token;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Label {

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -40,7 +40,7 @@ pub use constraint::{
     RolePlayerConstraint, SubConstraint, Value, ValueConstraint, ValueTypeConstraint,
 };
 pub use disjunction::Disjunction;
-pub use label::{Label, Type};
+pub use label::Label;
 pub use named_references::NamedReferences;
 pub use negation::Negation;
 pub use schema::{RuleDeclaration, RuleDefinition};

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -158,10 +158,10 @@ impl fmt::Display for Pattern {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Pattern::*;
         match self {
-            Conjunction(conjunction) => write!(f, "{}", conjunction),
-            Disjunction(disjunction) => write!(f, "{}", disjunction),
-            Negation(negation) => write!(f, "{}", negation),
-            Variable(variable) => write!(f, "{}", variable),
+            Conjunction(conjunction) => write!(f, "{conjunction}"),
+            Disjunction(disjunction) => write!(f, "{disjunction}"),
+            Negation(negation) => write!(f, "{negation}"),
+            Variable(variable) => write!(f, "{variable}"),
         }
     }
 }
@@ -200,9 +200,9 @@ impl fmt::Display for Definable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Definable::*;
         match self {
-            RuleDeclaration(rule_declaration) => write!(f, "{}", rule_declaration),
-            RuleDefinition(rule) => write!(f, "{}", rule),
-            TypeVariable(variable) => write!(f, "{}", variable),
+            RuleDeclaration(rule_declaration) => write!(f, "{rule_declaration}"),
+            RuleDefinition(rule) => write!(f, "{rule}"),
+            TypeVariable(variable) => write!(f, "{variable}"),
         }
     }
 }

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -35,10 +35,10 @@ use std::{collections::HashSet, fmt};
 
 pub use conjunction::Conjunction;
 pub use constraint::{
-    AbstractConstraint, HasConstraint, IIDConstraint, IsConstraint, IsExplicit, IsKeyAttribute,
+    AbstractConstraint, Annotation, HasConstraint, IIDConstraint, IsConstraint, IsExplicit,
     IsaConstraint, LabelConstraint, OwnsConstraint, PlaysConstraint, RegexConstraint,
     RelatesConstraint, RelationConstraint, RolePlayerConstraint, SubConstraint, Value,
-    ValueConstraint, ValueTypeConstraint, KEY,
+    ValueConstraint, ValueTypeConstraint,
 };
 pub use disjunction::Disjunction;
 pub use label::{Label, Type};

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -35,10 +35,9 @@ use std::{collections::HashSet, fmt};
 
 pub use conjunction::Conjunction;
 pub use constraint::{
-    AbstractConstraint, Annotation, HasConstraint, IIDConstraint, IsConstraint, IsExplicit,
-    IsaConstraint, LabelConstraint, OwnsConstraint, PlaysConstraint, RegexConstraint,
-    RelatesConstraint, RelationConstraint, RolePlayerConstraint, SubConstraint, Value,
-    ValueConstraint, ValueTypeConstraint,
+    AbstractConstraint, Annotation, HasConstraint, IIDConstraint, IsConstraint, IsExplicit, IsaConstraint,
+    LabelConstraint, OwnsConstraint, PlaysConstraint, RegexConstraint, RelatesConstraint, RelationConstraint,
+    RolePlayerConstraint, SubConstraint, Value, ValueConstraint, ValueTypeConstraint,
 };
 pub use disjunction::Disjunction;
 pub use label::{Label, Type};
@@ -46,10 +45,9 @@ pub use named_references::NamedReferences;
 pub use negation::Negation;
 pub use schema::{RuleDeclaration, RuleDefinition};
 pub use variable::{
-    ConceptConstrainable, ConceptVariable, ConceptVariableBuilder, Reference,
-    RelationConstrainable, RelationVariableBuilder, ThingConstrainable, ThingVariable,
-    ThingVariableBuilder, TypeConstrainable, TypeVariable, TypeVariableBuilder, UnboundVariable,
-    Variable, Visibility,
+    ConceptConstrainable, ConceptVariable, ConceptVariableBuilder, Reference, RelationConstrainable,
+    RelationVariableBuilder, ThingConstrainable, ThingVariable, ThingVariableBuilder, TypeConstrainable, TypeVariable,
+    TypeVariableBuilder, UnboundVariable, Variable, Visibility,
 };
 
 use crate::{

--- a/rust/pattern/negation.rs
+++ b/rust/pattern/negation.rs
@@ -73,8 +73,7 @@ impl Normalisable for Negation {
             Pattern::Disjunction(disjunction) => disjunction.compute_normalised(),
             Pattern::Negation(_) => panic!("{}", TypeQLError::RedundantNestedNegation()),
             Pattern::Variable(variable) => {
-                Disjunction::new(vec![Conjunction::new(vec![variable.clone().into()]).into()])
-                    .into()
+                Disjunction::new(vec![Conjunction::new(vec![variable.clone().into()]).into()]).into()
             }
         })
         .into()

--- a/rust/pattern/schema/rule.rs
+++ b/rust/pattern/schema/rule.rs
@@ -25,7 +25,6 @@ use std::{fmt, iter};
 use crate::{
     common::{
         error::{collect_err, TypeQLError},
-        string::indent,
         token,
         validatable::Validatable,
         Result,

--- a/rust/pattern/schema/rule.rs
+++ b/rust/pattern/schema/rule.rs
@@ -100,10 +100,7 @@ impl Validatable for RuleDefinition {
     }
 }
 
-fn expect_no_nested_negations<'a>(
-    patterns: impl Iterator<Item = &'a Pattern>,
-    rule_label: &Label,
-) -> Result<()> {
+fn expect_no_nested_negations<'a>(patterns: impl Iterator<Item = &'a Pattern>, rule_label: &Label) -> Result<()> {
     collect_err(&mut patterns.map(|p| -> Result<()> {
         match p {
             Pattern::Conjunction(c) => expect_no_nested_negations(c.patterns.iter(), rule_label),
@@ -131,10 +128,7 @@ fn contains_negations<'a>(mut patterns: impl Iterator<Item = &'a Pattern>) -> bo
 
 fn expect_infer_single_edge(then: &ThingVariable, rule_label: &Label) -> Result<()> {
     if then.has.len() == 1
-        && (then.iid.is_none()
-            && then.isa.is_none()
-            && then.value.is_none()
-            && then.relation.is_none())
+        && (then.iid.is_none() && then.isa.is_none() && then.value.is_none() && then.relation.is_none())
         || then.relation.is_some()
             && then.isa.is_some()
             && (then.iid.is_none() && then.has.is_empty() && then.value.is_none())
@@ -166,11 +160,7 @@ fn expect_valid_inference(then: &ThingVariable, rule_label: &Label) -> Result<()
     }
 }
 
-fn expect_then_bounded_by_when(
-    then: &ThingVariable,
-    when: &Conjunction,
-    rule_label: &Label,
-) -> Result<()> {
+fn expect_then_bounded_by_when(then: &ThingVariable, when: &Conjunction, rule_label: &Label) -> Result<()> {
     let bounds = when.named_references();
     if !then.references().filter(|r| r.is_name()).all(|r| bounds.contains(r)) {
         Err(TypeQLError::InvalidRuleThenVariables(rule_label.clone()))?

--- a/rust/pattern/test/mod.rs
+++ b/rust/pattern/test/mod.rs
@@ -44,16 +44,8 @@ $com isa company;
     assert_eq!(
         normalised,
         or!(
-            and!(
-                var("com").has(("name", var("n1"))),
-                var("n1").eq("the-company"),
-                var("com").isa("company"),
-            ),
-            and!(
-                var("com").has(("name", var("n2"))),
-                var("n2").eq("another-company"),
-                var("com").isa("company"),
-            )
+            and!(var("com").has(("name", var("n1"))), var("n1").eq("the-company"), var("com").isa("company"),),
+            and!(var("com").has(("name", var("n2"))), var("n2").eq("another-company"), var("com").isa("company"),)
         )
         .into_disjunction()
     );

--- a/rust/pattern/variable/builder/mod.rs
+++ b/rust/pattern/variable/builder/mod.rs
@@ -25,7 +25,5 @@ mod thing;
 mod type_;
 
 pub use concept::{ConceptConstrainable, ConceptVariableBuilder};
-pub use thing::{
-    RelationConstrainable, RelationVariableBuilder, ThingConstrainable, ThingVariableBuilder,
-};
+pub use thing::{RelationConstrainable, RelationVariableBuilder, ThingConstrainable, ThingVariableBuilder};
 pub use type_::{TypeConstrainable, TypeVariableBuilder};

--- a/rust/pattern/variable/builder/thing.rs
+++ b/rust/pattern/variable/builder/thing.rs
@@ -23,8 +23,8 @@
 use crate::{
     common::token::Predicate,
     pattern::{
-        HasConstraint, IIDConstraint, IsaConstraint, RelationConstraint, RolePlayerConstraint,
-        ThingVariable, Value, ValueConstraint,
+        HasConstraint, IIDConstraint, IsaConstraint, RelationConstraint, RolePlayerConstraint, ThingVariable, Value,
+        ValueConstraint,
     },
 };
 

--- a/rust/pattern/variable/builder/type_.rs
+++ b/rust/pattern/variable/builder/type_.rs
@@ -23,8 +23,8 @@
 use crate::{
     common::token::ValueType,
     pattern::{
-        LabelConstraint, OwnsConstraint, PlaysConstraint, RegexConstraint, RelatesConstraint,
-        SubConstraint, TypeVariable, ValueTypeConstraint,
+        LabelConstraint, OwnsConstraint, PlaysConstraint, RegexConstraint, RelatesConstraint, SubConstraint,
+        TypeVariable, ValueTypeConstraint,
     },
     Label,
 };

--- a/rust/pattern/variable/concept.rs
+++ b/rust/pattern/variable/concept.rs
@@ -42,18 +42,14 @@ impl ConceptVariable {
     }
 
     pub fn references(&self) -> Box<dyn Iterator<Item = &Reference> + '_> {
-        Box::new(
-            iter::once(&self.reference)
-                .chain(self.is_constraint.iter().map(|is| &is.variable.reference)),
-        )
+        Box::new(iter::once(&self.reference).chain(self.is_constraint.iter().map(|is| &is.variable.reference)))
     }
 }
 
 impl Validatable for ConceptVariable {
     fn validate(&self) -> Result<()> {
         collect_err(
-            &mut iter::once(self.reference.validate())
-                .chain(self.is_constraint.iter().map(Validatable::validate)),
+            &mut iter::once(self.reference.validate()).chain(self.is_constraint.iter().map(Validatable::validate)),
         )
     }
 }

--- a/rust/pattern/variable/concept.rs
+++ b/rust/pattern/variable/concept.rs
@@ -68,7 +68,7 @@ impl fmt::Display for ConceptVariable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.reference)?;
         if let Some(is) = &self.is_constraint {
-            write!(f, " {}", is)?;
+            write!(f, " {is}")?;
         }
         Ok(())
     }

--- a/rust/pattern/variable/mod.rs
+++ b/rust/pattern/variable/mod.rs
@@ -30,8 +30,8 @@ mod unbound;
 use std::{collections::HashSet, fmt};
 
 pub use builder::{
-    ConceptConstrainable, ConceptVariableBuilder, RelationConstrainable, RelationVariableBuilder,
-    ThingConstrainable, ThingVariableBuilder, TypeConstrainable, TypeVariableBuilder,
+    ConceptConstrainable, ConceptVariableBuilder, RelationConstrainable, RelationVariableBuilder, ThingConstrainable,
+    ThingVariableBuilder, TypeConstrainable, TypeVariableBuilder,
 };
 pub use concept::ConceptVariable;
 pub use reference::{Reference, Visibility};

--- a/rust/pattern/variable/mod.rs
+++ b/rust/pattern/variable/mod.rs
@@ -110,10 +110,10 @@ impl fmt::Display for Variable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Variable::*;
         match self {
-            Unbound(unbound) => write!(f, "{}", unbound),
-            Concept(concept) => write!(f, "{}", concept),
-            Thing(thing) => write!(f, "{}", thing),
-            Type(type_) => write!(f, "{}", type_),
+            Unbound(unbound) => write!(f, "{unbound}"),
+            Concept(concept) => write!(f, "{concept}"),
+            Thing(thing) => write!(f, "{thing}"),
+            Type(type_) => write!(f, "{type_}"),
         }
     }
 }

--- a/rust/pattern/variable/thing.rs
+++ b/rust/pattern/variable/thing.rs
@@ -72,9 +72,9 @@ impl ThingVariable {
         }
 
         if let Some(value) = &self.value {
-            write!(f, "{}", value)?;
+            write!(f, "{value}")?;
         } else if let Some(relation) = &self.relation {
-            write!(f, "{}", relation)?;
+            write!(f, "{relation}")?;
         }
 
         Ok(())

--- a/rust/pattern/variable/thing.rs
+++ b/rust/pattern/variable/thing.rs
@@ -25,8 +25,8 @@ use std::{fmt, iter};
 use crate::{
     common::{error::collect_err, validatable::Validatable, Result},
     pattern::{
-        HasConstraint, IIDConstraint, IsaConstraint, Reference, RelationConstrainable,
-        RelationConstraint, RolePlayerConstraint, ThingConstrainable, ValueConstraint,
+        HasConstraint, IIDConstraint, IsaConstraint, Reference, RelationConstrainable, RelationConstraint,
+        RolePlayerConstraint, ThingConstrainable, ValueConstraint,
     },
     write_joined,
 };
@@ -43,14 +43,7 @@ pub struct ThingVariable {
 
 impl ThingVariable {
     pub fn new(reference: Reference) -> ThingVariable {
-        ThingVariable {
-            reference,
-            iid: None,
-            isa: None,
-            has: Vec::new(),
-            value: None,
-            relation: None,
-        }
+        ThingVariable { reference, iid: None, isa: None, has: Vec::new(), value: None, relation: None }
     }
 
     pub fn references(&self) -> Box<dyn Iterator<Item = &Reference> + '_> {

--- a/rust/pattern/variable/type_.rs
+++ b/rust/pattern/variable/type_.rs
@@ -29,8 +29,8 @@ use crate::{
         Result,
     },
     pattern::{
-        AbstractConstraint, LabelConstraint, OwnsConstraint, PlaysConstraint, Reference,
-        RegexConstraint, RelatesConstraint, SubConstraint, TypeConstrainable, ValueTypeConstraint,
+        AbstractConstraint, LabelConstraint, OwnsConstraint, PlaysConstraint, Reference, RegexConstraint,
+        RelatesConstraint, SubConstraint, TypeConstrainable, ValueTypeConstraint,
     },
     write_joined,
 };

--- a/rust/pattern/variable/type_.rs
+++ b/rust/pattern/variable/type_.rs
@@ -149,7 +149,7 @@ impl fmt::Display for TypeVariable {
         if self.reference.is_visible() {
             write!(f, "{}", self.reference)?;
             if let Some(type_) = &self.label {
-                write!(f, " {}", type_)?;
+                write!(f, " {type_}")?;
             }
         } else {
             write!(f, "{}", self.label.as_ref().unwrap().label)?;

--- a/rust/pattern/variable/unbound.rs
+++ b/rust/pattern/variable/unbound.rs
@@ -25,11 +25,10 @@ use std::{fmt, iter};
 use crate::{
     common::{validatable::Validatable, Result},
     pattern::{
-        ConceptConstrainable, ConceptVariable, HasConstraint, IIDConstraint, IsConstraint,
-        IsaConstraint, LabelConstraint, OwnsConstraint, PlaysConstraint, Reference,
-        RegexConstraint, RelatesConstraint, RelationConstrainable, RelationConstraint,
-        RolePlayerConstraint, SubConstraint, ThingConstrainable, ThingVariable, TypeConstrainable,
-        TypeVariable, ValueConstraint, ValueTypeConstraint, Visibility,
+        ConceptConstrainable, ConceptVariable, HasConstraint, IIDConstraint, IsConstraint, IsaConstraint,
+        LabelConstraint, OwnsConstraint, PlaysConstraint, Reference, RegexConstraint, RelatesConstraint,
+        RelationConstrainable, RelationConstraint, RolePlayerConstraint, SubConstraint, ThingConstrainable,
+        ThingVariable, TypeConstrainable, TypeVariable, ValueConstraint, ValueTypeConstraint, Visibility,
     },
 };
 

--- a/rust/query/aggregate.rs
+++ b/rust/query/aggregate.rs
@@ -94,7 +94,7 @@ impl fmt::Display for TypeQLMatchAggregate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}\n{}", self.query, self.method)?;
         if let Some(var) = &self.var {
-            write!(f, " {}", var)?;
+            write!(f, " {var}")?;
         }
         f.write_str(";")
     }
@@ -104,7 +104,7 @@ impl fmt::Display for TypeQLMatchGroupAggregate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", self.query, self.method)?;
         if let Some(var) = &self.var {
-            write!(f, " {}", var)?;
+            write!(f, " {var}")?;
         }
         f.write_str(";")
     }

--- a/rust/query/aggregate.rs
+++ b/rust/query/aggregate.rs
@@ -61,29 +61,19 @@ impl<T: AggregateQueryBuilder> Validatable for AggregateQuery<T> {
         collect_err(
             &mut [expect_method_variable_compatible(self.method, &self.var), self.query.validate()]
                 .into_iter()
-                .chain(
-                    self.var
-                        .iter()
-                        .map(|v| expect_variable_in_scope(v, self.query.named_references())),
-                ),
+                .chain(self.var.iter().map(|v| expect_variable_in_scope(v, self.query.named_references()))),
         )
     }
 }
 
-fn expect_method_variable_compatible(
-    method: token::Aggregate,
-    var: &Option<UnboundVariable>,
-) -> Result<()> {
+fn expect_method_variable_compatible(method: token::Aggregate, var: &Option<UnboundVariable>) -> Result<()> {
     if method == token::Aggregate::Count && var.is_some() {
         Err(TypeQLError::InvalidCountVariableArgument())?
     }
     Ok(())
 }
 
-fn expect_variable_in_scope(
-    var: &UnboundVariable,
-    names_in_scope: HashSet<Reference>,
-) -> Result<()> {
+fn expect_variable_in_scope(var: &UnboundVariable, names_in_scope: HashSet<Reference>) -> Result<()> {
     if !names_in_scope.contains(&var.reference) {
         Err(TypeQLError::VariableOutOfScopeMatch(var.reference.clone()))?;
     }

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -120,15 +120,15 @@ impl fmt::Display for Query {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Query::*;
         match self {
-            Match(query) => write!(f, "{}", query),
-            Insert(query) => write!(f, "{}", query),
-            Delete(query) => write!(f, "{}", query),
-            Update(query) => write!(f, "{}", query),
-            Define(query) => write!(f, "{}", query),
-            Undefine(query) => write!(f, "{}", query),
-            Aggregate(query) => write!(f, "{}", query),
-            Group(query) => write!(f, "{}", query),
-            GroupAggregate(query) => write!(f, "{}", query),
+            Match(query) => write!(f, "{query}"),
+            Insert(query) => write!(f, "{query}"),
+            Delete(query) => write!(f, "{query}"),
+            Update(query) => write!(f, "{query}"),
+            Define(query) => write!(f, "{query}"),
+            Undefine(query) => write!(f, "{query}"),
+            Aggregate(query) => write!(f, "{query}"),
+            Group(query) => write!(f, "{query}"),
+            GroupAggregate(query) => write!(f, "{query}"),
         }
     }
 }

--- a/rust/query/typeql_delete.rs
+++ b/rust/query/typeql_delete.rs
@@ -60,20 +60,15 @@ impl Validatable for TypeQLDelete {
     }
 }
 
-fn expect_delete_in_scope_of_match(
-    match_query: &TypeQLMatch,
-    variables: &[ThingVariable],
-) -> Result<()> {
+fn expect_delete_in_scope_of_match(match_query: &TypeQLMatch, variables: &[ThingVariable]) -> Result<()> {
     let names_in_scope = match_query.named_references();
-    collect_err(&mut variables.iter().flat_map(|v| v.references()).filter(|r| r.is_name()).map(
-        |r| -> Result<()> {
-            if names_in_scope.contains(r) {
-                Ok(())
-            } else {
-                Err(TypeQLError::VariableOutOfScopeDelete(r.clone()))?
-            }
-        },
-    ))
+    collect_err(&mut variables.iter().flat_map(|v| v.references()).filter(|r| r.is_name()).map(|r| -> Result<()> {
+        if names_in_scope.contains(r) {
+            Ok(())
+        } else {
+            Err(TypeQLError::VariableOutOfScopeDelete(r.clone()))?
+        }
+    }))
 }
 
 impl fmt::Display for TypeQLDelete {

--- a/rust/query/typeql_insert.rs
+++ b/rust/query/typeql_insert.rs
@@ -89,7 +89,7 @@ fn expect_insert_in_scope_of_match(
 impl fmt::Display for TypeQLInsert {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(match_query) = &self.match_query {
-            writeln!(f, "{}", match_query)?;
+            writeln!(f, "{match_query}")?;
         }
 
         writeln!(f, "{}", token::Command::Insert)?;

--- a/rust/query/typeql_insert.rs
+++ b/rust/query/typeql_insert.rs
@@ -60,10 +60,7 @@ impl Validatable for TypeQLInsert {
     }
 }
 
-fn expect_insert_in_scope_of_match(
-    match_query: &Option<TypeQLMatch>,
-    variables: &[ThingVariable],
-) -> Result<()> {
+fn expect_insert_in_scope_of_match(match_query: &Option<TypeQLMatch>, variables: &[ThingVariable]) -> Result<()> {
     if let Some(match_query) = match_query {
         let names_in_scope = match_query.named_references();
         if variables.iter().any(|v| {
@@ -72,13 +69,8 @@ fn expect_insert_in_scope_of_match(
         }) {
             Ok(())
         } else {
-            let variables_str =
-                variables.iter().map(ThingVariable::to_string).collect::<Vec<String>>().join(", ");
-            let bounds_str = names_in_scope
-                .into_iter()
-                .map(|r| r.to_string())
-                .collect::<Vec<String>>()
-                .join(", ");
+            let variables_str = variables.iter().map(ThingVariable::to_string).collect::<Vec<String>>().join(", ");
+            let bounds_str = names_in_scope.into_iter().map(|r| r.to_string()).collect::<Vec<String>>().join(", ");
             Err(TypeQLError::NoVariableInScopeInsert(variables_str, bounds_str))?
         }
     } else {

--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -188,7 +188,7 @@ impl fmt::Display for TypeQLMatch {
         write!(f, "{}", token::Command::Match)?;
 
         for pattern in &self.conjunction.patterns {
-            write!(f, "\n{};", pattern)?;
+            write!(f, "\n{pattern};")?;
         }
 
         if !self.modifiers.is_empty() {
@@ -272,7 +272,7 @@ pub mod sorting {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "{}", self.var)?;
             if let Some(order) = &self.order {
-                write!(f, " {}", order)?;
+                write!(f, " {order}")?;
             }
             Ok(())
         }

--- a/rust/query/typeql_undefine.rs
+++ b/rust/query/typeql_undefine.rs
@@ -41,13 +41,11 @@ pub struct TypeQLUndefine {
 
 impl TypeQLUndefine {
     pub fn new(undefinables: Vec<Definable>) -> Self {
-        undefinables.into_iter().fold(TypeQLUndefine::default(), |undefine, undefinable| {
-            match undefinable {
-                Definable::RuleDeclaration(rule) => undefine.add_rule(rule),
-                Definable::TypeVariable(var) => undefine.add_definition(var),
-                Definable::RuleDefinition(r) => {
-                    panic!("{}", TypeQLError::InvalidUndefineQueryRule(r.label))
-                }
+        undefinables.into_iter().fold(TypeQLUndefine::default(), |undefine, undefinable| match undefinable {
+            Definable::RuleDeclaration(rule) => undefine.add_rule(rule),
+            Definable::TypeVariable(var) => undefine.add_definition(var),
+            Definable::RuleDefinition(r) => {
+                panic!("{}", TypeQLError::InvalidUndefineQueryRule(r.label))
             }
         })
     }

--- a/rust/query/typeql_update.rs
+++ b/rust/query/typeql_update.rs
@@ -38,9 +38,8 @@ pub struct TypeQLUpdate {
 impl Validatable for TypeQLUpdate {
     fn validate(&self) -> Result<()> {
         collect_err(
-            &mut ([expect_non_empty(&self.insert_variables), self.delete_query.validate()]
-                .into_iter())
-            .chain(self.insert_variables.iter().map(Validatable::validate)),
+            &mut ([expect_non_empty(&self.insert_variables), self.delete_query.validate()].into_iter())
+                .chain(self.insert_variables.iter().map(Validatable::validate)),
         )
     }
 }

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -23,3 +23,4 @@
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
 use_small_heuristics = "Max"
+max_width = 120

--- a/rust/tests/behaviour/main.rs
+++ b/rust/tests/behaviour/main.rs
@@ -38,7 +38,7 @@ fn main() {
 }
 
 fn parse_query_in_step(step: &Step) -> Query {
-    parse_query(&step.docstring.as_ref().unwrap()).unwrap()
+    parse_query(step.docstring.as_ref().unwrap()).unwrap()
 }
 
 fn reparse_query(parsed: &Query) -> Query {
@@ -61,13 +61,13 @@ generic_step_impl! {
 #[step("reasoning schema")]
 #[step("typeql define")]
 async fn typeql_define(_: &mut TypeQLWorld, step: &Step) {
-    let parsed = parse_query_in_step(&step);
+    let parsed = parse_query_in_step(step);
     assert_eq!(parsed, reparse_query(&parsed));
 }
 
 #[step("typeql undefine")]
 async fn typeql_undefine(_: &mut TypeQLWorld, step: &Step) {
-    let parsed = parse_query_in_step(&step);
+    let parsed = parse_query_in_step(step);
     assert_eq!(parsed, reparse_query(&parsed));
 }
 
@@ -75,19 +75,19 @@ async fn typeql_undefine(_: &mut TypeQLWorld, step: &Step) {
 #[step("reasoning data")]
 #[step("typeql insert")]
 async fn typeql_insert(_: &mut TypeQLWorld, step: &Step) {
-    let parsed = parse_query_in_step(&step);
+    let parsed = parse_query_in_step(step);
     assert_eq!(parsed, reparse_query(&parsed));
 }
 
 #[step("typeql delete")]
 async fn typeql_delete(_: &mut TypeQLWorld, step: &Step) {
-    let parsed = parse_query_in_step(&step);
+    let parsed = parse_query_in_step(step);
     assert_eq!(parsed, reparse_query(&parsed));
 }
 
 #[step("typeql update")]
 async fn typeql_update(_: &mut TypeQLWorld, step: &Step) {
-    let parsed = parse_query_in_step(&step);
+    let parsed = parse_query_in_step(step);
     assert_eq!(parsed, reparse_query(&parsed));
 }
 
@@ -98,7 +98,7 @@ async fn typeql_update(_: &mut TypeQLWorld, step: &Step) {
 #[step("reasoning query")]
 #[step("verify answer set is equivalent for query")]
 async fn typeql_match(_: &mut TypeQLWorld, step: &Step) {
-    let parsed = parse_query_in_step(&step);
+    let parsed = parse_query_in_step(step);
     assert_eq!(parsed, reparse_query(&parsed));
 }
 

--- a/rust/typeql_lang.rs
+++ b/rust/typeql_lang.rs
@@ -32,8 +32,8 @@ mod util;
 pub use builder::{contains, eq, gt, gte, like, lt, lte, neq, not, rel, rule, type_, var};
 use common::Result;
 use parser::{
-    visit_eof_definables, visit_eof_label, visit_eof_pattern, visit_eof_patterns,
-    visit_eof_queries, visit_eof_query, visit_eof_schema_rule, visit_eof_variable,
+    visit_eof_definables, visit_eof_label, visit_eof_pattern, visit_eof_patterns, visit_eof_queries, visit_eof_query,
+    visit_eof_schema_rule, visit_eof_variable,
 };
 use pattern::{Definable, Label, Pattern, RuleDefinition, Variable};
 use query::Query;


### PR DESCRIPTION
## What is the goal of this PR?

We generalise the annotation syntax and parsing to be able to handle a new type of annotation: the `@unique` annotation, which is available only on the owns constraint: `define person sub entity, owns email @unique;`

The `@unique` annotation has been introduced first in TypeQL Java in https://github.com/vaticle/typeql/pull/273.

## What are the changes implemented in this PR?

We update the pest grammar used in the Rust parser to mirror the changes in TypeQL Java, and adjust the parser visitors to match.

A few drive-by fixes:
- mild refactoring prompted by Clippy;
- replaced usage of deprecated `chrono` `NaiveDateTime` builders with up-to-date variants.