### PR TITLE
Update pest 2.4.0 => 2.7.4 

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "cca04c5dfcff32e09f9e74d4e0aa90acbd023c23", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/dmitrii-ubskii/vaticle-dependencies",
+        commit = "ce0b804565aac066fc2e90e3b8c8850c54c0e19a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/dmitrii-ubskii/vaticle-dependencies",
-        commit = "ce0b804565aac066fc2e90e3b8c8850c54c0e19a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "fcc9a56b65e6ab69bbf0f1680affe38e12617ed6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -36,10 +36,10 @@ use crate::{
     filter, gte, lt, lte, min, not, or, parse_definables, parse_label, parse_pattern, parse_patterns, parse_queries,
     parse_query, parse_variable,
     pattern::{
-        Annotation::Key, ConceptVariableBuilder, Conjunction, Disjunction, ExpressionBuilder, Label,
-        RelationVariableBuilder, ThingVariableBuilder, TypeVariableBuilder, ValueVariableBuilder, Variable,
+        Annotation::Key, ConceptVariableBuilder, ExpressionBuilder, Label, RelationVariableBuilder,
+        ThingVariableBuilder, TypeVariableBuilder, ValueVariableBuilder, Variable,
     },
-    query::{AggregateQueryBuilder, TypeQLDefine, TypeQLInsert, TypeQLMatch, TypeQLUndefine},
+    query::AggregateQueryBuilder,
     rel, rule, sort_vars, type_, typeql_insert, typeql_match, Query,
 };
 

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -436,9 +436,9 @@ $a == ?x isa age;"#;
 
 #[test]
 fn test_parsing_variable_name_clash_throws() {
-    let query = r#"match\n
+    let query = r"match\n
 $z isa person, has age $y;
-?y = $y;"#;
+?y = $y;";
 
     let parsed = parse_query(query);
     assert!(parsed.is_err());
@@ -1690,7 +1690,7 @@ digit sub attribute,
     regex "\d";"#;
 
     let parsed = parse_query(query).unwrap().into_define();
-    let expected = typeql_define!(type_("digit").sub("attribute").regex(r#"\d"#));
+    let expected = typeql_define!(type_("digit").sub("attribute").regex(r"\d"));
 
     assert_valid_eq_repr!(expected, parsed, query);
 }
@@ -1701,7 +1701,7 @@ fn undefine_attribute_type_regex() {
 digit regex "\d";"#;
 
     let parsed = parse_query(query).unwrap().into_undefine();
-    let expected = typeql_undefine!(type_("digit").regex(r#"\d"#));
+    let expected = typeql_undefine!(type_("digit").regex(r"\d"));
     assert_valid_eq_repr!(expected, parsed, query);
 }
 

--- a/rust/pattern/test/mod.rs
+++ b/rust/pattern/test/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     and,
     builder::cvar,
     not, or, parse_query,
-    pattern::{Conjunction, Disjunction, Normalisable, ThingVariableBuilder},
+    pattern::{Disjunction, Normalisable, ThingVariableBuilder},
 };
 
 #[test]


### PR DESCRIPTION
## What is the goal of this PR?

We update to pest and pest-derive v2.7.4, which among other things purports to fix the error where [deriving Parser fails on "undeclared crate or module `alloc`"](https://github.com/pest-parser/pest/issues/899) (https://github.com/pest-parser/pest/pull/900).

## What are the changes implemented in this PR?

We also clean up some compile warnings (unused imports and hashes).