### PR TITLE
Refactor TypeQL Java projection builder

### DIFF
--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -34,7 +34,7 @@
 @maven//:org_checkerframework_checker_qual_3_5_0
 @maven//:org_hamcrest_hamcrest_core_1_3
 @maven//:org_hamcrest_hamcrest_library_1_3
-@maven//:org_jetbrains_compose_compiler_compiler_1_3_2
+@maven//:org_jetbrains_compose_compiler_compiler_1_5_7
 @maven//:org_jsoup_jsoup_1_16_1
 @maven//:org_slf4j_slf4j_api_2_0_0
 @maven//:org_yaml_snakeyaml_1_25

--- a/java/query/builder/ProjectionBuilder.java
+++ b/java/query/builder/ProjectionBuilder.java
@@ -28,18 +28,25 @@ import com.vaticle.typeql.lang.query.TypeQLFetch;
 import com.vaticle.typeql.lang.query.TypeQLGet;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public interface ProjectionBuilder {
 
     interface Attribute {
 
-        default TypeQLFetch.Projection.Attribute fetch(String attribute) {
-            return fetch(Reference.label(attribute));
+        default TypeQLFetch.Projection.Attribute fetch(String attribute, String... attributes) {
+            return fetch(Stream.concat(Stream.of(attribute), Stream.of(attributes))
+                    .map(attr -> new Pair<>(Reference.label(attribute), (TypeQLFetch.Key.Label) null))
+                    .collect(Collectors.toList())
+            );
         }
 
-        default TypeQLFetch.Projection.Attribute fetch(Reference.Label label) {
-            return fetch(new Pair<>(label, null));
+        default TypeQLFetch.Projection.Attribute fetch(Reference.Label label, Reference.Label... labels) {
+            return fetch(Stream.concat(Stream.of(label), Stream.of(labels))
+                    .map(l -> new Pair<>(l, (TypeQLFetch.Key.Label) null))
+                    .collect(Collectors.toList())
+            );
         }
 
         default TypeQLFetch.Projection.Attribute fetch(String attribute, String label) {

--- a/rust/pattern/constraint/type_/owns.rs
+++ b/rust/pattern/constraint/type_/owns.rs
@@ -259,11 +259,11 @@ impl<const N: usize> From<(TypeReference, TypeReference, [Annotation; N])> for O
 impl fmt::Display for OwnsConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", token::Constraint::Owns, self.attribute_type)?;
-        for annotation in &self.annotations {
-            write!(f, " {annotation}")?;
-        }
         if let Some(overridden) = &self.overridden_attribute_type {
             write!(f, " {} {}", token::Constraint::As, overridden)?;
+        }
+        for annotation in &self.annotations {
+            write!(f, " {annotation}")?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Usage and product changes

We note a previous change in [2eef07d388391e073cc1631f5af2bbf15e844cc4](https://github.com/vaticle/typeql/commit/2eef07d388391e073cc1631f5af2bbf15e844cc4) and extend it here to refactor the TypeQL Fetch projection query builder:

Usage rename, before:
```
cVar("x").map("name")
label("subquery").map(TypeQL.match(...).fetch(...))
```

Usage now: 
```
cVar("x").fetch("name")
label("subquery").fetch(TypeQL.match(...).fetch(...))
```


Fetching multiple attributes without relabeling, before:
```
cVar("x").fetch(list(pair("name"), null), pair("age", null), pair("dob", null)))
```
Usage now:
```
cVar("x").fetch("name", "age", "dob")
```

## Implementation

Previously, we renamed the `.map()` builder method to `.fetch()`

We additionally clean up the attribute projection builder to allow specifying a list of attribute to project, as strings, instead of enforcing passing a list of pairs containing the attribute label.
