### PR TITLE
Remove unnecessary parentheses

### DIFF
--- a/rust/query/typeql_match.rs
+++ b/rust/query/typeql_match.rs
@@ -303,7 +303,7 @@ impl From<&str> for Sorting {
     }
 }
 
-impl<const N: usize> From<([(&str, token::Order); N])> for Sorting {
+impl<const N: usize> From<[(&str, token::Order); N]> for Sorting {
     fn from(ordered_vars: [(&str, token::Order); N]) -> Self {
         Self::new(
             ordered_vars


### PR DESCRIPTION
## What is the goal of this PR?

As per the Rust compiler:
```
warning: unnecessary parentheses around type

    |
306 | impl<const N: usize> From<([(&str, token::Order); N])> for Sorting {
    |                           ^                         ^
    |
    = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
    |
306 - impl<const N: usize> From<([(&str, token::Order); N])> for Sorting {
306 + impl<const N: usize> From<[(&str, token::Order); N]> for Sorting {
    |
```

## What are the changes implemented in this PR?

We've removed some unnecessary parentheses from an `impl` block signature.