### PR TITLE
Migrate artifact hosting to cloudsmith

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -72,7 +72,7 @@ build:
       image: vaticle-ubuntu-22.04
       dependencies: [build, build-dependency, test-rust]
       command: |
-        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
+        export DEPLOY_CRATE_TOKEN=$REPO_TYPEDB_CRATES_TOKEN
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
     deploy-maven-snapshot:
@@ -82,8 +82,8 @@ build:
       image: vaticle-ubuntu-22.04
       dependencies: [build, build-dependency, test-java]
       command: |
-        export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --define version=$(git rev-parse HEAD) //grammar/java:deploy-maven -- snapshot
         bazel run --define version=$(git rev-parse HEAD) //java/builder:deploy-maven -- snapshot
@@ -99,8 +99,8 @@ build:
       image: vaticle-ubuntu-20.04
       dependencies: [ build, build-dependency ]
       command: |
-        export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_PIP_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_PIP_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_PIP_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grammar/python:deploy-pip -- snapshot
     test-deployment-maven:
       filter:
@@ -149,8 +149,8 @@ release:
       image: vaticle-ubuntu-22.04
       dependencies: [deploy-github]
       command: |
-        export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(cat VERSION) //grammar/java:deploy-maven -- release
         bazel run --define version=$(cat VERSION) //java/builder:deploy-maven -- release
         bazel run --define version=$(cat VERSION) //java/common:deploy-maven -- release

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Discussion Forum](https://img.shields.io/badge/discourse-forum-blue.svg)](https://forum.typedb.com)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typedb-796de3.svg)](https://stackoverflow.com/questions/tagged/typedb)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typeql-3dce8c.svg)](https://stackoverflow.com/questions/tagged/typeql)
+[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat)](https://cloudsmith.com)
 
 # Introducing TypeQL
 
@@ -176,6 +177,12 @@ In the past, TypeDB was enabled by various open-source products and communities 
 [Apache Spark](http://spark.apache.org), 
 [Apache TinkerPop](http://tinkerpop.apache.org), 
 and [JanusGraph](http://janusgraph.org). 
+
+### Package hosting
+Package repository hosting is graciously provided by  [Cloudsmith](https://cloudsmith.com).
+Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
+enables your organization to create, store and share packages in any format, to any place, with total
+confidence.
 
 ## Licensing
 

--- a/RELEASE_NOTES_LATEST.md
+++ b/RELEASE_NOTES_LATEST.md
@@ -11,8 +11,8 @@ cargo add typeql@2.25.8
 ```xml
 <repositories>
     <repository>
-        <id>repo.vaticle.com</id>
-        <url>https://repo.vaticle.com/repository/maven/</url>
+        <id>repo.typedb.com</id>
+        <url>https://repo.typedb.com/public/public-release/maven/</url>
     </repository>
 </repositories>
 

--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -11,8 +11,8 @@ cargo add typeql@{version}
 ```xml
 <repositories>
     <repository>
-        <id>repo.vaticle.com</id>
-        <url>https://repo.vaticle.com/repository/maven/</url>
+        <id>repo.typedb.com</id>
+        <url>https://repo.typedb.com/public/public-release/maven/</url>
     </repository>
 </repositories>
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -124,6 +124,12 @@ github_deps()
 # Load //maven
 load("@vaticle_bazel_distribution//maven:deps.bzl", vaticle_bazel_distribution_maven_artifacts = "maven_artifacts")
 
+# Load @vaticle_bazel_distribution_cloudsmith
+load("@vaticle_bazel_distribution//common/cloudsmith:deps.bzl", cloudsmith_deps = "deps")
+cloudsmith_deps()
+load("@vaticle_bazel_distribution_cloudsmith//:requirements.bzl", install_cloudsmith_deps = "install_deps")
+install_cloudsmith_deps()
+
 ################################
 # Load @vaticle dependencies #
 ################################

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -125,10 +125,10 @@ github_deps()
 load("@vaticle_bazel_distribution//maven:deps.bzl", vaticle_bazel_distribution_maven_artifacts = "maven_artifacts")
 
 # Load @vaticle_bazel_distribution_cloudsmith
-load("@vaticle_bazel_distribution//common/cloudsmith:deps.bzl", cloudsmith_deps = "deps")
-cloudsmith_deps()
-load("@vaticle_bazel_distribution_cloudsmith//:requirements.bzl", install_cloudsmith_deps = "install_deps")
-install_cloudsmith_deps()
+load("@vaticle_bazel_distribution//common/uploader:deps.bzl", uploader_dpes = "deps")
+uploader_dpes()
+load("@vaticle_bazel_distribution_uploader//:requirements.bzl", install_uploader_deps = "install_deps")
+install_uploader_deps()
 
 ################################
 # Load @vaticle dependencies #

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -35,6 +35,7 @@
 @maven//:org_hamcrest_hamcrest_core_1_3
 @maven//:org_hamcrest_hamcrest_library_1_3
 @maven//:org_jetbrains_compose_compiler_compiler_1_3_2
+@maven//:org_jsoup_jsoup_1_16_1
 @maven//:org_slf4j_slf4j_api_2_0_0
 @maven//:org_yaml_snakeyaml_1_25
 @maven//:org_zeroturnaround_zt_exec_1_10

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "da4f5ba66210f830ab1847cf88296bec31c48455", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "b2d38ffe707d2caf84f4e27cb283b6a491ae15f5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,14 +21,14 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "7ec10d713d8feca159a4af8b5ef65e4a8d2f9b75", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "3855727ed3f6d93ccc5f176f4414e0142ca718a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/krishnangovindraj/typedb-common",
-        commit = "9574419264352ce3eae620aaae87ed99d1706fe2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "fb539f760b16412118d68c782c9cdf7d93e6f395", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "81a2d656612761a0d1741bbe944f377eff228d16", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "da4f5ba66210f830ab1847cf88296bec31c48455", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/krishnangovindraj/typedb-common",
-        commit = "fd9ec61f9cc8bd0ae7a70097257d3191731316e9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "9574419264352ce3eae620aaae87ed99d1706fe2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "89cbbc4e9807b10835591559bd77bd6a9a754a8a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "81a2d656612761a0d1741bbe944f377eff228d16", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,15 +20,15 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "3855727ed3f6d93ccc5f176f4414e0142ca718a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "9632621e9e6381e192ba744ccb3f7447d0433c19", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/krishnangovindraj/typedb-common",
-        commit = "fb539f760b16412118d68c782c9cdf7d93e6f395", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "7b1a82a10e826a4cd67ee333fa4e089118f4d94e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "b2d38ffe707d2caf84f4e27cb283b6a491ae15f5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "7ec10d713d8feca159a4af8b5ef65e4a8d2f9b75", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,15 +20,15 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "5bf5826067d9a371efc2144343cd4f5c2649ee8e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/krishnangovindraj/dependencies",
+        commit = "89cbbc4e9807b10835591559bd77bd6a9a754a8a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.25.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/krishnangovindraj/typedb-common",
+        commit = "fd9ec61f9cc8bd0ae7a70097257d3191731316e9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():

--- a/grammar/README.md
+++ b/grammar/README.md
@@ -13,8 +13,8 @@ If you would like to develop language TypeQL plugins or extension in Java, and r
 
 <repositories>
     <repository>
-        <id>repo.vaticle.com</id>
-        <url>https://repo.vaticle.com/repository/maven/</url>
+        <id>repo.typedb.com</id>
+        <url>https://repo.typedb.com/public/public-release/maven/</url>
     </repository>
 </repositories>
 
@@ -27,7 +27,7 @@ If you would like to develop language TypeQL plugins or extension in Java, and r
 </dependencies>
 ```
 
-Replace `{version}` with the version number, in which you can find the latest of TypeQL Grammar on our [Maven Repository](https://repo.vaticle.com/#browse/browse:maven:com%2Fvaticle%2Ftypeql%2Ftypeql-grammar).
+Replace `{version}` with the version number, in which you can find the latest of TypeQL Grammar on our [Maven Repository](https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name%3A%27%5Etypeql-grammar%24%27).
 
 ---
 

--- a/grammar/java/BUILD
+++ b/grammar/java/BUILD
@@ -48,8 +48,8 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
-    snapshot = deployment['maven.snapshot'],
-    release = deployment['maven.release']
+    snapshot = deployment['maven']['snapshot']['upload'],
+    release = deployment['maven']['release']['upload']
 )
 
 checkstyle_test(

--- a/grammar/python/BUILD
+++ b/grammar/python/BUILD
@@ -87,8 +87,8 @@ assemble_pip(
 deploy_pip(
     name = "deploy-pip",
     target = ":assemble-pip",
-    snapshot = deployment["pypi.snapshot"],
-    release = deployment["pypi.release"],
+    snapshot = deployment["pypi"]["snapshot"],
+    release = deployment["pypi"]["release"],
 )
 
 checkstyle_test(

--- a/java/BUILD
+++ b/java/BUILD
@@ -54,8 +54,8 @@ assemble_maven(
 
 deploy_maven(
     name = "deploy-maven",
-    release = deployment["maven.release"],
-    snapshot = deployment["maven.snapshot"],
+    release = deployment["maven"]["release"]["upload"],
+    snapshot = deployment["maven"]["snapshot"]["upload"],
     target = ":assemble-maven",
 )
 

--- a/java/README.md
+++ b/java/README.md
@@ -19,8 +19,8 @@ You can learn more about TypeQL Language Library for Java from [typedb.com/docs]
 ```xml
 <repositories>
     <repository>
-        <id>repo.vaticle.com</id>
-        <url>https://repo.vaticle.com/repository/maven/</url>
+        <id>repo.typedb.com</id>
+        <url>https://repo.typedb.com/public/public-release/maven/</url>
     </repository>
 </repositories>
 
@@ -33,7 +33,7 @@ You can learn more about TypeQL Language Library for Java from [typedb.com/docs]
 </dependencies>
 ```
 
-Replace `{version}` with the version number, in which you can find the latest on [TypeQL's Maven Repository](https://repo.vaticle.com/#browse/browse:maven:com%2Fvaticle%2Ftypeql%2Ftypeql-lang). Further documentation: http://typedb.com/docs/client-api/java#typeql
+Replace `{version}` with the version number, in which you can find the latest on [TypeQL's Maven Repository](https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name%3A%27%5Etypeql-lang%24%27). Further documentation: http://typedb.com/docs/client-api/java#typeql
 
 ## Building TypeQL from Source
 

--- a/java/builder/BUILD
+++ b/java/builder/BUILD
@@ -51,8 +51,8 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
-    snapshot = deployment['maven.snapshot'],
-    release = deployment['maven.release']
+    snapshot = deployment['maven']['snapshot']['upload'],
+    release = deployment['maven']['release']['upload']
 )
 
 checkstyle_test(

--- a/java/common/BUILD
+++ b/java/common/BUILD
@@ -51,8 +51,8 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
-    snapshot = deployment['maven.snapshot'],
-    release = deployment['maven.release']
+    snapshot = deployment['maven']['snapshot']['upload'],
+    release = deployment['maven']['release']['upload']
 )
 
 checkstyle_test(

--- a/java/parser/BUILD
+++ b/java/parser/BUILD
@@ -58,8 +58,8 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
-    snapshot = deployment['maven.snapshot'],
-    release = deployment['maven.release']
+    snapshot = deployment['maven']['snapshot']['upload'],
+    release = deployment['maven']['release']['upload']
 )
 
 checkstyle_test(

--- a/java/pattern/BUILD
+++ b/java/pattern/BUILD
@@ -58,8 +58,8 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
-    snapshot = deployment['maven.snapshot'],
-    release = deployment['maven.release']
+    snapshot = deployment['maven']['snapshot']['upload'],
+    release = deployment['maven']['release']['upload']
 )
 
 checkstyle_test(

--- a/java/query/BUILD
+++ b/java/query/BUILD
@@ -54,8 +54,8 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
-    snapshot = deployment['maven.snapshot'],
-    release = deployment['maven.release']
+    snapshot = deployment['maven']['snapshot']['upload'],
+    release = deployment['maven']['release']['upload']
 )
 
 checkstyle_test(

--- a/java/test/deployment/pom.xml
+++ b/java/test/deployment/pom.xml
@@ -30,14 +30,14 @@ under the License.
     <url>http://maven.apache.org</url>
     <repositories>
         <repository>
-            <id>repo.vaticle.com.release</id>
-            <name>repo.vaticle.com</name>
-            <url>http://repo.vaticle.com/repository/maven/</url>
+            <id>repo.typedb.com.release</id>
+            <name>repo.typedb.com</name>
+            <url>https://repo.typedb.com/public/public-release/maven/</url>
         </repository>
         <repository>
-            <id>repo.vaticle.com.snapshot</id>
-            <name>repo.vaticle.com</name>
-            <url>https://repo.vaticle.com/repository/maven-snapshot/</url>
+            <id>repo.typedb.com.snapshot</id>
+            <name>repo.typedb.com</name>
+            <url>https://repo.typedb.com/public/public-snapshot/maven/</url>
         </repository>
     </repositories>
     <build>

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -71,8 +71,8 @@ assemble_crate(
 deploy_crate(
     name = "deploy_crate",
     target = ":assemble_crate",
-    snapshot = deployment["crate.snapshot"],
-    release = deployment["crate.release"],
+    snapshot = deployment["crate"]["snapshot"],
+    release = deployment["crate"]["release"],
 )
 
 deploy_github(


### PR DESCRIPTION
## What is the goal of this PR?
Updates artifact deployment & consumption rules to use cloudsmith instead of the self-hosted sonatype repository.



## What are the changes implemented in this PR?
* Bumps repository dependencies, Updates deployment targets