### PR TITLE
Make the author of the Python grammar and TypeQL Rust "TypeDB Community"

### DIFF
--- a/grammar/python/BUILD
+++ b/grammar/python/BUILD
@@ -62,8 +62,8 @@ assemble_pip(
         "Topic :: Database :: Front-Ends"
     ],
     url = "https://github.com/vaticle/typeql",
-    author = "Vaticle",
-    author_email = "community@vaticle.com",
+    author = "TypeDB Community",
+    author_email = "community@typedb.com",
     license = "AGPLv3",
     requirements_file = "//:requirements.txt",
     keywords = ["typeql", "typedb", "database", "strongly-typed"],

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -49,7 +49,7 @@ assemble_crate(
     homepage = "https://github.com/vaticle/typeql",
     repository = "https://github.com/vaticle/typeql",
     keywords = ["typeql", "typedb", "database", "strongly-typed"],
-    authors = ["Vaticle <community@vaticle.com>"]
+    authors = ["TypeDB Community <community@typedb.com>"]
 )
 
 deploy_crate(


### PR DESCRIPTION
## Usage and product changes

The `author` field of our Python grammar and Rust library is now **TypeDB Community** with the email being **community@typedb.com**.

## Implementation

The former labels "Vaticle" and "community@vaticle.com" are no longer applicable and have been replaced.