### PR TITLE
Fix Rust parser for definables and variables

### DIFF
--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -159,7 +159,10 @@ pub(crate) fn visit_eof_patterns(patterns: &str) -> Result<Vec<Pattern>> {
 }
 
 pub(crate) fn visit_eof_definables(definables: &str) -> Result<Vec<Definable>> {
-    visit_definables(parse_single(Rule::eof_definables, definables)?).into_iter().map(Validatable::validated).collect()
+    visit_definables(parse_single(Rule::eof_definables, definables)?.into_children().consume_expected(Rule::definables))
+        .into_iter()
+        .map(Validatable::validated)
+        .collect()
 }
 
 pub(crate) fn visit_eof_variable(variable: &str) -> Result<Variable> {

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -163,7 +163,9 @@ pub(crate) fn visit_eof_definables(definables: &str) -> Result<Vec<Definable>> {
 }
 
 pub(crate) fn visit_eof_variable(variable: &str) -> Result<Variable> {
-    visit_pattern_variable(parse_single(Rule::eof_variable, variable)?).validated()
+    visit_pattern_variable(
+        parse_single(Rule::eof_variable, variable)?.into_children().consume_expected(Rule::pattern_variable)
+    ).validated()
 }
 
 pub(crate) fn visit_eof_label(label: &str) -> Result<Label> {

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -152,7 +152,7 @@ pub(crate) fn visit_eof_pattern(pattern: &str) -> Result<Pattern> {
 }
 
 pub(crate) fn visit_eof_patterns(patterns: &str) -> Result<Vec<Pattern>> {
-    visit_patterns(parse_single(Rule::eof_patterns, patterns)?.into_children().consume_expected(Rule::eof_patterns))
+    visit_patterns(parse_single(Rule::eof_patterns, patterns)?.into_children().consume_expected(Rule::patterns))
         .into_iter()
         .map(Validatable::validated)
         .collect()

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -164,8 +164,9 @@ pub(crate) fn visit_eof_definables(definables: &str) -> Result<Vec<Definable>> {
 
 pub(crate) fn visit_eof_variable(variable: &str) -> Result<Variable> {
     visit_pattern_variable(
-        parse_single(Rule::eof_variable, variable)?.into_children().consume_expected(Rule::pattern_variable)
-    ).validated()
+        parse_single(Rule::eof_variable, variable)?.into_children().consume_expected(Rule::pattern_variable),
+    )
+    .validated()
 }
 
 pub(crate) fn visit_eof_label(label: &str) -> Result<Label> {

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -31,7 +31,8 @@ use crate::{
         },
         validatable::Validatable,
     },
-    gte, lt, lte, not, or, parse_definables, parse_label, parse_pattern, parse_queries, parse_query, parse_variable,
+    gte, lt, lte, not, or, parse_definables, parse_label, parse_pattern, parse_patterns, parse_queries, parse_query,
+    parse_variable,
     pattern::{
         Annotation::Key, ConceptVariableBuilder, Conjunction, Disjunction, Label, RelationVariableBuilder,
         ThingVariableBuilder, TypeVariableBuilder, Variable,
@@ -1004,6 +1005,25 @@ fn test_parsing_pattern() {
     );
 
     assert_valid_eq_repr!(expected, parsed, pattern);
+}
+
+#[test]
+fn test_parsing_patterns() {
+    let patterns = r#"(wife: $a, husband: $b) isa marriage;
+    $a has gender "male";
+    $b has gender "female";
+"#;
+
+    let parsed = parse_patterns(patterns).unwrap().into_iter().map(|p| p.into_variable()).collect::<Vec<_>>();
+    let expected: Vec<Variable> = vec![
+        Variable::Thing(rel(("wife", "a")).rel(("husband", "b")).isa("marriage")),
+        Variable::Thing(var("a").has(("gender", "male"))),
+        Variable::Thing(var("b").has(("gender", "female"))),
+    ];
+
+    for i in 1..expected.len() {
+        assert_eq!(expected[i], parsed[i]);
+    }
 }
 
 #[test]

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -31,9 +31,9 @@ use crate::{
         },
         validatable::Validatable,
     },
-    gte, lt, lte, not, or, parse_label, parse_pattern, parse_queries, parse_query, parse_variable,
+    gte, lt, lte, not, or, parse_definables, parse_label, parse_pattern, parse_queries, parse_query, parse_variable,
     pattern::{
-        Annotation::Key, ConceptVariableBuilder, Conjunction, Disjunction, RelationVariableBuilder,
+        Annotation::Key, ConceptVariableBuilder, Conjunction, Disjunction, Label, RelationVariableBuilder,
         ThingVariableBuilder, TypeVariableBuilder, Variable,
     },
     query::{AggregateQueryBuilder, TypeQLDefine, TypeQLInsert, TypeQLMatch, TypeQLUndefine},
@@ -1060,6 +1060,15 @@ fn test_parse_variable_has() {
     } else {
         panic!("Expected ThingVariable, found {variable:?}.");
     }
+}
+
+#[test]
+fn test_parse_label() {
+    let label = "label_with-symbols";
+
+    let parsed = parse_label(label).unwrap();
+    let expected = Label { scope: None, name: String::from(label) };
+    assert_eq!(expected, parsed);
 }
 
 #[test]

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -31,10 +31,10 @@ use crate::{
         },
         validatable::Validatable,
     },
-    gte, lt, lte, not, or, parse_pattern, parse_queries, parse_query,
+    gte, lt, lte, not, or, parse_label, parse_pattern, parse_queries, parse_query, parse_variable,
     pattern::{
         Annotation::Key, ConceptVariableBuilder, Conjunction, Disjunction, RelationVariableBuilder,
-        ThingVariableBuilder, TypeVariableBuilder,
+        ThingVariableBuilder, TypeVariableBuilder, Variable,
     },
     query::{AggregateQueryBuilder, TypeQLDefine, TypeQLInsert, TypeQLMatch, TypeQLUndefine},
     rel, rule, type_, typeql_insert, typeql_match, var, Query,
@@ -1034,6 +1034,32 @@ rule a-rule: when {
         .then(var("x").has(("is_interesting", true))));
 
     assert_valid_eq_repr!(expected, parsed, query);
+}
+
+#[test]
+fn test_parse_variable_rel() {
+    let variable = "(wife: $a, husband: $b) isa marriage";
+
+    let parsed = parse_variable(variable).unwrap();
+    if let Variable::Thing(parsed_var) = parsed {
+        let expected = rel(("wife", "a")).rel(("husband", "b")).isa("marriage");
+        assert_valid_eq_repr!(expected, parsed_var, variable);
+    } else {
+        panic!("Expected ThingVariable, found {variable:?}.");
+    }
+}
+
+#[test]
+fn test_parse_variable_has() {
+    let variable = "$x has is_interesting true";
+
+    let parsed = parse_variable(variable).unwrap();
+    if let Variable::Thing(parsed_var) = parsed {
+        let expected = var("x").has(("is_interesting", true));
+        assert_valid_eq_repr!(expected, parsed_var, variable);
+    } else {
+        panic!("Expected ThingVariable, found {variable:?}.");
+    }
 }
 
 #[test]

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -1057,6 +1057,21 @@ rule a-rule: when {
 }
 
 #[test]
+fn test_parse_definables() {
+    let query = r#"athlete sub person;
+      runner sub athlete;
+      sprinter sub runner;"#;
+
+    let parsed = parse_definables(query).unwrap().into_iter().map(|p| p.into_type_variable()).collect::<Vec<_>>();
+    let expected =
+        vec![type_("athlete").sub("person"), type_("runner").sub("athlete"), type_("sprinter").sub("runner")];
+
+    for i in 1..expected.len() {
+        assert_eq!(expected[i], parsed[i]);
+    }
+}
+
+#[test]
 fn test_parse_variable_rel() {
     let variable = "(wife: $a, husband: $b) isa marriage";
 

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -73,7 +73,7 @@ get $a;"#;
 }
 
 #[test]
-fn test_parse_string_with_slash() {
+fn test_parsing_string_with_slash() {
     let query = r#"match
 $x isa person,
     has name "alice/bob";"#;
@@ -490,7 +490,7 @@ has-genre relates $p;"#;
 }
 
 #[test]
-fn test_parse_relates_type_variable() {
+fn test_parsing_relates_type_variable() {
     let query = r#"match
 $x isa $type;
 $type relates someRole;"#;
@@ -928,7 +928,7 @@ $x value double;"#;
 }
 
 #[test]
-fn test_parse_without_var() {
+fn test_parsing_without_var() {
     let query = r#"match
 $_ isa person;"#;
 
@@ -1021,9 +1021,7 @@ fn test_parsing_patterns() {
         Variable::Thing(var("b").has(("gender", "female"))),
     ];
 
-    for i in 1..expected.len() {
-        assert_eq!(expected[i], parsed[i]);
-    }
+    assert_eq!(expected, parsed);
 }
 
 #[test]
@@ -1057,7 +1055,7 @@ rule a-rule: when {
 }
 
 #[test]
-fn test_parse_definables() {
+fn test_parsing_definables() {
     let query = r#"athlete sub person;
       runner sub athlete;
       sprinter sub runner;"#;
@@ -1066,13 +1064,11 @@ fn test_parse_definables() {
     let expected =
         vec![type_("athlete").sub("person"), type_("runner").sub("athlete"), type_("sprinter").sub("runner")];
 
-    for i in 1..expected.len() {
-        assert_eq!(expected[i], parsed[i]);
-    }
+    assert_eq!(expected, parsed);
 }
 
 #[test]
-fn test_parse_variable_rel() {
+fn test_parsing_variable_rel() {
     let variable = "(wife: $a, husband: $b) isa marriage";
 
     let parsed = parse_variable(variable).unwrap();
@@ -1085,7 +1081,7 @@ fn test_parse_variable_rel() {
 }
 
 #[test]
-fn test_parse_variable_has() {
+fn test_parsing_variable_has() {
     let variable = "$x has is_interesting true";
 
     let parsed = parse_variable(variable).unwrap();
@@ -1098,7 +1094,7 @@ fn test_parse_variable_has() {
 }
 
 #[test]
-fn test_parse_label() {
+fn test_parsing_label() {
     let label = "label_with-symbols";
 
     let parsed = parse_label(label).unwrap();
@@ -1107,7 +1103,7 @@ fn test_parse_label() {
 }
 
 #[test]
-fn test_parse_boolean() {
+fn test_parsing_boolean() {
     let query = r#"insert
 $_ has flag true;"#;
 
@@ -1117,7 +1113,7 @@ $_ has flag true;"#;
 }
 
 #[test]
-fn test_parse_aggregate_group() {
+fn test_parsing_aggregate_group() {
     let query = r#"match
 $x isa movie;
 group $x;"#;
@@ -1129,7 +1125,7 @@ group $x;"#;
 }
 
 #[test]
-fn test_parse_aggregate_group_count() {
+fn test_parsing_aggregate_group_count() {
     let query = r#"match
 $x isa movie;
 group $x; count;"#;
@@ -1141,7 +1137,7 @@ group $x; count;"#;
 }
 
 #[test]
-fn test_parse_aggregate_std() {
+fn test_parsing_aggregate_std() {
     let query = r#"match
 $x isa movie;
 std $x;"#;
@@ -1153,7 +1149,7 @@ std $x;"#;
 }
 
 #[test]
-fn test_parse_aggregate_to_string() {
+fn test_parsing_aggregate_to_string() {
     let query = r#"match
 $x isa movie;
 get $x;
@@ -1163,7 +1159,7 @@ group $x; count;"#;
 }
 
 #[test]
-fn when_parse_incorrect_syntax_throw_typeql_syntax_exception_with_helpful_error() {
+fn when_parsing_incorrect_syntax_throw_typeql_syntax_exception_with_helpful_error() {
     let parsed = parse_query("match\n$x isa");
     assert!(parsed.is_err());
     let report = parsed.unwrap_err().to_string();
@@ -1174,7 +1170,7 @@ fn when_parse_incorrect_syntax_throw_typeql_syntax_exception_with_helpful_error(
 }
 
 #[test]
-fn when_parse_incorrect_syntax_trailing_query_whitespace_is_ignored() {
+fn when_parsing_incorrect_syntax_trailing_query_whitespace_is_ignored() {
     let parsed = parse_query("match\n$x isa \n");
     assert!(parsed.is_err());
     let report = parsed.unwrap_err().to_string();
@@ -1185,7 +1181,7 @@ fn when_parse_incorrect_syntax_trailing_query_whitespace_is_ignored() {
 }
 
 #[test]
-fn when_parse_incorrect_syntax_error_message_should_retain_whitespace() {
+fn when_parsing_incorrect_syntax_error_message_should_retain_whitespace() {
     let parsed = parse_query("match\n$x isa ");
     assert!(parsed.is_err());
     let report = parsed.unwrap_err().to_string();
@@ -1223,12 +1219,12 @@ $x regex "(fe)male";"#;
 }
 
 #[test]
-fn test_typeql_parse_query() {
+fn test_typeql_parsing_query() {
     assert!(matches!(parse_query("match\n$x isa movie;"), Ok(Query::Match(_))));
 }
 
 #[test]
-fn test_parse_key() {
+fn test_parsing_key() {
     let query = r#"match
 $x owns name @key;
 get $x;"#;
@@ -1239,12 +1235,12 @@ get $x;"#;
 }
 
 #[test]
-fn test_parse_empty_string() {
+fn test_parsing_empty_string() {
     assert!(parse_query("").is_err());
 }
 
 #[test]
-fn test_parse_list_one_match() {
+fn test_parsing_list_one_match() {
     let queries = "match $y isa movie;";
     let parsed = parse_queries(queries).unwrap().map(|q| q.unwrap().into_match()).collect::<Vec<_>>();
     let expected = vec![typeql_match!(var("y").isa("movie"))];
@@ -1252,7 +1248,7 @@ fn test_parse_list_one_match() {
 }
 
 #[test]
-fn test_parse_list_one_insert() {
+fn test_parsing_list_one_insert() {
     let queries = "insert $x isa movie;";
     let parsed = parse_queries(queries).unwrap().map(|q| q.unwrap().into_insert()).collect::<Vec<_>>();
     let expected = vec![typeql_insert!(var("x").isa("movie"))];
@@ -1260,7 +1256,7 @@ fn test_parse_list_one_insert() {
 }
 
 #[test]
-fn test_parse_list_one_insert_with_whitespace_prefix() {
+fn test_parsing_list_one_insert_with_whitespace_prefix() {
     let queries = " insert $x isa movie;";
     let parsed = parse_queries(queries).unwrap().map(|q| q.unwrap().into_insert()).collect::<Vec<_>>();
     let expected = vec![typeql_insert!(var("x").isa("movie"))];
@@ -1268,7 +1264,7 @@ fn test_parse_list_one_insert_with_whitespace_prefix() {
 }
 
 #[test]
-fn test_parse_list_one_insert_with_prefix_comment() {
+fn test_parsing_list_one_insert_with_prefix_comment() {
     let queries = r#"#hola
 insert $x isa movie;"#;
     let parsed = parse_queries(queries).unwrap().map(|q| q.unwrap().into_insert()).collect::<Vec<_>>();
@@ -1277,7 +1273,7 @@ insert $x isa movie;"#;
 }
 
 #[test]
-fn test_parse_list() {
+fn test_parsing_list() {
     let queries = "insert $x isa movie; match $y isa movie;";
     let parsed = parse_queries(queries).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
     let expected = vec![typeql_insert!(var("x").isa("movie")).into(), typeql_match!(var("y").isa("movie")).into()];
@@ -1285,7 +1281,7 @@ fn test_parse_list() {
 }
 
 #[test]
-fn test_parse_many_match_insert_without_stack_overflow() {
+fn test_parsing_many_match_insert_without_stack_overflow() {
     let num_queries = 10_000;
     let query = "match\n$x isa person; insert $x has name 'bob';\n";
     let queries = query.repeat(num_queries);


### PR DESCRIPTION
## What is the goal of this PR?

While parsing `Variable`, `visit_pattern_variable()` panicked because of incorrect argument format. We fixed it and added unit tests. Similar errors ware while parsing `definables` and `patterns`.

## What are the changes implemented in this PR?

- We extracted subtree with `pattern_variable` as a root before passing it to `visit_pattern_variable()`.
- We extracted subtree with `definables` as a root before passing it to `visit_definables()`.
- We fixed an error in `visit_eof_patterns()` function: it tried to extract `eof_patterns` instead of `patterns`.
- We added unit test for parse functions that wasn't covered.
