### PR TITLE
Sanitise rust macros to avoid forcing user's environment

### DIFF
--- a/rust/builder/mod.rs
+++ b/rust/builder/mod.rs
@@ -32,35 +32,35 @@ use crate::{
 #[macro_export]
 macro_rules! typeql_match {
     ($($pattern:expr),* $(,)?) => {{
-        TypeQLMatch::from_patterns(vec![$($pattern.into()),*])
+        $crate::query::TypeQLMatch::from_patterns(vec![$($pattern.into()),*])
     }}
 }
 
 #[macro_export]
 macro_rules! typeql_insert {
     ($($thing_variable:expr),* $(,)?) => {{
-        TypeQLInsert::new(vec![$($thing_variable),*])
+        $crate::query::TypeQLInsert::new(vec![$($thing_variable),*])
     }}
 }
 
 #[macro_export]
 macro_rules! typeql_define {
     ($($pattern:expr),* $(,)?) => {{
-        TypeQLDefine::new(vec![$($pattern.into()),*])
+        $crate::query::TypeQLDefine::new(vec![$($pattern.into()),*])
     }}
 }
 
 #[macro_export]
 macro_rules! typeql_undefine {
     ($($pattern:expr),* $(,)?) => {{
-        TypeQLUndefine::new(vec![$($pattern.into()),*])
+        $crate::query::TypeQLUndefine::new(vec![$($pattern.into()),*])
     }}
 }
 
 #[macro_export]
 macro_rules! and {
     ($($pattern:expr),* $(,)?) => {{
-        Conjunction::new(vec![$($pattern.into()),*])
+        $crate::pattern::Conjunction::new(vec![$($pattern.into()),*])
     }}
 }
 
@@ -70,7 +70,7 @@ macro_rules! or {
         let mut patterns = vec![$($pattern.into()),*];
         match patterns.len() {
             1 => patterns.pop().unwrap(),
-            _ => Disjunction::new(patterns).into(),
+            _ => $crate::pattern::Disjunction::new(patterns).into(),
         }
     }}
 }

--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -166,9 +166,9 @@ macro_rules! error_messages {
     };
 }
 
+#[allow(dead_code)]
 #[cfg(test)]
 mod tests {
-    use std::fmt::Debug;
     error_messages! { TestError
         code: "TST", type: "Test Error",
         BasicError() =

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -34,10 +34,10 @@ use crate::{
     gte, lt, lte, not, or, parse_definables, parse_label, parse_pattern, parse_patterns, parse_queries, parse_query,
     parse_variable,
     pattern::{
-        Annotation::Key, ConceptVariableBuilder, Conjunction, Disjunction, Label, RelationVariableBuilder,
-        ThingVariableBuilder, TypeVariableBuilder, Variable,
+        Annotation::Key, ConceptVariableBuilder, Label, RelationVariableBuilder, ThingVariableBuilder,
+        TypeVariableBuilder, Variable,
     },
-    query::{AggregateQueryBuilder, TypeQLDefine, TypeQLInsert, TypeQLMatch, TypeQLUndefine},
+    query::AggregateQueryBuilder,
     rel, rule, type_, typeql_insert, typeql_match, var, Query,
 };
 

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -51,7 +51,7 @@ pub use variable::{
 };
 
 use crate::{
-    common::{error::TypeQLError, validatable::Validatable, Result},
+    common::{validatable::Validatable, Result},
     enum_getter, enum_wrapper,
 };
 

--- a/rust/pattern/test/mod.rs
+++ b/rust/pattern/test/mod.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     and, not, or, parse_query,
-    pattern::{Conjunction, Disjunction, Normalisable, ThingVariableBuilder},
+    pattern::{Disjunction, Normalisable, ThingVariableBuilder},
     var,
 };
 

--- a/rust/query/mod.rs
+++ b/rust/query/mod.rs
@@ -43,7 +43,7 @@ pub use typeql_update::TypeQLUpdate;
 pub use writable::Writable;
 
 use crate::{
-    common::{error::TypeQLError, validatable::Validatable, Result},
+    common::{validatable::Validatable, Result},
     enum_getter, enum_wrapper,
 };
 

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -36,7 +36,7 @@ macro_rules! enum_getter {
             pub fn $fn_name(self) -> $classname {
                 match self {
                     Self::$enum_variant(x) => x,
-                    _ => panic!("{}", TypeQLError::InvalidCasting(
+                    _ => panic!("{}", $crate::common::error::TypeQLError::InvalidCasting(
                         stringify!($enum_name),
                         self.enum_getter_get_name(),
                         stringify!($enum_variant),


### PR DESCRIPTION
## What is the goal of this PR?

Problem is described in #298: we have macros that need access to other items in our crate. Paths to these items were not absolute, and users had to import that particular items and were able to use their own objects with the same names and use it in the macros. Now all paths are absolute, based on the `$crate` metavariable.

## What are the changes implemented in this PR?

- We updated all macros that need access to other items in the crate.
- We removed redundant imports. 

closes #298
