### PR TITLE
Relation variable name in rule 'then' must not be present.

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -17,6 +17,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
+
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
@@ -34,6 +35,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "767bf98fef7383addf42a1ae6e97a44874bb4f0b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/shiladitya-mukherjee/typedb-behaviour",
+        commit = "1cb48d28fa5bd75308260c48c8d4ad478c0a7e49", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -17,7 +17,6 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,6 +35,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/shiladitya-mukherjee/typedb-behaviour",
-        commit = "1cb48d28fa5bd75308260c48c8d4ad478c0a7e49", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "19c835840f8bb992dfcea4a80f6b518b1b577ae3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -91,8 +91,8 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
             new ErrorMessage(34, "Rule '%s' 'then' variables must be present in the 'when', outside of nested patterns.");
     public static final ErrorMessage INVALID_RULE_THEN_ROLES =
             new ErrorMessage(35, "Rule '%s' 'then' '%s' must specify all role types explicitly or by using a variable.");
-    public static final ErrorMessage INVALID_RULE_THEN_EXPLICIT_VARIABLE =
-            new ErrorMessage(36, "Rule '%s': relation variable '%s' in 'then' must not be explicit.");
+    public static final ErrorMessage INVALID_RULE_THEN_RELATION_VARIABLE =
+            new ErrorMessage(36, "Rule '%s': relation variable name '%s' in 'then' must not be present.");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =
             new ErrorMessage(37, "Invalid query containing redundant nested negations.");
     public static final ErrorMessage VARIABLE_NOT_SORTED =

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -91,7 +91,7 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
             new ErrorMessage(34, "Rule '%s' 'then' variables must be present in the 'when', outside of nested patterns.");
     public static final ErrorMessage INVALID_RULE_THEN_ROLES =
             new ErrorMessage(35, "Rule '%s' 'then' '%s' must specify all role types explicitly or by using a variable.");
-    public static final ErrorMessage   RELATION_IN_THEN_NOT_ANONYMOUS =
+    public static final ErrorMessage INVALID_RULE_THEN_EXPLICIT_VARIABLE =
             new ErrorMessage(36, "Rule '%s': relation variable '%s' in 'then' must not be explicit.");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =
             new ErrorMessage(37, "Invalid query containing redundant nested negations.");

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -105,6 +105,8 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
             new ErrorMessage(41, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
     public static final ErrorMessage INVALID_ANNOTATION =
             new ErrorMessage(42, "Invalid annotation '%s' on '%s' constraint");
+    public static final ErrorMessage RELATION_NOT_ANONYMOUS =
+            new ErrorMessage(43, "Relation in then clause should be anonymous");
 
     private static final String codePrefix = "TQL";
     private static final String messagePrefix = "TypeQL Error";

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -92,7 +92,7 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
     public static final ErrorMessage INVALID_RULE_THEN_ROLES =
             new ErrorMessage(35, "Rule '%s' 'then' '%s' must specify all role types explicitly or by using a variable.");
     public static final ErrorMessage   RELATION_IN_THEN_NOT_ANONYMOUS =
-            new ErrorMessage(36, "Relation in then clause used to infer new relations should be anonymous");
+            new ErrorMessage(36, "Rule '%s': relation variable '%s' in 'then' must not be explicit.");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =
             new ErrorMessage(37, "Invalid query containing redundant nested negations.");
     public static final ErrorMessage VARIABLE_NOT_SORTED =

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -91,22 +91,22 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
             new ErrorMessage(34, "Rule '%s' 'then' variables must be present in the 'when', outside of nested patterns.");
     public static final ErrorMessage INVALID_RULE_THEN_ROLES =
             new ErrorMessage(35, "Rule '%s' 'then' '%s' must specify all role types explicitly or by using a variable.");
+    public static final ErrorMessage   RELATION_IN_THEN_NOT_ANONYMOUS =
+            new ErrorMessage(36, "Relation in then clause used to infer new relations should be anonymous");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =
-            new ErrorMessage(36, "Invalid query containing redundant nested negations.");
+            new ErrorMessage(37, "Invalid query containing redundant nested negations.");
     public static final ErrorMessage VARIABLE_NOT_SORTED =
-            new ErrorMessage(37, "Variable '%s' does not exist in the sorting clause.");
+            new ErrorMessage(38, "Variable '%s' does not exist in the sorting clause.");
     public static final ErrorMessage INVALID_SORTING_ORDER =
-            new ErrorMessage(38, "Invalid sorting order '%s'. Valid options: '%s' or '%s'.");
+            new ErrorMessage(39, "Invalid sorting order '%s'. Valid options: '%s' or '%s'.");
     public static final ErrorMessage INVALID_COUNT_VARIABLE_ARGUMENT =
-            new ErrorMessage(39, "Aggregate COUNT does not accept a Variable.");
+            new ErrorMessage(40, "Aggregate COUNT does not accept a Variable.");
     public static final ErrorMessage ILLEGAL_GRAMMAR =
-            new ErrorMessage(40, "Illegal grammar!");
+            new ErrorMessage(41, "Illegal grammar!");
     public static final ErrorMessage ILLEGAL_CHAR_IN_LABEL =
-            new ErrorMessage(41, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
+            new ErrorMessage(42, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
     public static final ErrorMessage INVALID_ANNOTATION =
-            new ErrorMessage(42, "Invalid annotation '%s' on '%s' constraint");
-    public static final ErrorMessage RELATION_NOT_ANONYMOUS =
-            new ErrorMessage(43, "Relation in then clause used to infer new relations should be anonymous");
+            new ErrorMessage(43, "Invalid annotation '%s' on '%s' constraint");
 
     private static final String codePrefix = "TQL";
     private static final String messagePrefix = "TypeQL Error";

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -106,7 +106,7 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
     public static final ErrorMessage INVALID_ANNOTATION =
             new ErrorMessage(42, "Invalid annotation '%s' on '%s' constraint");
     public static final ErrorMessage RELATION_NOT_ANONYMOUS =
-            new ErrorMessage(43, "Relation in then clause should be anonymous");
+            new ErrorMessage(43, "Relation in then clause used to infer new relations should be anonymous");
 
     private static final String codePrefix = "TQL";
     private static final String messagePrefix = "TypeQL Error";

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -52,7 +52,7 @@ import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_VARIABLES;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_MISSING_PATTERNS;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_NESTED_NEGATION;
-import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_EXPLICIT_VARIABLE;
+import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_RELATION_VARIABLE;
 import static com.vaticle.typeql.lang.common.util.Strings.indent;
 
 public class Rule implements Definable {
@@ -165,9 +165,9 @@ public class Rule implements Definable {
             throw TypeQLException.of(INVALID_RULE_THEN_ROLES.message(label, then));
         }
 
-        // relation variable in 'then' must not be explicit
+        // relation variable name in 'then' must not be present
         if (then.relation().isPresent() && then.reference().isName()) {
-            throw TypeQLException.of(INVALID_RULE_THEN_EXPLICIT_VARIABLE.message(label, then.reference()));
+            throw TypeQLException.of(INVALID_RULE_THEN_RELATION_VARIABLE.message(label, then.reference()));
         }
     }
 

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -164,7 +164,8 @@ public class Rule implements Definable {
                 .reduce(true, Boolean::logicalAnd)) {
             throw TypeQLException.of(INVALID_RULE_THEN_ROLES.message(label, then));
         }
-        // variable declared in when cannot be redeclared in then
+
+        // relation variables used to infer new relations in then clause should be anonymous
         if (then.relation().isPresent())
         {
             if (then.reference().isName())

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -165,12 +165,11 @@ public class Rule implements Definable {
             throw TypeQLException.of(INVALID_RULE_THEN_ROLES.message(label, then));
         }
 
-        // relation variables used to infer new relations in then clause should be anonymous
+        // relation variable in 'then' must not be explicit
         if (then.relation().isPresent()&&then.reference().isName()) {
-                throw TypeQLException.of(RELATION_IN_THEN_NOT_ANONYMOUS.message(label, then));
+                throw TypeQLException.of(RELATION_IN_THEN_NOT_ANONYMOUS.message(label, then.reference()));
         }
     }
-
 
     @Override
     public String toString() {

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -166,8 +166,8 @@ public class Rule implements Definable {
         }
 
         // relation variable in 'then' must not be explicit
-        if (then.relation().isPresent()&&then.reference().isName()) {
-                throw TypeQLException.of(INVALID_RULE_THEN_EXPLICIT_VARIABLE.message(label, then.reference()));
+        if (then.relation().isPresent() && then.reference().isName()) {
+            throw TypeQLException.of(INVALID_RULE_THEN_EXPLICIT_VARIABLE.message(label, then.reference()));
         }
     }
 

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -52,6 +52,7 @@ import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_VARIABLES;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_MISSING_PATTERNS;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_NESTED_NEGATION;
+import static com.vaticle.typeql.lang.common.exception.ErrorMessage.RELATION_NOT_ANONYMOUS;
 import static com.vaticle.typeql.lang.common.util.Strings.indent;
 
 public class Rule implements Definable {
@@ -163,7 +164,14 @@ public class Rule implements Definable {
                 .reduce(true, Boolean::logicalAnd)) {
             throw TypeQLException.of(INVALID_RULE_THEN_ROLES.message(label, then));
         }
+        // variable declared in when cannot be redeclared in then
+        if (then.relation().isPresent())
+        {
+            if (then.reference().isName())
+                throw TypeQLException.of(RELATION_NOT_ANONYMOUS.message(label, then));
+        }
     }
+
 
     @Override
     public String toString() {

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -52,7 +52,7 @@ import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_VARIABLES;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_MISSING_PATTERNS;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_NESTED_NEGATION;
-import static com.vaticle.typeql.lang.common.exception.ErrorMessage.RELATION_IN_THEN_NOT_ANONYMOUS;
+import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_EXPLICIT_VARIABLE;
 import static com.vaticle.typeql.lang.common.util.Strings.indent;
 
 public class Rule implements Definable {
@@ -167,7 +167,7 @@ public class Rule implements Definable {
 
         // relation variable in 'then' must not be explicit
         if (then.relation().isPresent()&&then.reference().isName()) {
-                throw TypeQLException.of(RELATION_IN_THEN_NOT_ANONYMOUS.message(label, then.reference()));
+                throw TypeQLException.of(INVALID_RULE_THEN_EXPLICIT_VARIABLE.message(label, then.reference()));
         }
     }
 

--- a/java/pattern/schema/Rule.java
+++ b/java/pattern/schema/Rule.java
@@ -52,7 +52,7 @@ import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_THEN_VARIABLES;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_MISSING_PATTERNS;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_RULE_WHEN_NESTED_NEGATION;
-import static com.vaticle.typeql.lang.common.exception.ErrorMessage.RELATION_NOT_ANONYMOUS;
+import static com.vaticle.typeql.lang.common.exception.ErrorMessage.RELATION_IN_THEN_NOT_ANONYMOUS;
 import static com.vaticle.typeql.lang.common.util.Strings.indent;
 
 public class Rule implements Definable {
@@ -166,10 +166,8 @@ public class Rule implements Definable {
         }
 
         // relation variables used to infer new relations in then clause should be anonymous
-        if (then.relation().isPresent())
-        {
-            if (then.reference().isName())
-                throw TypeQLException.of(RELATION_NOT_ANONYMOUS.message(label, then));
+        if (then.relation().isPresent()&&then.reference().isName()) {
+                throw TypeQLException.of(RELATION_IN_THEN_NOT_ANONYMOUS.message(label, then));
         }
     }
 

--- a/java/test/behaviour/typeql/TypeQLSteps.java
+++ b/java/test/behaviour/typeql/TypeQLSteps.java
@@ -139,6 +139,7 @@ public class TypeQLSteps {
     @Given("for each session, open transactions of type: {}")
     @Given("for each session, open transactions with reasoning of type: {}")
     @Given("verify answers are consistent across {} executions")
+    @Given("set time-zone is: {}")
     public void do_nothing_with_arg(String ignored) { }
 
     @Given("connection open data sessions for databases:")


### PR DESCRIPTION
## What is the goal of this PR?

Check that relation variables used to infer new relations in then clause should be anonymous

## What are the changes implemented in this PR?

- Updated TypeDB behaviour dependency.
- Added error message to display in case of exception thrown from the check.
- Added test to check if the relation reference variable in then clause is anonymous.