### PR TITLE
Debug formatting Errors

### DIFF
--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -188,12 +188,8 @@ mod tests {
             let display = format!("{error}");
             let compact_debug = format!("{error:?}");
             let expanded_debug = format!("{error:#?}");
-            println!("display:\n{}", display);
-            println!("compact_debug:\n{}", compact_debug);
-            println!("expanded_debug:\n{}", expanded_debug);
             assert!(compact_debug.contains(&display.replace('\n', &"\\n")));
             assert!(expanded_debug.contains(&display.replace('\n', &"\\n")));
         }
-        panic!();
     }
 }

--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -63,17 +63,10 @@ macro_rules! error_messages {
                 }
             }
 
-            const fn name(&self) -> &'static str {
+            fn name(&self) -> String {
                 match self {$(
-                    Self::$error_name(..) => std::stringify!($error_name),
+                    Self::$error_name(..) => format!("{}::{}", std::any::type_name::<Self>(), std::stringify!($error_name)),
                 )*}
-            }
-
-            fn format_payload<'a, 'b>(&'a self, debug_struct: &'a mut std::fmt::DebugStruct<'a, 'b>) -> &mut std::fmt::DebugStruct<'a, 'b>
-                where 'b: 'a
-            {
-                $(error_messages!(@payload self, debug_struct, $error_name $(, $inner)*);)*
-                unreachable!()
             }
         }
 
@@ -91,11 +84,11 @@ macro_rules! error_messages {
 
         impl std::fmt::Debug for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                let mut debug_struct = f.debug_struct(&self.name());
-                let mut repr = debug_struct
+                let mut binding = f.debug_struct(&self.name());
+                let mut debug_struct = binding
                     .field("message", &format!("{}", self));
-                repr = self.format_payload(repr);
-                repr.finish()
+                $(error_messages!(@payload self, $error_name, debug_struct $(, $inner)*);)*
+                debug_struct.finish()
             }
         }
 
@@ -132,33 +125,33 @@ macro_rules! error_messages {
         }
     };
 
-    (@payload $self:ident, $format:ident, $error_name:ident) => {
+    (@payload $self:ident, $error_name:ident, $format:ident) => {
         if let Self::$error_name() = &$self {
-            return $format.field("payload", &())
+            $format.field("payload", &());
         }
     };
 
-    (@payload $self:ident, $format:ident, $error_name:ident, $t1:ty) => {
+    (@payload $self:ident, $error_name:ident, $format:ident, $t1:ty) => {
         if let Self::$error_name(_0) = &$self {
-            return $format.field("payload", &(_0))
+            $format.field("payload", &(_0));
         }
     };
 
-    (@payload $self:ident, $format:ident, $error_name:ident, $t1:ty, $t2:ty) => {
+    (@payload $self:ident, $error_name:ident, $format:ident, $t1:ty, $t2:ty) => {
         if let Self::$error_name(_0, _1) = &$self {
-            return $format.field("payload", &(_0, _1))
+            $format.field("payload", &(_0, _1));
         }
     };
 
-    (@payload $self:ident, $format:ident, $error_name:ident, $t1:ty, $t2:ty, $t3:ty) => {
+    (@payload $self:ident, $error_name:ident, $format:ident, $t1:ty, $t2:ty, $t3:ty) => {
         if let Self::$error_name(_0, _1, _2) = &$self {
-            return $format.field("payload", &(_0, _1, _2))
+            $format.field("payload", &(_0, _1, _2));
         }
     };
 
-    (@payload $self:ident, $format:ident, $error_name:ident, $t1:ty, $t2:ty, $t3:ty, $t4:ty) => {
+    (@payload $self:ident, $error_name:ident, $format:ident, $t1:ty, $t2:ty, $t3:ty, $t4:ty) => {
         if let Self::$error_name(_0, _1, _2, _3) = &$self {
-            return $format.field("payload", &(_0, _1, _2, _3))
+            $format.field("payload", &(_0, _1, _2, _3));
         }
     };
 }

--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -185,12 +185,8 @@ mod tests {
             let display = format!("{error}");
             let compact_debug = format!("{error:?}");
             let expanded_debug = format!("{error:#?}");
-            println!("display:\n{display}");
-            println!("compact_debug:\n{compact_debug}");
-            println!("expanded_debug:\n{expanded_debug}");
             assert!(compact_debug.contains(&display.replace('\n', &"\\n")));
             assert!(expanded_debug.contains(&display.replace('\n', &"\\n")));
         }
-        panic!()
     }
 }

--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -132,7 +132,7 @@ mod tests {
         BasicError() =
             1: "This is a basic error.",
         ErrorWithAttributes(i32, String) =
-            2: "This is an error with i32 {} and string {}.",
+            2: "This is an error with i32 {} and string '{}'.",
         MultiLine() =
             3: "This is an error,\nthat spans,\nmultiple lines."
     }

--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -26,7 +26,7 @@ macro_rules! error_messages {
         $name:ident code: $code_pfx:literal, type: $message_pfx:literal,
         $($error_name:ident( $($inner:ty),* $(,)? ) = $code:literal: $body:literal),+ $(,)?
     } => {
-        #[derive(Clone, Debug, Eq, PartialEq)]
+        #[derive(Clone, Eq, PartialEq)]
         pub enum $name {$(
             $error_name($($inner),*),
         )*}
@@ -62,6 +62,12 @@ macro_rules! error_messages {
                     _ => unreachable!(),
                 }
             }
+
+            const fn name(&self) -> &'static str {
+                match self {$(
+                    Self::$error_name(..) => std::stringify!($error_name),
+                )*}
+            }
         }
 
         impl std::fmt::Display for $name {
@@ -73,6 +79,15 @@ macro_rules! error_messages {
                     self.code(),
                     self.message()
                 )
+            }
+        }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.debug_struct(&self.name())
+                    .field("code", &self.code())
+                    .field("message", &self.message())
+                    .finish()
             }
         }
 

--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -85,7 +85,12 @@ macro_rules! error_messages {
         impl std::fmt::Debug for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
                 let mut binding = f.debug_struct(self.name());
-                $(error_messages!(@payload self, $error_name, binding.field("message", &format!("{}", self)) $(, $inner)*);)*
+                || { $(error_messages!(@payload
+                    self,
+                    $error_name,
+                    binding.field("message", &format!("{}", self))
+                    $(, $inner)*);
+                )* }();
                 binding.finish()
             }
         }
@@ -125,31 +130,31 @@ macro_rules! error_messages {
 
     (@payload $self:ident, $error_name:ident, $format:expr) => {
         if let Self::$error_name() = &$self {
-            $format.field("payload", &());
+            return $format.field("payload", &());
         }
     };
 
     (@payload $self:ident, $error_name:ident, $format:expr, $t1:ty) => {
         if let Self::$error_name(_0) = &$self {
-            $format.field("payload", &(_0));
+            return $format.field("payload", &(_0));
         }
     };
 
     (@payload $self:ident, $error_name:ident, $format:expr, $t1:ty, $t2:ty) => {
         if let Self::$error_name(_0, _1) = &$self {
-            $format.field("payload", &(_0, _1));
+            return $format.field("payload", &(_0, _1));
         }
     };
 
     (@payload $self:ident, $error_name:ident, $format:expr, $t1:ty, $t2:ty, $t3:ty) => {
         if let Self::$error_name(_0, _1, _2) = &$self {
-            $format.field("payload", &(_0, _1, _2));
+            return $format.field("payload", &(_0, _1, _2));
         }
     };
 
     (@payload $self:ident, $error_name:ident, $format:expr, $t1:ty, $t2:ty, $t3:ty, $t4:ty) => {
         if let Self::$error_name(_0, _1, _2, _3) = &$self {
-            $format.field("payload", &(_0, _1, _2, _3));
+            return $format.field("payload", &(_0, _1, _2, _3));
         }
     };
 }

--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -146,11 +146,11 @@ mod tests {
         ];
 
         for error in errors {
-            let display = format!("{error}").replace('\n', &"\\n");
+            let display = format!("{error}");
             let compact_debug = format!("{error:?}");
             let expanded_debug = format!("{error:#?}");
-            assert!(compact_debug.contains(&display));
-            assert!(expanded_debug.contains(&display));
+            assert!(compact_debug.contains(&display.replace('\n', &"\\n")));
+            assert!(expanded_debug.contains(&display.replace('\n', &"\\n")));
         }
     }
 }

--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -65,7 +65,7 @@ macro_rules! error_messages {
 
             const fn name(&self) -> &'static str {
                 match self {$(
-                    Self::$error_name(..) => concat!(std::stringify!($name), "::", std::stringify!($error_name)),
+                    Self::$error_name(..) => concat!(stringify!($name), "::", stringify!($error_name)),
                 )*}
             }
         }
@@ -84,14 +84,15 @@ macro_rules! error_messages {
 
         impl std::fmt::Debug for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                let mut binding = f.debug_struct(self.name());
-                || { $(error_messages!(@payload
+                let mut debug_struct = f.debug_struct(self.name());
+                debug_struct.field("message", &format!("{}", self));
+                $(error_messages!(@payload
                     self,
                     $error_name,
-                    binding.field("message", &format!("{}", self))
-                    $(, $inner)*);
-                )* }();
-                binding.finish()
+                    debug_struct
+                    $(, $inner)*
+                );)*
+                debug_struct.finish()
             }
         }
 
@@ -128,33 +129,33 @@ macro_rules! error_messages {
         }
     };
 
-    (@payload $self:ident, $error_name:ident, $format:expr) => {
+    (@payload $self:ident, $error_name:ident, $debug_struct:expr) => {
         if let Self::$error_name() = &$self {
-            return $format.field("payload", &());
+            $debug_struct.field("payload", &());
         }
     };
 
-    (@payload $self:ident, $error_name:ident, $format:expr, $t1:ty) => {
+    (@payload $self:ident, $error_name:ident, $debug_struct:expr, $t1:ty) => {
         if let Self::$error_name(_0) = &$self {
-            return $format.field("payload", &(_0));
+            $debug_struct.field("payload", &(_0));
         }
     };
 
-    (@payload $self:ident, $error_name:ident, $format:expr, $t1:ty, $t2:ty) => {
+    (@payload $self:ident, $error_name:ident, $debug_struct:expr, $t1:ty, $t2:ty) => {
         if let Self::$error_name(_0, _1) = &$self {
-            return $format.field("payload", &(_0, _1));
+            $debug_struct.field("payload", &(_0, _1));
         }
     };
 
-    (@payload $self:ident, $error_name:ident, $format:expr, $t1:ty, $t2:ty, $t3:ty) => {
+    (@payload $self:ident, $error_name:ident, $debug_struct:expr, $t1:ty, $t2:ty, $t3:ty) => {
         if let Self::$error_name(_0, _1, _2) = &$self {
-            return $format.field("payload", &(_0, _1, _2));
+            $debug_struct.field("payload", &(_0, _1, _2));
         }
     };
 
-    (@payload $self:ident, $error_name:ident, $format:expr, $t1:ty, $t2:ty, $t3:ty, $t4:ty) => {
+    (@payload $self:ident, $error_name:ident, $debug_struct:expr, $t1:ty, $t2:ty, $t3:ty, $t4:ty) => {
         if let Self::$error_name(_0, _1, _2, _3) = &$self {
-            return $format.field("payload", &(_0, _1, _2, _3));
+            $debug_struct.field("payload", &(_0, _1, _2, _3));
         }
     };
 }

--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -68,6 +68,11 @@ macro_rules! error_messages {
                     Self::$error_name(..) => std::stringify!($error_name),
                 )*}
             }
+
+            const fn payload(&self) -> String {
+                $(error_messages!(@payload self, $error_name $(, $inner)*);)*
+                unreachable!()
+            }
         }
 
         impl std::fmt::Display for $name {
@@ -85,6 +90,7 @@ macro_rules! error_messages {
         impl std::fmt::Debug for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
                 f.debug_struct(&self.name())
+                    .field("payload", &self.payload())
                     .field("code", &self.code())
                     .field("message", &format!("{self}"))
                     .finish()
@@ -123,6 +129,36 @@ macro_rules! error_messages {
             return format!($body, _0, _1, _2, _3)
         }
     };
+
+    (@payload $self:ident, $error_name:ident) => {
+        if let Self::$error_name() = &$self {
+            return format!("{:?}", ())
+        }
+    };
+
+    (@payload $self:ident, $error_name:ident, $t1:ty) => {
+        if let Self::$error_name(_0) = &$self {
+            return format!("{:?}", (_0))
+        }
+    };
+
+    (@payload $self:ident, $error_name:ident, $t1:ty, $t2:ty) => {
+        if let Self::$error_name(_0, _1) = &$self {
+            return format!("{:?}", (_0, _1))
+        }
+    };
+
+    (@payload $self:ident, $error_name:ident, $t1:ty, $t2:ty, $t3:ty) => {
+        if let Self::$error_name(_0, _1, _2) = &$self {
+            return format!("{:?}", (_0, _1, _2))
+        }
+    };
+
+    (@payload $self:ident, $error_name:ident, $t1:ty, $t2:ty, $t3:ty, $t4:ty) => {
+        if let Self::$error_name(_0, _1, _2, _3) = &$self {
+            return format!("{:?}", (_0, _1, _2, _3))
+        }
+    };
 }
 
 #[cfg(test)]
@@ -152,5 +188,6 @@ mod tests {
             assert!(compact_debug.contains(&display.replace('\n', &"\\n")));
             assert!(expanded_debug.contains(&display.replace('\n', &"\\n")));
         }
+        panic!();
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?
We improve the debug formatting for macro-generated errors, by including more detail about the error. This solves issue https://github.com/vaticle/typedb-client-rust/issues/44

## What are the changes implemented in this PR?
We include the error code and error message in the debug format for macro-generated errors. We do this by explicitly implimenting `std::fmt::Debug`, inserting the error code and error message.
