### PR TITLE
Technical debt: improve error_messages, cleanup

### DIFF
--- a/rust/builder/mod.rs
+++ b/rust/builder/mod.rs
@@ -83,7 +83,7 @@ macro_rules! max {
         let args = [$($arg, )*];
         $crate::pattern::Expression::Function($crate::pattern::Function {
             function_name: $crate::common::token::Function::Max,
-            args: args.into_iter().map(|arg| Box::new(arg.into())).collect(),
+            args: args.into_iter().map(Into::into).collect(),
         })
     }}
 }
@@ -94,7 +94,7 @@ macro_rules! min {
         let args = [$($arg, )*];
         $crate::pattern::Expression::Function($crate::pattern::Function {
             function_name: token::Function::Min,
-            args: args.into_iter().map(|arg| Box::new(arg.into())).collect(),
+            args: args.into_iter().map(Into::into).collect(),
         })
     }}
 }
@@ -178,17 +178,17 @@ pub fn like<T: Into<String>>(value: T) -> Predicate {
 }
 
 pub fn abs<T: Into<Expression>>(arg: T) -> Function {
-    Function { function_name: token::Function::Abs, args: vec![Box::from(arg.into())] }
+    Function { function_name: token::Function::Abs, args: vec![arg.into()] }
 }
 
 pub fn ceil<T: Into<Expression>>(arg: T) -> Function {
-    Function { function_name: token::Function::Ceil, args: vec![Box::from(arg.into())] }
+    Function { function_name: token::Function::Ceil, args: vec![arg.into()] }
 }
 
 pub fn floor<T: Into<Expression>>(arg: T) -> Function {
-    Function { function_name: token::Function::Floor, args: vec![Box::from(arg.into())] }
+    Function { function_name: token::Function::Floor, args: vec![arg.into()] }
 }
 
 pub fn round<T: Into<Expression>>(arg: T) -> Function {
-    Function { function_name: token::Function::Round, args: vec![Box::from(arg.into())] }
+    Function { function_name: token::Function::Round, args: vec![arg.into()] }
 }

--- a/rust/builder/mod.rs
+++ b/rust/builder/mod.rs
@@ -33,37 +33,37 @@ use crate::{
 
 #[macro_export]
 macro_rules! typeql_match {
-    ($($pattern:expr),* $(,)?) => {{
-        $crate::query::MatchClause::from_patterns(vec![$($pattern.into()),*])
-    }}
+    ($($pattern:expr),* $(,)?) => {
+        $crate::query::MatchClause::new($crate::pattern::Conjunction::new(vec![$($pattern.into()),*]))
+    }
 }
 
 #[macro_export]
 macro_rules! typeql_insert {
-    ($($thing_statement:expr),* $(,)?) => {{
+    ($($thing_statement:expr),* $(,)?) => {
         $crate::query::TypeQLInsert::new(vec![$($thing_statement),*])
-    }}
+    }
 }
 
 #[macro_export]
 macro_rules! typeql_define {
-    ($($pattern:expr),* $(,)?) => {{
+    ($($pattern:expr),* $(,)?) => {
         $crate::query::TypeQLDefine::new(vec![$($pattern.into()),*])
-    }}
+    }
 }
 
 #[macro_export]
 macro_rules! typeql_undefine {
-    ($($pattern:expr),* $(,)?) => {{
+    ($($pattern:expr),* $(,)?) => {
         $crate::query::TypeQLUndefine::new(vec![$($pattern.into()),*])
-    }}
+    }
 }
 
 #[macro_export]
 macro_rules! and {
-    ($($pattern:expr),* $(,)?) => {{
+    ($($pattern:expr),* $(,)?) => {
         $crate::pattern::Conjunction::new(vec![$($pattern.into()),*])
-    }}
+    }
 }
 
 #[macro_export]
@@ -80,10 +80,9 @@ macro_rules! or {
 #[macro_export]
 macro_rules! max {
     ($($arg:expr),* $(,)?) => {{
-        let args = [$($arg, )*];
         $crate::pattern::Expression::Function($crate::pattern::Function {
             function_name: $crate::common::token::Function::Max,
-            args: args.into_iter().map(Into::into).collect(),
+            args: vec![$($arg.into()),*],
         })
     }}
 }
@@ -91,10 +90,9 @@ macro_rules! max {
 #[macro_export]
 macro_rules! min {
     ($($arg:expr),* $(,)?) => {{
-        let args = [$($arg, )*];
         $crate::pattern::Expression::Function($crate::pattern::Function {
             function_name: token::Function::Min,
-            args: args.into_iter().map(Into::into).collect(),
+            args: vec![$($arg.into()),*],
         })
     }}
 }
@@ -102,14 +100,14 @@ macro_rules! min {
 #[macro_export]
 macro_rules! filter {
     ($($arg:expr),* $(,)?) => {{
-        [$(Into::<$crate::pattern::UnboundVariable>::into($arg)),*]
+        [$($crate::pattern::UnboundVariable::from($arg)),*]
     }}
 }
 
 #[macro_export]
 macro_rules! sort_vars {
     ($($arg:expr),*) => {{
-        $crate::query::Sorting::new(vec![$(Into::<$crate::query::sorting::SortVariable>::into($arg), )*])
+        $crate::query::Sorting::new(vec![$($crate::query::sorting::SortVariable::from($arg), )*])
     }}
 }
 

--- a/rust/builder/mod.rs
+++ b/rust/builder/mod.rs
@@ -141,7 +141,7 @@ pub fn label(name: impl Into<ProjectionKeyLabel>) -> ProjectionKeyLabel {
 }
 
 pub fn rel<T: Into<RolePlayerConstraint>>(value: T) -> ThingStatement {
-    ConceptVariable::hidden().rel(value)
+    ConceptVariable::Hidden.rel(value)
 }
 
 pub fn eq<T: Into<Value>>(value: T) -> Predicate {

--- a/rust/builder/mod.rs
+++ b/rust/builder/mod.rs
@@ -69,7 +69,6 @@ macro_rules! and {
 #[macro_export]
 macro_rules! or {
     ($pattern:expr $(,)?) => { 
-        // $pattern.into()
         compile_error!("Useless disjunction of one pattern");
     };
 

--- a/rust/builder/mod.rs
+++ b/rust/builder/mod.rs
@@ -68,7 +68,7 @@ macro_rules! and {
 
 #[macro_export]
 macro_rules! or {
-    ($pattern:expr $(,)?) => { 
+    ($pattern:expr $(,)?) => {
         compile_error!("Useless disjunction of one pattern");
     };
 

--- a/rust/builder/mod.rs
+++ b/rust/builder/mod.rs
@@ -68,13 +68,14 @@ macro_rules! and {
 
 #[macro_export]
 macro_rules! or {
-    ($($pattern:expr),* $(,)?) => {{
-        let mut patterns = vec![$($pattern.into()),*];
-        match patterns.len() {
-            1 => patterns.pop().unwrap(),
-            _ => $crate::pattern::Disjunction::new(patterns).into(),
-        }
-    }}
+    ($pattern:expr $(,)?) => { 
+        // $pattern.into()
+        compile_error!("Useless disjunction of one pattern");
+    };
+
+    ($($pattern:expr),+ $(,)?) => {
+        $crate::pattern::Disjunction::new(vec![$($pattern.into()),*])
+    };
 }
 
 #[macro_export]

--- a/rust/common/error/macros.rs
+++ b/rust/common/error/macros.rs
@@ -24,11 +24,11 @@
 macro_rules! error_messages {
     {
         $name:ident code: $code_pfx:literal, type: $message_pfx:literal,
-        $($error_name:ident $(( $($inner:ty),* $(,)? ))? = $code:literal: $body:literal),+ $(,)?
+        $($error_name:ident $({ $($field:ident : $inner:ty),+ $(,)? })? = $code:literal: $body:literal),+ $(,)?
     } => {
         #[derive(Clone, Eq, PartialEq)]
         pub enum $name {$(
-            $error_name $( ( $($inner),* ) )?,
+            $error_name$( { $($field: $inner),+ })?,
         )*}
 
         impl $name {
@@ -36,7 +36,7 @@ macro_rules! error_messages {
 
             pub const fn code(&self) -> usize {
                 match self {$(
-                    Self::$error_name $( (error_messages!(@rest $($inner),*)) )? => $code,
+                    Self::$error_name $({ $($field: _),+ })? => $code,
                 )*}
             }
 
@@ -45,8 +45,9 @@ macro_rules! error_messages {
             }
 
             pub fn message(&self) -> String {
-                $(error_messages!(@format self, $error_name, $body $($(, $inner)*)?);)*
-                unreachable!()
+                match self {$(
+                    Self::$error_name $({$($field),+})? => format!($body $($(, $field = $field)+)?),
+                )*}
             }
 
             const fn max_code() -> usize {
@@ -71,7 +72,7 @@ macro_rules! error_messages {
 
             const fn name(&self) -> &'static str {
                 match self {$(
-                    Self::$error_name $( (error_messages!(@rest $($inner),*)) )? => concat!(stringify!($name), "::", stringify!($error_name)),
+                    Self::$error_name $({ $($field: _),+ })? => concat!(stringify!($name), "::", stringify!($error_name)),
                 )*}
             }
         }
@@ -92,12 +93,13 @@ macro_rules! error_messages {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct(self.name());
                 debug_struct.field("message", &format!("{}", self));
-                $(error_messages!(@payload
-                    self,
-                    $error_name,
-                    debug_struct
-                    $($(, $inner)*)?
-                );)*
+                $(
+                    $(
+                        if let Self::$error_name { $($field),+ } = &self {
+                            $(debug_struct.field(stringify!($field), &$field);)+
+                        }
+                    )?
+                )*
                 debug_struct.finish()
             }
         }
@@ -106,64 +108,6 @@ macro_rules! error_messages {
             fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
                 None
             }
-        }
-    };
-
-    (@rest $($inner:ty),*) => { .. };
-
-    (@format $self:ident, $error_name:ident, $body:literal) => {
-        if &Self::$error_name == $self {
-            return format!($body)
-        }
-    };
-    (@format $self:ident, $error_name:ident, $body:literal, $t1:ty) => {
-        if let Self::$error_name(_0) = &$self {
-            return format!($body, _0)
-        }
-    };
-    (@format $self:ident, $error_name:ident, $body:literal, $t1:ty, $t2:ty) => {
-        if let Self::$error_name(_0, _1) = &$self {
-            return format!($body, _0, _1)
-        }
-    };
-    (@format $self:ident, $error_name:ident, $body:literal, $t1:ty, $t2:ty, $t3:ty) => {
-        if let Self::$error_name(_0, _1, _2) = &$self {
-            return format!($body, _0, _1, _2)
-        }
-    };
-    (@format $self:ident, $error_name:ident, $body:literal, $t1:ty, $t2:ty, $t3:ty, $t4:ty) => {
-        if let Self::$error_name(_0, _1, _2, _3) = &$self {
-            return format!($body, _0, _1, _2, _3)
-        }
-    };
-
-    (@payload $self:ident, $error_name:ident, $debug_struct:expr) => {
-        if let Self::$error_name = &$self {
-            $debug_struct.field("payload", &());
-        }
-    };
-
-    (@payload $self:ident, $error_name:ident, $debug_struct:expr, $t1:ty) => {
-        if let Self::$error_name(_0) = &$self {
-            $debug_struct.field("payload", &(_0));
-        }
-    };
-
-    (@payload $self:ident, $error_name:ident, $debug_struct:expr, $t1:ty, $t2:ty) => {
-        if let Self::$error_name(_0, _1) = &$self {
-            $debug_struct.field("payload", &(_0, _1));
-        }
-    };
-
-    (@payload $self:ident, $error_name:ident, $debug_struct:expr, $t1:ty, $t2:ty, $t3:ty) => {
-        if let Self::$error_name(_0, _1, _2) = &$self {
-            $debug_struct.field("payload", &(_0, _1, _2));
-        }
-    };
-
-    (@payload $self:ident, $error_name:ident, $debug_struct:expr, $t1:ty, $t2:ty, $t3:ty, $t4:ty) => {
-        if let Self::$error_name(_0, _1, _2, _3) = &$self {
-            $debug_struct.field("payload", &(_0, _1, _2, _3));
         }
     };
 }
@@ -175,8 +119,8 @@ mod tests {
         code: "TST", type: "Test Error",
         BasicError =
             1: "This is a basic error.",
-        ErrorWithAttributes(i32, String) =
-            2: "This is an error with i32 {} and string '{}'.",
+        ErrorWithAttributes { int: i32, string: String } =
+            2: "This is an error with i32 {int} and string '{string}'.",
         MultiLine =
             3: "This is an error,\nthat spans,\nmultiple lines."
     }
@@ -185,7 +129,7 @@ mod tests {
     pub fn debug_includes_display() {
         let errors = [
             TestError::BasicError,
-            TestError::ErrorWithAttributes(1, "error message".to_string()),
+            TestError::ErrorWithAttributes { int: 1, string: "error message".to_string() },
             TestError::MultiLine,
         ];
 

--- a/rust/common/error/mod.rs
+++ b/rust/common/error/mod.rs
@@ -109,7 +109,7 @@ error_messages! { TypeQLError
     MatchHasNoBoundingNamedVariable =
         7: "The match query does not have named variables to bound the nested disjunction/negation pattern(s).",
     VariableNameConflict { names: String } =
-        8: "The variable names '{names}' cannot be used for both concept variables and value variables.",
+        8: "The variable names {names} cannot be used for both concept variables and value variables.",
     MatchStatementHasNoNamedVariable { pattern: Pattern } =
         9: "The statement '{pattern}' has no named variable.",
     MatchHasUnboundedNestedPattern { pattern: Pattern } =

--- a/rust/common/error/mod.rs
+++ b/rust/common/error/mod.rs
@@ -102,11 +102,11 @@ error_messages! { TypeQLError
         3: "There is a syntax error near line {}:\n{}",
     InvalidCasting(&'static str, &'static str, &'static str, &'static str) =
         4: "Enum '{}::{}' does not match '{}', and cannot be unwrapped into '{}'.",
-    MissingPatterns() =
+    MissingPatterns =
         5: "The query has not been provided with any patterns.",
-    MissingDefinables() =
+    MissingDefinables =
         6: "The query has not been provided with any definables.",
-    MatchHasNoBoundingNamedVariable() =
+    MatchHasNoBoundingNamedVariable =
         7: "The match query does not have named variables to bound the nested disjunction/negation pattern(s).",
     VariableNameConflict(String) =
         8: "The variable name '{}' cannot be used for both concept variables and value variables.",
@@ -134,17 +134,17 @@ error_messages! { TypeQLError
         19: "None of the variables in 'insert' ('{}') is within scope of 'match' ('{}')",
     InsertModifiersRequireMatch(String) =
         20: "The insert query '{}' contains query modifiers that require a 'match' clause be specified",
-    VariableNotNamed() =
+    VariableNotNamed =
         21: "Anonymous variable encountered in a match query filter.",
     InvalidVariableName(String) =
         22: "The variable name '{}' is invalid; variables must match the following regular expression: '^[a-zA-Z0-9][a-zA-Z0-9_-]+$'.",
-    MissingConstraintRelationPlayer() =
+    MissingConstraintRelationPlayer =
         23: "A relation variable has not been provided with role players.",
     InvalidConstraintPredicate(token::Predicate, Value) =
         24: "The '{}' constraint may only accept a string value as its operand, got '{}' instead.",
     InvalidConstraintDatetimePrecision(NaiveDateTime) =
         25: "Attempted to assign DateTime value of '{}' which is more precise than 1 millisecond.",
-    InvalidDefineQueryVariable() =
+    InvalidDefineQueryVariable =
         26: "Invalid define/undefine query. User defined variables are not accepted in define/undefine query.",
     InvalidUndefineQueryRule(Label) =
         27: "Invalid undefine query: the rule body of '{}' ('when' or 'then') cannot be undefined. The rule must be undefined entirely by referring to its label.",
@@ -160,11 +160,11 @@ error_messages! { TypeQLError
         32: "Rule '{}' 'then' variables must be present in the 'when', outside of nested patterns.",
     InvalidRuleThenRoles(Label, ThingStatement) =
         33: "Rule '{}' 'then' '{}' must specify all role types explicitly or by using a variable.",
-    RedundantNestedNegation() =
+    RedundantNestedNegation =
         34: "Invalid query containing redundant nested negations.",
     VariableNotSorted(Variable) =
         35: "Variable '{}' does not exist in the sorting clause.",
-    InvalidCountVariableArgument() =
+    InvalidCountVariableArgument =
         36: "Aggregate COUNT does not accept a Variable.",
     IllegalGrammar(String) =
         37: "Illegal grammar: '{}'",

--- a/rust/common/error/mod.rs
+++ b/rust/common/error/mod.rs
@@ -78,7 +78,7 @@ pub(crate) fn syntax_error<T: pest::RuleType>(query: &str, error: PestError<T>) 
             }
         })
         .join("\n");
-    TypeQLError::SyntaxErrorDetailed(error_line_nr, formatted_error)
+    TypeQLError::SyntaxErrorDetailed { error_line_nr, formatted_error }
 }
 
 impl fmt::Display for Error {
@@ -98,76 +98,76 @@ pub fn collect_err(i: impl IntoIterator<Item = Result<(), Error>>) -> Result<(),
 
 error_messages! { TypeQLError
     code: "TQL", type: "TypeQL Error",
-    SyntaxErrorDetailed(usize, String) =
-        3: "There is a syntax error near line {}:\n{}",
-    InvalidCasting(&'static str, &'static str, &'static str, &'static str) =
-        4: "Enum '{}::{}' does not match '{}', and cannot be unwrapped into '{}'.",
+    SyntaxErrorDetailed { error_line_nr: usize, formatted_error: String } =
+        3: "There is a syntax error near line {error_line_nr}:\n{formatted_error}",
+    InvalidCasting { enum_name: &'static str, variant: &'static str, expected_variant: &'static str, typename: &'static str } =
+        4: "Enum '{enum_name}::{variant}' does not match '{expected_variant}', and cannot be unwrapped into '{typename}'.",
     MissingPatterns =
         5: "The query has not been provided with any patterns.",
     MissingDefinables =
         6: "The query has not been provided with any definables.",
     MatchHasNoBoundingNamedVariable =
         7: "The match query does not have named variables to bound the nested disjunction/negation pattern(s).",
-    VariableNameConflict(String) =
-        8: "The variable name '{}' cannot be used for both concept variables and value variables.",
-    MatchStatementHasNoNamedVariable(Pattern) =
-        9: "The statement '{}' has no named variable.",
-    MatchHasUnboundedNestedPattern(Pattern) =
-        10: "The match query contains a nested pattern is not bounded: '{}'.",
-    InvalidIIDString(String) =
-        11: "Invalid IID: '{}'. IIDs must follow the regular expression: '0x[0-9a-f]+'.",
-    InvalidAttributeTypeRegex(String) =
-        12: "Invalid regular expression '{}'.",
-    GetVarRepeating(Variable) =
-        13: "The variable '{}' occurred more than once in get query filter.",
-    GetVarNotBound(Variable) =
-        14: "The get variable '{}' is not bound in the match clause.",
-    AggregateVarNotBound(Variable) =
-        15: "The get-aggregate variable '{}' is not bound in the match clause.",
-    GroupVarNotBound(Variable) =
-        16: "The get-group variable '{}' is not bound in the match clause.",
-    SortVarNotBound(Variable) =
-        17: "The sort variable '{}' is not bound in the match clause.",
-    DeleteVarNotBound(Variable) =
-        18: "The delete variable '{}' is not bound in the match clause.",
-    InsertClauseNotBound(String, String) =
-        19: "None of the variables in 'insert' ('{}') is within scope of 'match' ('{}')",
-    InsertModifiersRequireMatch(String) =
-        20: "The insert query '{}' contains query modifiers that require a 'match' clause be specified",
+    VariableNameConflict { names: String } =
+        8: "The variable names '{names}' cannot be used for both concept variables and value variables.",
+    MatchStatementHasNoNamedVariable { pattern: Pattern } =
+        9: "The statement '{pattern}' has no named variable.",
+    MatchHasUnboundedNestedPattern { pattern: Pattern } =
+        10: "The match query contains a nested pattern is not bounded: '{pattern}'.",
+    InvalidIIDString { iid: String } =
+        11: "Invalid IID: '{iid}'. IIDs must follow the regular expression: '0x[0-9a-f]+'.",
+    InvalidAttributeTypeRegex { regex: String } =
+        12: "Invalid regular expression '{regex}'.",
+    GetVarRepeating { variable: Variable } =
+        13: "The variable '{variable}' occurred more than once in get query filter.",
+    GetVarNotBound { variable: Variable } =
+        14: "The get variable '{variable}' is not bound in the match clause.",
+    AggregateVarNotBound { variable: Variable } =
+        15: "The get-aggregate variable '{variable}' is not bound in the match clause.",
+    GroupVarNotBound { variable: Variable } =
+        16: "The get-group variable '{variable}' is not bound in the match clause.",
+    SortVarNotBound { variable: Variable } =
+        17: "The sort variable '{variable}' is not bound in the match clause.",
+    DeleteVarNotBound { variable: Variable } =
+        18: "The delete variable '{variable}' is not bound in the match clause.",
+    InsertClauseNotBound { insert_statements: String, bounds: String } =
+        19: "None of the variables in 'insert' ('{insert_statements}') is within scope of 'match' ('{bounds}')",
+    InsertModifiersRequireMatch { insert: String } =
+        20: "The insert query '{insert}' contains query modifiers that require a 'match' clause be specified",
     VariableNotNamed =
         21: "Anonymous variable encountered in a match query filter.",
-    InvalidVariableName(String) =
-        22: "The variable name '{}' is invalid; variables must match the following regular expression: '^[a-zA-Z0-9][a-zA-Z0-9_-]+$'.",
+    InvalidVariableName { name: String } =
+        22: "The variable name '{name}' is invalid; variables must match the following regular expression: '^[a-zA-Z0-9][a-zA-Z0-9_-]+$'.",
     MissingConstraintRelationPlayer =
         23: "A relation variable has not been provided with role players.",
-    InvalidConstraintPredicate(token::Predicate, Value) =
-        24: "The '{}' constraint may only accept a string value as its operand, got '{}' instead.",
-    InvalidConstraintDatetimePrecision(NaiveDateTime) =
-        25: "Attempted to assign DateTime value of '{}' which is more precise than 1 millisecond.",
+    InvalidConstraintPredicate { predicate: token::Predicate, value: Value } =
+        24: "The '{predicate}' constraint may only accept a string value as its operand, got '{value}' instead.",
+    InvalidConstraintDatetimePrecision { date_time: NaiveDateTime } =
+        25: "Attempted to assign DateTime value of '{date_time}' which is more precise than 1 millisecond.",
     InvalidDefineQueryVariable =
         26: "Invalid define/undefine query. User defined variables are not accepted in define/undefine query.",
-    InvalidUndefineQueryRule(Label) =
-        27: "Invalid undefine query: the rule body of '{}' ('when' or 'then') cannot be undefined. The rule must be undefined entirely by referring to its label.",
-    InvalidRuleWhenMissingPatterns(Label) =
-        28: "Rule '{}' 'when' has not been provided with any patterns.",
-    InvalidRuleWhenNestedNegation(Label) =
-        29: "Rule '{}' 'when' contains a nested negation.",
-    InvalidRuleThen(Label, ThingStatement) =
-        30: "Rule '{}' 'then' '{}': must be exactly one attribute ownership, or exactly one relation.",
-    InvalidRuleThenHas(Label, ThingStatement, ConceptVariable, Label) =
-        31: "Rule '{}' 'then' '{}' tries to assign type '{}' to variable '{}', but this variable already had a type assigned by the rule 'when'. Try omitting this type assignment.",
-    InvalidRuleThenVariables(Label) =
-        32: "Rule '{}' 'then' variables must be present in the 'when', outside of nested patterns.",
-    InvalidRuleThenRoles(Label, ThingStatement) =
-        33: "Rule '{}' 'then' '{}' must specify all role types explicitly or by using a variable.",
+    InvalidUndefineQueryRule { rule_label: Label } =
+        27: "Invalid undefine query: the rule body of '{rule_label}' ('when' or 'then') cannot be undefined. The rule must be undefined entirely by referring to its label.",
+    InvalidRuleWhenMissingPatterns { rule_label: Label } =
+        28: "Rule '{rule_label}' 'when' has not been provided with any patterns.",
+    InvalidRuleWhenNestedNegation { rule_label: Label } =
+        29: "Rule '{rule_label}' 'when' contains a nested negation.",
+    InvalidRuleThen { rule_label: Label, then: ThingStatement } =
+        30: "Rule '{rule_label}' 'then' '{then}': must be exactly one attribute ownership, or exactly one relation.",
+    InvalidRuleThenHas { rule_label: Label, then: ThingStatement, variable: ConceptVariable, type_label: Label } =
+        31: "Rule '{rule_label}' 'then' '{then}' tries to assign type '{type_label}' to variable '{variable}', but this variable already had a type assigned by the rule 'when'. Try omitting this type assignment.",
+    InvalidRuleThenVariables { rule_label: Label } =
+        32: "Rule '{rule_label}' 'then' variables must be present in the 'when', outside of nested patterns.",
+    InvalidRuleThenRoles { rule_label: Label, then: ThingStatement } =
+        33: "Rule '{rule_label}' 'then' '{then}' must specify all role types explicitly or by using a variable.",
     RedundantNestedNegation =
         34: "Invalid query containing redundant nested negations.",
-    VariableNotSorted(Variable) =
-        35: "Variable '{}' does not exist in the sorting clause.",
+    VariableNotSorted { variable: Variable } =
+        35: "Variable '{variable}' does not exist in the sorting clause.",
     InvalidCountVariableArgument =
         36: "Aggregate COUNT does not accept a Variable.",
-    IllegalGrammar(String) =
-        37: "Illegal grammar: '{}'",
-    IllegalCharInLabel(String) =
-        38: "'{}' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.",
+    IllegalGrammar { input: String } =
+        37: "Illegal grammar: '{input}'",
+    IllegalCharInLabel { input: String } =
+        38: "'{input}' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.",
 }

--- a/rust/common/string.rs
+++ b/rust/common/string.rs
@@ -33,11 +33,11 @@ pub(crate) fn indent(multiline_string: &str) -> String {
 }
 
 pub(crate) fn escape_regex(regex: &str) -> String {
-    regex.replace('/', r#"\/"#)
+    regex.replace('/', r"\/")
 }
 
 pub(crate) fn unescape_regex(regex: &str) -> String {
-    regex.replace(r#"\/"#, "/")
+    regex.replace(r"\/", "/")
 }
 
 pub(crate) fn format_double(double: f64) -> String {

--- a/rust/pattern/conjunction.rs
+++ b/rust/pattern/conjunction.rs
@@ -67,7 +67,7 @@ fn validate_bounded(
     conjunction: &Conjunction,
 ) -> Result {
     if bounds.is_disjoint(names) {
-        Err(TypeQLError::MatchHasUnboundedNestedPattern(conjunction.clone().into()))?;
+        Err(TypeQLError::MatchHasUnboundedNestedPattern { pattern: conjunction.clone().into() })?;
     }
     Ok(())
 }

--- a/rust/pattern/constant.rs
+++ b/rust/pattern/constant.rs
@@ -50,10 +50,10 @@ impl LeftOperand for Constant {}
 
 impl Validatable for Constant {
     fn validate(&self) -> Result {
-        match &self {
-            Self::DateTime(date_time) => {
+        match self {
+            &Self::DateTime(date_time) => {
                 if date_time.nanosecond() % 1000000 > 0 {
-                    Err(TypeQLError::InvalidConstraintDatetimePrecision(*date_time))?
+                    Err(TypeQLError::InvalidConstraintDatetimePrecision { date_time })?
                 }
                 Ok(())
             }

--- a/rust/pattern/constraint/concept/is.rs
+++ b/rust/pattern/constraint/concept/is.rs
@@ -40,13 +40,13 @@ impl Validatable for IsConstraint {
 
 impl From<&str> for IsConstraint {
     fn from(string: &str) -> Self {
-        Self::from(ConceptVariable::Name(string.to_string()))
+        Self::from(ConceptVariable::Named(string.to_string()))
     }
 }
 
 impl From<String> for IsConstraint {
     fn from(string: String) -> Self {
-        Self::from(ConceptVariable::Name(string))
+        Self::from(ConceptVariable::Named(string))
     }
 }
 

--- a/rust/pattern/constraint/predicate.rs
+++ b/rust/pattern/constraint/predicate.rs
@@ -68,7 +68,7 @@ impl Validatable for Predicate {
 
 fn validate_string_value_with_substring_predicate(predicate: token::Predicate, value: &Value) -> Result {
     if predicate.is_substring() && !matches!(value, Value::Constant(Constant::String(_))) {
-        Err(TypeQLError::InvalidConstraintPredicate(predicate, value.clone()))?
+        Err(TypeQLError::InvalidConstraintPredicate { predicate, value: value.clone() })?
     }
     Ok(())
 }

--- a/rust/pattern/constraint/thing/iid.rs
+++ b/rust/pattern/constraint/thing/iid.rs
@@ -42,7 +42,7 @@ impl IIDConstraint {
 impl Validatable for IIDConstraint {
     fn validate(&self) -> Result {
         if !is_valid_iid(&self.iid) {
-            Err(TypeQLError::InvalidIIDString(self.iid.clone()))?
+            Err(TypeQLError::InvalidIIDString { iid: self.iid.clone() })?
         }
         Ok(())
     }

--- a/rust/pattern/constraint/thing/relation.rs
+++ b/rust/pattern/constraint/thing/relation.rs
@@ -64,7 +64,7 @@ impl Validatable for RelationConstraint {
 
 fn expect_role_players_present(role_players: &[RolePlayerConstraint]) -> Result {
     if role_players.is_empty() {
-        Err(TypeQLError::MissingConstraintRelationPlayer())?
+        Err(TypeQLError::MissingConstraintRelationPlayer)?
     }
     Ok(())
 }

--- a/rust/pattern/constraint/thing/relation.rs
+++ b/rust/pattern/constraint/thing/relation.rs
@@ -116,7 +116,7 @@ impl From<&str> for RolePlayerConstraint {
 
 impl From<String> for RolePlayerConstraint {
     fn from(player_var: String) -> Self {
-        Self::from(ConceptVariable::named(player_var))
+        Self::from(ConceptVariable::Named(player_var))
     }
 }
 
@@ -128,13 +128,13 @@ impl From<(&str, &str)> for RolePlayerConstraint {
 
 impl From<(String, String)> for RolePlayerConstraint {
     fn from((role_type, player_var): (String, String)) -> Self {
-        Self::from((role_type, ConceptVariable::named(player_var)))
+        Self::from((role_type, ConceptVariable::Named(player_var)))
     }
 }
 
 impl From<(Label, String)> for RolePlayerConstraint {
     fn from((role_type, player_var): (Label, String)) -> Self {
-        Self::from((role_type, ConceptVariable::named(player_var)))
+        Self::from((role_type, ConceptVariable::Named(player_var)))
     }
 }
 

--- a/rust/pattern/constraint/type_/owns.rs
+++ b/rust/pattern/constraint/type_/owns.rs
@@ -108,21 +108,12 @@ impl From<TypeReference> for OwnsConstraint {
     }
 }
 
-impl From<(&str, &str)> for OwnsConstraint {
-    fn from((attribute_type, overridden_attribute_type): (&str, &str)) -> Self {
-        OwnsConstraint::from((Label::from(attribute_type), Label::from(overridden_attribute_type)))
-    }
-}
-
-impl From<(String, String)> for OwnsConstraint {
-    fn from((attribute_type, overridden_attribute_type): (String, String)) -> Self {
-        OwnsConstraint::from((Label::from(attribute_type), Label::from(overridden_attribute_type)))
-    }
-}
-
-impl From<(Label, Label)> for OwnsConstraint {
-    fn from((attribute_type, overridden_attribute_type): (Label, Label)) -> Self {
-        OwnsConstraint::from((TypeReference::Label(attribute_type), TypeReference::Label(overridden_attribute_type)))
+impl<T: Into<Label>, U: Into<Label>> From<(T, U)> for OwnsConstraint {
+    fn from((attribute_type, overridden_attribute_type): (T, U)) -> Self {
+        OwnsConstraint::from((
+            TypeReference::Label(attribute_type.into()),
+            TypeReference::Label(overridden_attribute_type.into()),
+        ))
     }
 }
 
@@ -141,21 +132,13 @@ impl From<(TypeReference, TypeReference)> for OwnsConstraint {
     }
 }
 
-impl From<(&str, Annotation)> for OwnsConstraint {
-    fn from((attribute_type, annotation): (&str, Annotation)) -> Self {
-        OwnsConstraint::from((Label::from(attribute_type), [annotation]))
-    }
-}
-
-impl From<(String, Annotation)> for OwnsConstraint {
-    fn from((attribute_type, annotation): (String, Annotation)) -> Self {
-        OwnsConstraint::from((Label::from(attribute_type), [annotation]))
-    }
-}
-
-impl From<(Label, Annotation)> for OwnsConstraint {
-    fn from((attribute_type, annotation): (Label, Annotation)) -> Self {
-        OwnsConstraint::from((TypeReference::Label(attribute_type), [annotation]))
+impl<T: Into<Label>> From<(T, Annotation)> for OwnsConstraint {
+    fn from((attribute_type, annotation): (T, Annotation)) -> Self {
+        Self {
+            attribute_type: TypeReference::Label(attribute_type.into()),
+            annotations: vec![annotation],
+            overridden_attribute_type: None,
+        }
     }
 }
 
@@ -171,23 +154,11 @@ impl From<(TypeReference, Annotation)> for OwnsConstraint {
     }
 }
 
-impl From<(&str, &str, Annotation)> for OwnsConstraint {
-    fn from((attribute_type, overridden_attribute_type, annotation): (&str, &str, Annotation)) -> Self {
-        OwnsConstraint::from((Label::from(attribute_type), Label::from(overridden_attribute_type), [annotation]))
-    }
-}
-
-impl From<(String, String, Annotation)> for OwnsConstraint {
-    fn from((attribute_type, overridden_attribute_type, annotation): (String, String, Annotation)) -> Self {
-        OwnsConstraint::from((Label::from(attribute_type), Label::from(overridden_attribute_type), [annotation]))
-    }
-}
-
-impl From<(Label, Label, Annotation)> for OwnsConstraint {
-    fn from((attribute_type, overridden_attribute_type, annotation): (Label, Label, Annotation)) -> Self {
+impl<T: Into<Label>, U: Into<Label>> From<(T, U, Annotation)> for OwnsConstraint {
+    fn from((attribute_type, overridden_attribute_type, annotation): (T, U, Annotation)) -> Self {
         OwnsConstraint::from((
-            TypeReference::Label(attribute_type),
-            TypeReference::Label(overridden_attribute_type),
+            TypeReference::Label(attribute_type.into()),
+            TypeReference::Label(overridden_attribute_type.into()),
             [annotation],
         ))
     }

--- a/rust/pattern/constraint/type_/plays.rs
+++ b/rust/pattern/constraint/type_/plays.rs
@@ -94,15 +94,13 @@ impl From<(ConceptVariable, ConceptVariable)> for PlaysConstraint {
     }
 }
 
-impl From<(&str, &str, &str)> for PlaysConstraint {
-    fn from((relation_type, role_type, overridden_role_name): (&str, &str, &str)) -> Self {
-        PlaysConstraint::from((relation_type.to_owned(), role_type.to_owned(), overridden_role_name.to_owned()))
-    }
-}
-
-impl From<(String, String, String)> for PlaysConstraint {
-    fn from((relation_type, role_name, overridden_role_name): (String, String, String)) -> Self {
-        PlaysConstraint::from((Label::from((relation_type, role_name)), Label::from(overridden_role_name)))
+impl<T, U, V> From<(T, U, V)> for PlaysConstraint
+where
+    (T, U): Into<Label>,
+    V: Into<Label>,
+{
+    fn from((relation_type, role_type, overridden_role_name): (T, U, V)) -> Self {
+        PlaysConstraint::from(((relation_type, role_type).into(), overridden_role_name.into()))
     }
 }
 

--- a/rust/pattern/constraint/type_/regex.rs
+++ b/rust/pattern/constraint/type_/regex.rs
@@ -34,7 +34,7 @@ pub struct RegexConstraint {
 impl Validatable for RegexConstraint {
     fn validate(&self) -> Result {
         if Regex::new(&self.regex).is_err() {
-            Err(TypeQLError::InvalidAttributeTypeRegex(self.regex.clone()))?;
+            Err(TypeQLError::InvalidAttributeTypeRegex { regex: self.regex.clone() })?;
         }
         Ok(())
     }

--- a/rust/pattern/constraint/type_/sub.rs
+++ b/rust/pattern/constraint/type_/sub.rs
@@ -61,7 +61,7 @@ impl From<ConceptVariable> for SubConstraint {
 
 impl From<TypeReference> for SubConstraint {
     fn from(type_: TypeReference) -> Self {
-        SubConstraint { type_: type_, is_explicit: IsExplicit::No }
+        SubConstraint { type_, is_explicit: IsExplicit::No }
     }
 }
 

--- a/rust/pattern/expression/function.rs
+++ b/rust/pattern/expression/function.rs
@@ -28,7 +28,7 @@ use crate::{common::token, pattern::LeftOperand, variable::variable::VariableRef
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Function {
     pub(crate) function_name: token::Function,
-    pub(crate) args: Vec<Box<Expression>>,
+    pub(crate) args: Vec<Expression>,
 }
 
 impl Function {

--- a/rust/pattern/negation.rs
+++ b/rust/pattern/negation.rs
@@ -58,7 +58,7 @@ impl Negation {
 impl Validatable for Negation {
     fn validate(&self) -> Result {
         match self.pattern.as_ref() {
-            Pattern::Negation(_) => Err(TypeQLError::RedundantNestedNegation())?,
+            Pattern::Negation(_) => Err(TypeQLError::RedundantNestedNegation)?,
             _ => Ok(()),
         }
     }
@@ -76,7 +76,7 @@ impl Normalisable for Negation {
         Negation::new(match self.pattern.as_ref() {
             Pattern::Conjunction(conjunction) => conjunction.compute_normalised(),
             Pattern::Disjunction(disjunction) => disjunction.compute_normalised(),
-            Pattern::Negation(_) => panic!("{}", TypeQLError::RedundantNestedNegation()),
+            Pattern::Negation(_) => panic!("{}", TypeQLError::RedundantNestedNegation),
             Pattern::Statement(variable) => {
                 Disjunction::new(vec![Conjunction::new(vec![variable.clone().into()]).into()]).into()
             }

--- a/rust/pattern/schema/rule.rs
+++ b/rust/pattern/schema/rule.rs
@@ -105,7 +105,7 @@ fn validate_no_nested_negations<'a>(patterns: impl Iterator<Item = &'a Pattern>,
             Pattern::Disjunction(d) => validate_no_nested_negations(d.patterns.iter(), rule_label),
             Pattern::Negation(n) => {
                 if contains_negations(iter::once(n.pattern.as_ref())) {
-                    Err(TypeQLError::InvalidRuleWhenNestedNegation(rule_label.clone()))?
+                    Err(TypeQLError::InvalidRuleWhenNestedNegation { rule_label: rule_label.clone() })?
                 } else {
                     Ok(())
                 }
@@ -127,22 +127,22 @@ fn validate_valid_inference(then: &ThingStatement, rule_label: &Label) -> Result
     if infers_ownership(then) {
         let has = then.has.get(0).unwrap();
         if let HasConstraint::HasConcept(Some(type_label), attr_var) = has {
-            Err(TypeQLError::InvalidRuleThenHas(
-                rule_label.clone(),
-                then.clone(),
-                attr_var.clone(),
-                type_label.clone(),
-            ))?
+            Err(TypeQLError::InvalidRuleThenHas {
+                rule_label: rule_label.clone(),
+                then: then.clone(),
+                variable: attr_var.clone(),
+                type_label: type_label.clone(),
+            })?
         }
         Ok(())
     } else if infers_relation(then) {
         let relation = then.relation.as_ref().unwrap();
         if !relation.role_players.iter().all(|rp| rp.role_type.is_some()) {
-            Err(TypeQLError::InvalidRuleThenRoles(rule_label.clone(), then.clone()))?
+            Err(TypeQLError::InvalidRuleThenRoles { rule_label: rule_label.clone(), then: then.clone() })?
         }
         Ok(())
     } else {
-        Err(TypeQLError::InvalidRuleThen(rule_label.clone(), then.clone()))?
+        Err(TypeQLError::InvalidRuleThen { rule_label: rule_label.clone(), then: then.clone() })?
     }
 }
 
@@ -160,7 +160,7 @@ fn infers_relation(then: &ThingStatement) -> bool {
 fn validate_then_bounded_by_when(then: &ThingStatement, when: &Conjunction, rule_label: &Label) -> Result {
     let bounds: HashSet<VariableRef<'_>> = when.retrieved_variables().collect();
     if !then.variables().filter(|r| r.is_name()).all(|r| bounds.contains(&r)) {
-        Err(TypeQLError::InvalidRuleThenVariables(rule_label.clone()))?
+        Err(TypeQLError::InvalidRuleThenVariables { rule_label: rule_label.clone() })?
     }
     Ok(())
 }

--- a/rust/pattern/statement/mod.rs
+++ b/rust/pattern/statement/mod.rs
@@ -75,7 +75,7 @@ impl Statement {
 
     pub fn validate_is_bounded_by(&self, bounds: &HashSet<VariableRef<'_>>) -> Result {
         if !self.variables().any(|r| r.is_name() && bounds.contains(&r)) {
-            Err(TypeQLError::MatchHasUnboundedNestedPattern(self.clone().into()))?
+            Err(TypeQLError::MatchHasUnboundedNestedPattern { pattern: self.clone().into() })?
         }
         Ok(())
     }

--- a/rust/pattern/statement/thing.rs
+++ b/rust/pattern/statement/thing.rs
@@ -125,7 +125,6 @@ impl fmt::Display for ThingStatement {
         } else if let Some(relation) = &self.relation {
             write!(f, "{relation}")?;
         }
-        ();
 
         if self.is_thing_constrained() {
             f.write_str(" ")?;

--- a/rust/pattern/statement/type_.rs
+++ b/rust/pattern/statement/type_.rs
@@ -125,7 +125,7 @@ impl TypeStatement {
 
     pub fn validate_definable(&self) -> Result {
         if self.label.is_none() {
-            Err(TypeQLError::InvalidDefineQueryVariable())?;
+            Err(TypeQLError::InvalidDefineQueryVariable)?;
         }
         Ok(())
     }

--- a/rust/pattern/test/mod.rs
+++ b/rust/pattern/test/mod.rs
@@ -49,7 +49,6 @@ get;"#;
             and!(cvar("com").has(("name", cvar("n1"))), cvar("n1").eq("the-company"), cvar("com").isa("company"),),
             and!(cvar("com").has(("name", cvar("n2"))), cvar("n2").eq("another-company"), cvar("com").isa("company"),)
         )
-        .into_disjunction()
     );
 }
 

--- a/rust/query/match_clause.rs
+++ b/rust/query/match_clause.rs
@@ -101,11 +101,11 @@ impl Validatable for MatchClause {
 fn validate_statements_have_named_variable<'a>(patterns: impl Iterator<Item = &'a Pattern>) -> Result {
     collect_err(patterns.map(|pattern| {
         match pattern {
-            Pattern::Statement(statement) => statement
-                .variables()
-                .any(|variable| variable.is_name())
-                .then_some(())
-                .ok_or_else(|| Error::from(TypeQLError::MatchStatementHasNoNamedVariable { pattern: pattern.clone() })),
+            Pattern::Statement(statement) => {
+                statement.variables().any(|variable| variable.is_name()).then_some(()).ok_or_else(|| {
+                    Error::from(TypeQLError::MatchStatementHasNoNamedVariable { pattern: pattern.clone() })
+                })
+            }
             Pattern::Conjunction(c) => validate_statements_have_named_variable(c.patterns.iter()),
             Pattern::Disjunction(d) => validate_statements_have_named_variable(d.patterns.iter()),
             Pattern::Negation(n) => validate_statements_have_named_variable(iter::once(n.pattern.as_ref())),

--- a/rust/query/match_clause.rs
+++ b/rust/query/match_clause.rs
@@ -109,7 +109,7 @@ fn validate_statements_have_named_variable<'a>(patterns: impl Iterator<Item = &'
                 .variables()
                 .any(|r| r.is_name())
                 .then_some(())
-                .ok_or_else(|| Error::from(TypeQLError::MatchStatementHasNoNamedVariable(p.clone()))),
+                .ok_or_else(|| Error::from(TypeQLError::MatchStatementHasNoNamedVariable { pattern: p.clone() })),
             Pattern::Conjunction(c) => validate_statements_have_named_variable(c.patterns.iter()),
             Pattern::Disjunction(d) => validate_statements_have_named_variable(d.patterns.iter()),
             Pattern::Negation(n) => validate_statements_have_named_variable(iter::once(n.pattern.as_ref())),

--- a/rust/query/match_clause.rs
+++ b/rust/query/match_clause.rs
@@ -59,11 +59,15 @@ impl MatchClause {
     }
 
     pub fn get_fixed<const N: usize, T: Into<Variable>>(self, vars: [T; N]) -> TypeQLGet {
-        self.get_vars(vars.into_iter().map(|var| var.into()).collect::<Vec<_>>())
+        self.get_vars(vars.into_iter().map(|var| var.into()).collect())
     }
 
     pub fn fetch(self, projections: Vec<Projection>) -> TypeQLFetch {
         TypeQLFetch { match_clause: self, projections, modifiers: Modifiers::default() }
+    }
+
+    pub fn fetch_fixed<const N: usize>(self, projections: [Projection; N]) -> TypeQLFetch {
+        self.fetch(projections.into())
     }
 
     pub fn insert(self, writable: impl Writable) -> TypeQLInsert {

--- a/rust/query/match_clause.rs
+++ b/rust/query/match_clause.rs
@@ -46,10 +46,6 @@ impl MatchClause {
         Self { conjunction }
     }
 
-    pub fn from_patterns(patterns: Vec<Pattern>) -> Self {
-        Self::new(Conjunction::new(patterns))
-    }
-
     pub fn get(self) -> TypeQLGet {
         TypeQLGet {
             match_clause: self,
@@ -68,10 +64,6 @@ impl MatchClause {
 
     pub fn fetch(self, projections: Vec<Projection>) -> TypeQLFetch {
         TypeQLFetch { match_clause: self, projections, modifiers: Modifiers::default() }
-    }
-
-    pub fn fetch_fixed<const N: usize>(self, projections: [Projection; N]) -> TypeQLFetch {
-        self.fetch(projections.into_iter().collect::<Vec<_>>())
     }
 
     pub fn insert(self, writable: impl Writable) -> TypeQLInsert {
@@ -103,13 +95,13 @@ impl Validatable for MatchClause {
 }
 
 fn validate_statements_have_named_variable<'a>(patterns: impl Iterator<Item = &'a Pattern>) -> Result {
-    collect_err(patterns.map(|p| {
-        match p {
-            Pattern::Statement(v) => v
+    collect_err(patterns.map(|pattern| {
+        match pattern {
+            Pattern::Statement(statement) => statement
                 .variables()
-                .any(|r| r.is_name())
+                .any(|variable| variable.is_name())
                 .then_some(())
-                .ok_or_else(|| Error::from(TypeQLError::MatchStatementHasNoNamedVariable { pattern: p.clone() })),
+                .ok_or_else(|| Error::from(TypeQLError::MatchStatementHasNoNamedVariable { pattern: pattern.clone() })),
             Pattern::Conjunction(c) => validate_statements_have_named_variable(c.patterns.iter()),
             Pattern::Disjunction(d) => validate_statements_have_named_variable(d.patterns.iter()),
             Pattern::Negation(n) => validate_statements_have_named_variable(iter::once(n.pattern.as_ref())),

--- a/rust/query/modifier.rs
+++ b/rust/query/modifier.rs
@@ -166,7 +166,7 @@ impl Sorting {
             available_variables
                 .contains(&r.variable.as_ref())
                 .then_some(())
-                .ok_or_else(|| TypeQLError::SortVarNotBound(r.variable.clone()).into())
+                .ok_or_else(|| TypeQLError::SortVarNotBound { variable: r.variable.clone() }.into())
         }))
     }
 }

--- a/rust/query/typeql_define.rs
+++ b/rust/query/typeql_define.rs
@@ -62,7 +62,7 @@ impl TypeQLDefine {
 
     fn validate_non_empty(&self) -> Result {
         if self.statements.is_empty() && self.rules.is_empty() {
-            Err(TypeQLError::MissingDefinables())?
+            Err(TypeQLError::MissingDefinables)?
         }
         Ok(())
     }

--- a/rust/query/typeql_define.rs
+++ b/rust/query/typeql_define.rs
@@ -45,7 +45,7 @@ impl TypeQLDefine {
             Definable::RuleDefinition(rule) => define.add_rule(rule),
             Definable::TypeStatement(var) => define.add_statement(var),
             Definable::RuleDeclaration(r) => {
-                panic!("{}", TypeQLError::InvalidRuleWhenMissingPatterns(r.label))
+                panic!("{}", TypeQLError::InvalidRuleWhenMissingPatterns { rule_label: r.label })
             }
         })
     }

--- a/rust/query/typeql_delete.rs
+++ b/rust/query/typeql_delete.rs
@@ -81,7 +81,7 @@ fn validate_delete_in_scope(scope_variables: &HashSet<VariableRef<'_>>, statemen
         if scope_variables.contains(&r) {
             Ok(())
         } else {
-            Err(TypeQLError::DeleteVarNotBound(r.to_owned()))?
+            Err(TypeQLError::DeleteVarNotBound { variable: r.to_owned() })?
         }
     }))
 }

--- a/rust/query/typeql_fetch.rs
+++ b/rust/query/typeql_fetch.rs
@@ -51,8 +51,8 @@ impl TypeQLFetch {
             .chain(self.projections.iter().flat_map(|p| p.key_variable().into_iter().chain(p.value_variables())));
         let (concept_refs, value_refs): (HashSet<VariableRef<'_>>, HashSet<VariableRef<'_>>) =
             all_refs.partition(|r| r.is_concept());
-        let concept_names = concept_refs.iter().map(|r| r).collect::<HashSet<_>>();
-        let value_names = value_refs.iter().map(|r| r).collect::<HashSet<_>>();
+        let concept_names = concept_refs.iter().collect::<HashSet<_>>();
+        let value_names = value_refs.iter().collect::<HashSet<_>>();
         let common_refs = concept_names.intersection(&value_names).collect::<HashSet<_>>();
         if !common_refs.is_empty() {
             return Err(TypeQLError::VariableNameConflict(common_refs.iter().map(|r| r.to_string()).join(", ")).into());
@@ -154,17 +154,16 @@ pub enum ProjectionKeyLabel {
 
 impl ProjectionKeyLabel {
     pub fn map_subquery_get_aggregate(self, subquery: TypeQLGetAggregate) -> Projection {
-        Projection::Subquery(self.into(), ProjectionSubquery::GetAggregate(subquery))
+        Projection::Subquery(self, ProjectionSubquery::GetAggregate(subquery))
     }
 
     pub fn map_subquery_fetch(self, subquery: TypeQLFetch) -> Projection {
-        Projection::Subquery(self.into(), ProjectionSubquery::Fetch(Box::new(subquery)))
+        Projection::Subquery(self, ProjectionSubquery::Fetch(Box::new(subquery)))
     }
 
     fn must_quote(s: &str) -> bool {
         // TODO: we should actually check against valid label regex, instead of valid variable regex - Java has to be updated too
-        let x = !variable::is_valid_variable_name(s);
-        x
+        !variable::is_valid_variable_name(s)
     }
 }
 

--- a/rust/query/typeql_fetch.rs
+++ b/rust/query/typeql_fetch.rs
@@ -55,7 +55,10 @@ impl TypeQLFetch {
         let value_names = value_refs.iter().collect::<HashSet<_>>();
         let common_refs = concept_names.intersection(&value_names).collect::<HashSet<_>>();
         if !common_refs.is_empty() {
-            return Err(TypeQLError::VariableNameConflict(common_refs.iter().map(|r| r.to_string()).join(", ")).into());
+            return Err(TypeQLError::VariableNameConflict {
+                names: common_refs.iter().map(|r| r.to_string()).join(", "),
+            }
+            .into());
         }
         Ok(())
     }

--- a/rust/query/typeql_get.rs
+++ b/rust/query/typeql_get.rs
@@ -88,7 +88,7 @@ impl Validatable for TypeQLGet {
 impl VariablesRetrieved for TypeQLGet {
     fn retrieved_variables(&self) -> Box<dyn Iterator<Item = VariableRef<'_>> + '_> {
         if !self.filter.vars.is_empty() {
-            Box::new(self.filter.vars.iter().map(|v| v.as_ref()))
+            Box::new(self.filter.vars.iter().map(Variable::as_ref))
         } else {
             self.match_clause.retrieved_variables()
         }
@@ -97,15 +97,15 @@ impl VariablesRetrieved for TypeQLGet {
 
 fn validate_filters_are_in_scope(match_variables: &HashSet<VariableRef<'_>>, filter: &Filter) -> Result {
     let mut seen = HashSet::new();
-    collect_err(filter.vars.iter().map(|r| {
-        if !r.is_name() {
+    collect_err(filter.vars.iter().map(|variable| {
+        if !variable.is_named() {
             Err(TypeQLError::VariableNotNamed.into())
-        } else if !match_variables.contains(&r.as_ref()) {
-            Err(TypeQLError::GetVarNotBound { variable: r.to_owned() }.into())
-        } else if seen.contains(&r) {
-            Err(TypeQLError::GetVarRepeating { variable: r.to_owned() }.into())
+        } else if !match_variables.contains(&variable.as_ref()) {
+            Err(TypeQLError::GetVarNotBound { variable: variable.clone() }.into())
+        } else if seen.contains(&variable) {
+            Err(TypeQLError::GetVarRepeating { variable: variable.clone() }.into())
         } else {
-            seen.insert(r);
+            seen.insert(variable);
             Ok(())
         }
     }))
@@ -116,9 +116,10 @@ fn validate_variable_names_are_unique(conjunction: &Conjunction) -> Result {
     let (concept_refs, value_refs) = all_refs.partition::<HashSet<_>, _>(VariableRef::is_concept);
     let common_refs = concept_refs.intersection(&value_refs).collect::<HashSet<_>>();
     if !common_refs.is_empty() {
-        return Err(
-            TypeQLError::VariableNameConflict { names: common_refs.iter().map(|r| r.to_string()).join(", ") }.into()
-        );
+        return Err(TypeQLError::VariableNameConflict {
+            names: common_refs.into_iter().map(VariableRef::to_string).join(", "),
+        }
+        .into());
     }
     Ok(())
 }

--- a/rust/query/typeql_get.rs
+++ b/rust/query/typeql_get.rs
@@ -74,12 +74,12 @@ impl TypeQLGet {
 impl Validatable for TypeQLGet {
     fn validate(&self) -> Result {
         let match_variables = self.match_clause.retrieved_variables().collect();
-        let filter_vars = HashSet::from_iter((&self.filter.vars).iter().map(Variable::as_ref));
+        let filter_vars = HashSet::from_iter(self.filter.vars.iter().map(Variable::as_ref));
         let retrieved_variables = if self.filter.vars.is_empty() { &match_variables } else { &filter_vars };
         collect_err([
             self.match_clause.validate(),
             validate_filters_are_in_scope(&match_variables, &self.filter),
-            self.modifiers.sorting.as_ref().map(|s| s.validate(&retrieved_variables)).unwrap_or(Ok(())),
+            self.modifiers.sorting.as_ref().map(|s| s.validate(retrieved_variables)).unwrap_or(Ok(())),
             validate_variable_names_are_unique(&self.match_clause.conjunction),
         ])
     }
@@ -113,11 +113,8 @@ fn validate_filters_are_in_scope(match_variables: &HashSet<VariableRef<'_>>, fil
 
 fn validate_variable_names_are_unique(conjunction: &Conjunction) -> Result {
     let all_refs = conjunction.variables_recursive();
-    let (concept_refs, value_refs): (HashSet<VariableRef<'_>>, HashSet<VariableRef<'_>>) =
-        all_refs.partition(|r| r.is_concept());
-    let concept_names = concept_refs.iter().map(|r| r).collect::<HashSet<_>>();
-    let value_names = value_refs.iter().map(|r| r).collect::<HashSet<_>>();
-    let common_refs = concept_names.intersection(&value_names).collect::<HashSet<_>>();
+    let (concept_refs, value_refs) = all_refs.partition::<HashSet<_>, _>(VariableRef::is_concept);
+    let common_refs = concept_refs.intersection(&value_refs).collect::<HashSet<_>>();
     if !common_refs.is_empty() {
         return Err(TypeQLError::VariableNameConflict(common_refs.iter().map(|r| r.to_string()).join(", ")).into());
     }

--- a/rust/query/typeql_get.rs
+++ b/rust/query/typeql_get.rs
@@ -99,7 +99,7 @@ fn validate_filters_are_in_scope(match_variables: &HashSet<VariableRef<'_>>, fil
     let mut seen = HashSet::new();
     collect_err(filter.vars.iter().map(|r| {
         if !r.is_name() {
-            Err(TypeQLError::VariableNotNamed().into())
+            Err(TypeQLError::VariableNotNamed.into())
         } else if !match_variables.contains(&r.as_ref()) {
             Err(TypeQLError::GetVarNotBound(r.to_owned()).into())
         } else if seen.contains(&r) {

--- a/rust/query/typeql_get.rs
+++ b/rust/query/typeql_get.rs
@@ -101,9 +101,9 @@ fn validate_filters_are_in_scope(match_variables: &HashSet<VariableRef<'_>>, fil
         if !r.is_name() {
             Err(TypeQLError::VariableNotNamed.into())
         } else if !match_variables.contains(&r.as_ref()) {
-            Err(TypeQLError::GetVarNotBound(r.to_owned()).into())
+            Err(TypeQLError::GetVarNotBound { variable: r.to_owned() }.into())
         } else if seen.contains(&r) {
-            Err(TypeQLError::GetVarRepeating(r.to_owned()).into())
+            Err(TypeQLError::GetVarRepeating { variable: r.to_owned() }.into())
         } else {
             seen.insert(r);
             Ok(())
@@ -116,7 +116,9 @@ fn validate_variable_names_are_unique(conjunction: &Conjunction) -> Result {
     let (concept_refs, value_refs) = all_refs.partition::<HashSet<_>, _>(VariableRef::is_concept);
     let common_refs = concept_refs.intersection(&value_refs).collect::<HashSet<_>>();
     if !common_refs.is_empty() {
-        return Err(TypeQLError::VariableNameConflict(common_refs.iter().map(|r| r.to_string()).join(", ")).into());
+        return Err(
+            TypeQLError::VariableNameConflict { names: common_refs.iter().map(|r| r.to_string()).join(", ") }.into()
+        );
     }
     Ok(())
 }

--- a/rust/query/typeql_get_aggregate.rs
+++ b/rust/query/typeql_get_aggregate.rs
@@ -77,7 +77,7 @@ fn validate_method_variable_compatible(method: &token::Aggregate, var: &Option<V
 
 fn validate_variable_in_scope(var: &Variable, scope_variables: &HashSet<VariableRef<'_>>) -> Result {
     if !scope_variables.contains(&var.as_ref()) {
-        Err(TypeQLError::AggregateVarNotBound(var.clone()))?;
+        Err(TypeQLError::AggregateVarNotBound { variable: var.clone() })?;
     }
     Ok(())
 }

--- a/rust/query/typeql_get_aggregate.rs
+++ b/rust/query/typeql_get_aggregate.rs
@@ -70,7 +70,7 @@ impl<T: AggregateQueryBuilder> Validatable for AggregateQuery<T> {
 
 fn validate_method_variable_compatible(method: &token::Aggregate, var: &Option<Variable>) -> Result {
     if *method == token::Aggregate::Count && var.is_some() {
-        Err(TypeQLError::InvalidCountVariableArgument())?
+        Err(TypeQLError::InvalidCountVariableArgument)?
     }
     Ok(())
 }

--- a/rust/query/typeql_get_group.rs
+++ b/rust/query/typeql_get_group.rs
@@ -61,7 +61,7 @@ impl VariablesRetrieved for TypeQLGetGroup {
 
 fn validate_variable_in_scope(var: &Variable, scope_variables: &HashSet<VariableRef<'_>>) -> Result {
     if !scope_variables.contains(&var.as_ref()) {
-        Err(TypeQLError::GroupVarNotBound(var.clone()))?;
+        Err(TypeQLError::GroupVarNotBound { variable: var.clone() })?;
     }
     Ok(())
 }

--- a/rust/query/typeql_insert.rs
+++ b/rust/query/typeql_insert.rs
@@ -97,7 +97,7 @@ fn validate_insert_in_scope_of_match(
         Ok(())
     } else {
         let stmts_str = statements.iter().map(ThingStatement::to_string).collect::<Vec<String>>().join(", ");
-        let bounds_str = match_variables.into_iter().map(|r| r.to_string()).collect::<Vec<String>>().join(", ");
+        let bounds_str = match_variables.iter().map(VariableRef::to_string).collect::<Vec<String>>().join(", ");
         Err(TypeQLError::InsertClauseNotBound(stmts_str, bounds_str))?
     }
 }

--- a/rust/query/typeql_insert.rs
+++ b/rust/query/typeql_insert.rs
@@ -61,7 +61,7 @@ impl TypeQLInsert {
 
     fn validate_modifiers_have_match_clause(&self) -> Result {
         if !self.modifiers.is_empty() && self.match_clause.is_none() {
-            Err(TypeQLError::InsertModifiersRequireMatch(self.to_string()))?
+            Err(TypeQLError::InsertModifiersRequireMatch { insert: self.to_string() })?
         } else {
             Ok(())
         }
@@ -98,7 +98,7 @@ fn validate_insert_in_scope_of_match(
     } else {
         let stmts_str = statements.iter().map(ThingStatement::to_string).collect::<Vec<String>>().join(", ");
         let bounds_str = match_variables.iter().map(VariableRef::to_string).collect::<Vec<String>>().join(", ");
-        Err(TypeQLError::InsertClauseNotBound(stmts_str, bounds_str))?
+        Err(TypeQLError::InsertClauseNotBound { insert_statements: stmts_str, bounds: bounds_str })?
     }
 }
 

--- a/rust/query/typeql_undefine.rs
+++ b/rust/query/typeql_undefine.rs
@@ -62,7 +62,7 @@ impl TypeQLUndefine {
 
     fn validate_non_empty(&self) -> Result {
         if self.statements.is_empty() && self.rules.is_empty() {
-            Err(TypeQLError::MissingDefinables())?
+            Err(TypeQLError::MissingDefinables)?
         }
         Ok(())
     }

--- a/rust/query/typeql_undefine.rs
+++ b/rust/query/typeql_undefine.rs
@@ -44,8 +44,8 @@ impl TypeQLUndefine {
         undefinables.into_iter().fold(TypeQLUndefine::default(), |undefine, undefinable| match undefinable {
             Definable::RuleDeclaration(rule) => undefine.add_rule(rule),
             Definable::TypeStatement(var) => undefine.add_statement(var),
-            Definable::RuleDefinition(r) => {
-                panic!("{}", TypeQLError::InvalidUndefineQueryRule(r.label))
+            Definable::RuleDefinition(rule) => {
+                panic!("{}", TypeQLError::InvalidUndefineQueryRule { rule_label: rule.label })
             }
         })
     }

--- a/rust/query/writable.rs
+++ b/rust/query/writable.rs
@@ -46,7 +46,7 @@ impl Writable for Vec<ThingStatement> {
 
 pub(crate) fn validate_non_empty(statements: &[ThingStatement]) -> Result {
     if statements.is_empty() {
-        Err(TypeQLError::MissingPatterns())?
+        Err(TypeQLError::MissingPatterns)?
     }
     Ok(())
 }

--- a/rust/util/mod.rs
+++ b/rust/util/mod.rs
@@ -22,7 +22,7 @@
 
 #[macro_export]
 macro_rules! enum_getter {
-    {$enum_name:ident $($fn_name:ident ( $enum_variant:ident ) => $classname:ty),* $(,)?} => {
+    {$enum_name:ident $($fn_name:ident ( $enum_variant:ident ) => $typename:ty),* $(,)?} => {
         impl $enum_name {
             fn enum_getter_get_name(&self) -> &'static str {
                 match self {
@@ -33,15 +33,15 @@ macro_rules! enum_getter {
             }
         }
         $(impl $enum_name {
-            pub fn $fn_name(self) -> $classname {
+            pub fn $fn_name(self) -> $typename {
                 match self {
                     Self::$enum_variant(x) => x,
-                    _ => panic!("{}", $crate::common::error::TypeQLError::InvalidCasting(
-                        stringify!($enum_name),
-                        self.enum_getter_get_name(),
-                        stringify!($enum_variant),
-                        stringify!($classname)
-                    )),
+                    _ => panic!("{}", $crate::common::error::TypeQLError::InvalidCasting{
+                        enum_name: stringify!($enum_name),
+                        variant: self.enum_getter_get_name(),
+                        expected_variant: stringify!($enum_variant),
+                        typename: stringify!($typename)
+                    }),
                 }
             }
         })*
@@ -50,9 +50,9 @@ macro_rules! enum_getter {
 
 #[macro_export]
 macro_rules! enum_wrapper {
-    {$enum_name:ident $($classname:ty => $enum_value:ident),* $(,)?} => {
-        $(impl From<$classname> for $enum_name {
-            fn from(x: $classname) -> Self {
+    {$enum_name:ident $($typename:ty => $enum_value:ident),* $(,)?} => {
+        $(impl From<$typename> for $enum_name {
+            fn from(x: $typename) -> Self {
                 Self::$enum_value(x)
             }
         })*

--- a/rust/variable/type_reference.rs
+++ b/rust/variable/type_reference.rs
@@ -36,7 +36,7 @@ pub enum TypeReference {
 impl TypeReference {
     pub fn into_type_statement(self) -> TypeStatement {
         match self {
-            Self::Label(label) => ConceptVariable::hidden().type_(label),
+            Self::Label(label) => ConceptVariable::Hidden.type_(label),
             Self::Variable(var) => var.into(),
         }
     }

--- a/rust/variable/variable.rs
+++ b/rust/variable/variable.rs
@@ -41,10 +41,10 @@ impl Variable {
         }
     }
 
-    pub fn is_name(&self) -> bool {
+    pub fn is_named(&self) -> bool {
         match self {
-            Variable::Concept(var) => var.is_name(),
-            Variable::Value(var) => var.is_name(),
+            Variable::Concept(var) => var.is_named(),
+            Variable::Value(var) => var.is_named(),
         }
     }
 }
@@ -88,8 +88,8 @@ pub enum VariableRef<'a> {
 impl VariableRef<'_> {
     pub fn is_name(&self) -> bool {
         match self {
-            VariableRef::Concept(var) => (*var).is_name(),
-            VariableRef::Value(var) => (*var).is_name(),
+            VariableRef::Concept(var) => (*var).is_named(),
+            VariableRef::Value(var) => (*var).is_named(),
         }
     }
 

--- a/rust/variable/variable.rs
+++ b/rust/variable/variable.rs
@@ -121,7 +121,7 @@ impl fmt::Display for VariableRef<'_> {
 pub(crate) fn validate_variable_name(name: &str) -> Result {
     // TODO this should be a static regex
     if !is_valid_variable_name(name) {
-        Err(TypeQLError::InvalidVariableName(name.to_string()))?
+        Err(TypeQLError::InvalidVariableName { name: name.to_owned() })?
     }
     Ok(())
 }

--- a/rust/variable/variable.rs
+++ b/rust/variable/variable.rs
@@ -101,7 +101,7 @@ impl VariableRef<'_> {
         matches!(self, VariableRef::Value(_))
     }
 
-    pub fn to_owned(&self) -> Variable {
+    pub fn to_owned(self) -> Variable {
         match self {
             Self::Concept(var) => Variable::Concept((*var).clone()),
             Self::Value(var) => Variable::Value((*var).clone()),

--- a/rust/variable/variable_concept.rs
+++ b/rust/variable/variable_concept.rs
@@ -28,45 +28,28 @@ use crate::{
     variable::variable::validate_variable_name,
 };
 
-#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
-pub enum Visibility {
-    Visible,
-    Invisible,
-}
-
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub enum ConceptVariable {
-    Anonymous(Visibility),
-    Name(String),
+    Anonymous,
+    Hidden,
+    Named(String),
 }
 
 impl ConceptVariable {
     const ANONYMOUS_NAME: &'static str = token::Char::Underscore.as_str();
 
-    pub fn named(name: String) -> ConceptVariable {
-        ConceptVariable::Name(name)
-    }
-
-    pub fn anonymous() -> ConceptVariable {
-        ConceptVariable::Anonymous(Visibility::Visible)
-    }
-
-    pub fn hidden() -> ConceptVariable {
-        ConceptVariable::Anonymous(Visibility::Invisible)
-    }
-
     pub fn is_visible(&self) -> bool {
-        !matches!(self, Self::Anonymous(Visibility::Invisible))
+        self != &Self::Hidden
     }
 
     pub fn is_name(&self) -> bool {
-        matches!(self, Self::Name(_))
+        matches!(self, Self::Named(_))
     }
 
     pub fn name(&self) -> &str {
         match self {
-            Self::Anonymous(_) => Self::ANONYMOUS_NAME,
-            Self::Name(name) => name,
+            Self::Anonymous | Self::Hidden => Self::ANONYMOUS_NAME,
+            Self::Named(name) => name,
         }
     }
 }
@@ -74,27 +57,27 @@ impl ConceptVariable {
 impl Validatable for ConceptVariable {
     fn validate(&self) -> Result {
         match self {
-            Self::Anonymous(_) => Ok(()),
-            Self::Name(n) => validate_variable_name(n),
+            Self::Anonymous | Self::Hidden => Ok(()),
+            Self::Named(n) => validate_variable_name(n),
         }
     }
 }
 
 impl From<()> for ConceptVariable {
     fn from(_: ()) -> Self {
-        ConceptVariable::anonymous()
+        ConceptVariable::Anonymous
     }
 }
 
 impl From<&str> for ConceptVariable {
     fn from(name: &str) -> Self {
-        ConceptVariable::named(name.to_string())
+        ConceptVariable::Named(name.to_string())
     }
 }
 
 impl From<String> for ConceptVariable {
     fn from(name: String) -> Self {
-        ConceptVariable::named(name)
+        ConceptVariable::Named(name)
     }
 }
 

--- a/rust/variable/variable_concept.rs
+++ b/rust/variable/variable_concept.rs
@@ -42,7 +42,7 @@ impl ConceptVariable {
         self != &Self::Hidden
     }
 
-    pub fn is_name(&self) -> bool {
+    pub fn is_named(&self) -> bool {
         matches!(self, Self::Named(_))
     }
 

--- a/rust/variable/variable_value.rs
+++ b/rust/variable/variable_value.rs
@@ -30,14 +30,10 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub enum ValueVariable {
-    Name(String),
+    Named(String),
 }
 
 impl ValueVariable {
-    pub fn named(name: String) -> ValueVariable {
-        Self::Name(name)
-    }
-
     pub fn into_value(self) -> ValueStatement {
         ValueStatement::new(self)
     }
@@ -51,7 +47,7 @@ impl ValueVariable {
     }
 
     pub fn name(&self) -> &str {
-        let Self::Name(name) = self;
+        let Self::Named(name) = self;
         name
     }
 }
@@ -59,20 +55,20 @@ impl ValueVariable {
 impl Validatable for ValueVariable {
     fn validate(&self) -> Result {
         match self {
-            Self::Name(n) => validate_variable_name(n),
+            Self::Named(n) => validate_variable_name(n),
         }
     }
 }
 
 impl From<&str> for ValueVariable {
     fn from(name: &str) -> Self {
-        ValueVariable::named(name.to_string())
+        ValueVariable::Named(name.to_owned())
     }
 }
 
 impl From<String> for ValueVariable {
     fn from(name: String) -> Self {
-        ValueVariable::named(name)
+        ValueVariable::Named(name)
     }
 }
 

--- a/rust/variable/variable_value.rs
+++ b/rust/variable/variable_value.rs
@@ -38,7 +38,7 @@ impl ValueVariable {
         ValueStatement::new(self)
     }
 
-    pub fn is_name(&self) -> bool {
+    pub fn is_named(&self) -> bool {
         true
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

`error_messages!` now accepts struct enum variants, rather than tuple variants. This forces the user to name the fields and to refer to the fields by name in the format strings, reducing user error.

## What are the changes implemented in this PR?

- `error_messages!` overhaul
- minor code style cleanup: naming, functional style fixes, simplified structure
    - split `Variable::Anonymous(Visible)` and `_::Anonymous(Invisible)` to `Variable::Anonymous` and `_::Hidden` respectively.