### PR TITLE
Update error messages to match Rust and Java implementations

### DIFF
--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -89,7 +89,7 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
     public static final ErrorMessage ILLEGAL_GRAMMAR =
             new ErrorMessage(41, "Illegal grammar: '%s'");
     public static final ErrorMessage INVALID_TYPE_LABEL =
-            new ErrorMessage(42, "The type label '%s' is invalid. Type labels must be valid Unicode identifiers.");
+            new ErrorMessage(42, "The type label '%s' is invalid. Type labels must be valid Unicode identifiers with restrictions on the leading character.");
     public static final ErrorMessage INVALID_ANNOTATION =
             new ErrorMessage(43, "Invalid annotation '%s' on '%s' constraint");
 

--- a/rust/common/error/mod.rs
+++ b/rust/common/error/mod.rs
@@ -93,7 +93,7 @@ error_messages! { TypeQLError
     MatchHasNoBoundingNamedVariable =
         7: "The match query does not have named variables to bound the nested disjunction/negation pattern(s).",
     VariableNameConflict { names: String } =
-        8: "The variable names {names} cannot be used for both concept variables and value variables.",
+        8: "The variable(s) named {names} cannot be used for both a concept variable and a value variable.",
     MatchStatementHasNoNamedVariable { pattern: Pattern } =
         9: "The statement '{pattern}' has no named variable.",
     MatchHasUnboundedNestedPattern { pattern: Pattern } =
@@ -129,7 +129,7 @@ error_messages! { TypeQLError
     InvalidConstraintDatetimePrecision { date_time: NaiveDateTime } =
         25: "Attempted to assign DateTime value of '{date_time}' which is more precise than 1 millisecond.",
     InvalidDefineQueryVariable =
-        26: "Invalid define/undefine query. User defined variables are not accepted in a define/undefine query.",
+        26: "Invalid define/undefine query. User-defined variables are not accepted in a define/undefine query.",
     InvalidUndefineQueryRule { rule_label: Label } =
         27: "Invalid undefine query: the rule body of '{rule_label}' ('when' or 'then') cannot be undefined. The rule must be undefined entirely by referring to its label.",
     InvalidRuleWhenMissingPatterns { rule_label: Label } =
@@ -153,5 +153,5 @@ error_messages! { TypeQLError
     IllegalGrammar { input: String } =
         37: "Illegal grammar: '{input}'",
     InvalidTypeLabel { label: String } =
-        38: "The type label '{label}' is invalid. Type labels must be valid utf-8 identifiers without a leading underscore.",
+        38: "The type label '{label}' is invalid. Type labels must be valid Unicode identifiers with restrictions on the leading character.",
 }


### PR DESCRIPTION
## Usage and product changes
We fixed various logical and grammatical issues in the Java and Rust error messages, aiming to have similar errors from both implementations.

## Implementation
* Add missing error messages update initiated in https://github.com/vaticle/typeql/commit/99bb587 for one of the languages.
* Update error message for valid labels format, broadening the leading character restrictions. 