### PR TITLE
Sync dependencies in CI

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -30,7 +30,7 @@ build:
   quality:
     filter:
       owner: vaticle
-      branch: master
+      branch: [master, development]
     dependency-analysis:
       image: vaticle-ubuntu-22.04
       command: |
@@ -111,6 +111,23 @@ build:
       command: |
         sed -i -e "s/TYPEQL_LANG_VERSION_MARKER/$FACTORY_COMMIT/g" java/test/deployment/pom.xml
         cd java/test/deployment/ && mvn test
+    sync-dependencies:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+        - build-dependency
+        - test-java
+        - test-rust
+        - deploy-crate-snapshot
+        - deploy-maven-snapshot
+        - deploy-pip-snapshot
+        - test-deployment-maven
+      command: |
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
 
 release:
   filter:
@@ -165,3 +182,16 @@ release:
         export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
         export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
         bazel run --define version=$(cat VERSION) //grammar/python:deploy-pip -- release
+    sync-dependencies-release:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - deploy-github
+        - deploy-crate-release
+        - deploy-maven-release
+        - deploy-pip-release
+      command: |
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@$(cat VERSION)


### PR DESCRIPTION
## Usage and product changes

We add a sync-dependencies job to be run in CI after successful snapshot and release deployments. The job sends a request to vaticle-bot to update all downstream dependencies.

Note: this PR does _not_ update the `dependencies` repo dependency. It will be updated automatically by the bot during its first pass.